### PR TITLE
feat(ci): add GitHub Pages, Releases workflows and ladder showcase

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,70 @@
+name: GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Build JS bridge ──────────────────────────────────────────────
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: packages/dart_monty_wasm/js/package-lock.json
+      - name: Build JS bridge
+        working-directory: packages/dart_monty_wasm/js
+        run: npm install && npm run build
+
+      # ── Compile Dart to JS ───────────────────────────────────────────
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install Dart dependencies
+        working-directory: example/web
+        run: dart pub get
+      - name: Compile main.dart
+        working-directory: example/web
+        run: dart compile js bin/main.dart -o web/main.dart.js
+      - name: Compile ladder_showcase.dart
+        working-directory: example/web
+        run: dart compile js bin/ladder_showcase.dart -o web/ladder_showcase.dart.js
+
+      # ── Assemble site ────────────────────────────────────────────────
+      - name: Copy JS/WASM assets
+        run: |
+          cp packages/dart_monty_wasm/assets/dart_monty_bridge.js example/web/web/
+          cp packages/dart_monty_wasm/assets/dart_monty_worker.js example/web/web/
+          cp packages/dart_monty_wasm/assets/wasi-worker-browser.mjs example/web/web/
+          cp packages/dart_monty_wasm/assets/*.wasm example/web/web/
+      - name: Copy fixture files
+        run: |
+          mkdir -p example/web/web/fixtures
+          cp test/fixtures/python_ladder/tier_*.json example/web/web/fixtures/
+
+      # ── Deploy ───────────────────────────────────────────────────────
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: example/web/web
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,154 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  build-native:
+    name: Native (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            ext: so
+            label: linux-x64
+          - os: macos-latest
+            ext: dylib
+            label: macos-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Build Rust library ─────────────────────────────────────────
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native
+      - name: Build Rust native library
+        working-directory: native
+        run: cargo build --release
+
+      # ── Compile Dart AOT binary ────────────────────────────────────
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install Dart dependencies
+        working-directory: example/native
+        run: dart pub get
+      - name: Compile native example
+        run: >-
+          dart compile exe
+          example/native/bin/main.dart
+          -o dart_monty_example
+          -DDART_MONTY_LIB_PATH=./libdart_monty_native.${{ matrix.ext }}
+
+      # ── Package tarball ────────────────────────────────────────────
+      - name: Create tarball
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          DIR="dart_monty-${TAG}-${{ matrix.label }}"
+          mkdir "$DIR"
+          cp dart_monty_example "$DIR/"
+          cp "native/target/release/libdart_monty_native.${{ matrix.ext }}" "$DIR/"
+          cat > "$DIR/README.md" << 'HEREDOC'
+          # dart_monty native example
+
+          Run the bundled binary:
+
+              ./dart_monty_example
+
+          The binary loads `libdart_monty_native` from the same directory.
+          Override with `DART_MONTY_LIB_PATH` if needed.
+          HEREDOC
+          tar czf "${DIR}.tar.gz" "$DIR"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.label }}
+          path: dart_monty-*-${{ matrix.label }}.tar.gz
+
+  build-web:
+    name: Web bundle
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Build JS bridge ──────────────────────────────────────────
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: packages/dart_monty_wasm/js/package-lock.json
+      - name: Build JS bridge
+        working-directory: packages/dart_monty_wasm/js
+        run: npm install && npm run build
+
+      # ── Compile Dart to JS ─────────────────────────────────────────
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install Dart dependencies
+        working-directory: example/web
+        run: dart pub get
+      - name: Compile main.dart
+        working-directory: example/web
+        run: dart compile js bin/main.dart -o web/main.dart.js
+      - name: Compile ladder_showcase.dart
+        working-directory: example/web
+        run: dart compile js bin/ladder_showcase.dart -o web/ladder_showcase.dart.js
+
+      # ── Assemble bundle ────────────────────────────────────────────
+      - name: Assemble web bundle
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          DIR="dart_monty-${TAG}-web"
+          mkdir "$DIR"
+          # HTML pages
+          cp example/web/web/index.html "$DIR/"
+          cp example/web/web/demo.html "$DIR/"
+          cp example/web/web/ladder.html "$DIR/"
+          cp example/web/web/coi-serviceworker.js "$DIR/"
+          # Compiled JS
+          cp example/web/web/main.dart.js "$DIR/"
+          cp example/web/web/ladder_showcase.dart.js "$DIR/"
+          # Bridge assets
+          cp packages/dart_monty_wasm/assets/dart_monty_bridge.js "$DIR/"
+          cp packages/dart_monty_wasm/assets/dart_monty_worker.js "$DIR/"
+          cp packages/dart_monty_wasm/assets/wasi-worker-browser.mjs "$DIR/"
+          cp packages/dart_monty_wasm/assets/*.wasm "$DIR/"
+          # Fixtures
+          mkdir -p "$DIR/fixtures"
+          cp test/fixtures/python_ladder/tier_*.json "$DIR/fixtures/"
+          # Zip
+          zip -r "${DIR}.zip" "$DIR"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: web-bundle
+          path: dart_monty-*-web.zip
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build-native, build-web]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh release create "$TAG" \
+            --title "dart_monty $TAG" \
+            --generate-notes \
+            dart_monty-*-linux-x64.tar.gz \
+            dart_monty-*-macos-x64.tar.gz \
+            dart_monty-*-web.zip

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,6 +1,7 @@
 **/pubspec.lock
 **/.dart_tool/
 web/web/*.js
+!web/web/coi-serviceworker.js
 web/web/*.mjs
 web/web/*.wasm
 web/web/*.map

--- a/example/web/bin/ladder_showcase.dart
+++ b/example/web/bin/ladder_showcase.dart
@@ -1,0 +1,398 @@
+/// Ladder Showcase — runs all Python ladder fixtures in-browser with visual
+/// pass/fail output to the DOM.
+///
+/// Build & run:
+///   bash run.sh → open http://localhost:8088/ladder.html
+library;
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+// ---------------------------------------------------------------------------
+// JS interop bindings for window.DartMontyBridge
+// ---------------------------------------------------------------------------
+
+@JS('DartMontyBridge.init')
+external JSPromise<JSBoolean> _montyInit();
+
+@JS('DartMontyBridge.run')
+external JSPromise<JSString> _montyRun(JSString code);
+
+@JS('DartMontyBridge.start')
+external JSPromise<JSString> _montyStart(
+  JSString code, [
+  JSString? extFnsJson,
+]);
+
+@JS('DartMontyBridge.resume')
+external JSPromise<JSString> _montyResume(JSString valueJson);
+
+@JS('DartMontyBridge.resumeWithError')
+external JSPromise<JSString> _montyResumeWithError(JSString errorJson);
+
+// ---------------------------------------------------------------------------
+// JS fetch interop
+// ---------------------------------------------------------------------------
+
+@JS('fetch')
+external JSPromise<LadderShowcase> _jsFetch(JSString url);
+
+extension type LadderShowcase(JSObject _) implements JSObject {
+  external JSPromise<JSString> text();
+}
+
+// ---------------------------------------------------------------------------
+// DOM reporting via JS callback
+// ---------------------------------------------------------------------------
+
+@JS('reportResult')
+external void _reportResult(
+  JSNumber tier,
+  JSNumber id,
+  JSString name,
+  JSString code,
+  JSBoolean passed,
+  JSString detail,
+);
+
+@JS('reportTierHeader')
+external void _reportTierHeader(JSString label);
+
+@JS('reportDone')
+external void _reportDone(JSNumber passed, JSNumber total, JSNumber skipped);
+
+@JS('reportInit')
+external void _reportInit(JSBoolean ok, JSString message);
+
+// ---------------------------------------------------------------------------
+// Fixture tier files
+// ---------------------------------------------------------------------------
+
+const _tierFiles = [
+  'fixtures/tier_01_expressions.json',
+  'fixtures/tier_02_variables.json',
+  'fixtures/tier_03_control_flow.json',
+  'fixtures/tier_04_functions.json',
+  'fixtures/tier_05_errors.json',
+  'fixtures/tier_06_external_fns.json',
+];
+
+const _tierLabels = [
+  'Tier 1: Expressions',
+  'Tier 2: Variables',
+  'Tier 3: Control Flow',
+  'Tier 4: Functions',
+  'Tier 5: Errors',
+  'Tier 6: External Functions',
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Map<String, dynamic> _parse(String json) =>
+    jsonDecode(json) as Map<String, dynamic>;
+
+Future<String> _fetchText(String url) async {
+  final response = await _jsFetch(url.toJS).toDart;
+
+  return (await response.text().toDart).toDart;
+}
+
+// ---------------------------------------------------------------------------
+// Result comparison
+// ---------------------------------------------------------------------------
+
+bool _valuesMatch(Object? actual, Object? expected) {
+  if (expected == null && actual == null) return true;
+  if (expected is List && actual is List) {
+    if (expected.length != actual.length) return false;
+    for (var i = 0; i < expected.length; i++) {
+      if (!_valuesMatch(actual[i], expected[i])) return false;
+    }
+
+    return true;
+  }
+  if (expected is num && actual is num) {
+    return (expected - actual).abs() < 0.001;
+  }
+
+  return '$actual' == '$expected';
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+Future<void> main() async {
+  final jsTrue = true.toJS;
+  final ok = (await _montyInit().toDart).toDart;
+  if (!ok) {
+    _reportInit(false.toJS, 'Failed to initialize Monty WASM Worker'.toJS);
+
+    return;
+  }
+  _reportInit(jsTrue, 'Worker initialized'.toJS);
+
+  var totalPassed = 0;
+  var totalTests = 0;
+  var totalSkipped = 0;
+
+  for (var tierIdx = 0; tierIdx < _tierFiles.length; tierIdx++) {
+    _reportTierHeader(_tierLabels[tierIdx].toJS);
+
+    try {
+      final json = await _fetchText(_tierFiles[tierIdx]);
+      final fixtures = (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+
+      for (final fixture in fixtures) {
+        totalTests++;
+        final id = fixture['id'] as int;
+        final name = fixture['name'] as String;
+        final code = fixture['code'] as String;
+        final nativeOnly = fixture['nativeOnly'] as bool? ?? false;
+
+        if (nativeOnly) {
+          totalSkipped++;
+          _reportResult(
+            (tierIdx + 1).toJS,
+            id.toJS,
+            name.toJS,
+            code.toJS,
+            jsTrue,
+            'Skipped (native only)'.toJS,
+          );
+          totalPassed++;
+          continue;
+        }
+
+        final verifyResult = await _runAndVerify(fixture);
+        final passed = verifyResult['passed'] as bool;
+        final detail = verifyResult['detail'] as String;
+
+        if (passed) totalPassed++;
+        _reportResult(
+          (tierIdx + 1).toJS,
+          id.toJS,
+          name.toJS,
+          code.toJS,
+          passed.toJS,
+          detail.toJS,
+        );
+      }
+    } catch (e) {
+      _reportResult(
+        (tierIdx + 1).toJS,
+        0.toJS,
+        'Tier load error'.toJS,
+        ''.toJS,
+        false.toJS,
+        'Failed to load ${_tierFiles[tierIdx]}: $e'.toJS,
+      );
+    }
+  }
+
+  _reportDone(totalPassed.toJS, totalTests.toJS, totalSkipped.toJS);
+}
+
+Future<Map<String, dynamic>> _runAndVerify(
+  Map<String, dynamic> fixture,
+) async {
+  final expected = fixture['expected'];
+  final expectedContains = fixture['expectedContains'] as String?;
+  final expectedSorted = fixture['expectedSorted'] as bool? ?? false;
+  final expectError = fixture['expectError'] as bool? ?? false;
+  final errorContains = fixture['errorContains'] as String?;
+
+  try {
+    if (fixture['externalFunctions'] != null) {
+      return _runIterative(fixture);
+    } else if (expectError) {
+      return _verifyError(fixture);
+    } else {
+      return _verifySimple(
+        fixture,
+        expected,
+        expectedContains,
+        expectedSorted,
+      );
+    }
+  } catch (e) {
+    if (expectError) {
+      final errStr = '$e';
+      if (errorContains != null && !errStr.contains(errorContains)) {
+        return {
+          'passed': false,
+          'detail': 'Expected error containing "$errorContains", got: $errStr',
+        };
+      }
+
+      return {'passed': true, 'detail': 'Error (expected): $errStr'};
+    }
+
+    return {'passed': false, 'detail': 'Exception: $e'};
+  }
+}
+
+Future<Map<String, dynamic>> _verifySimple(
+  Map<String, dynamic> fixture,
+  Object? expected,
+  String? expectedContains,
+  bool expectedSorted,
+) async {
+  final code = fixture['code'] as String;
+  final result = _parse((await _montyRun(code.toJS).toDart).toDart);
+
+  if (result['ok'] != true) {
+    return {
+      'passed': false,
+      'detail': 'Run failed: ${result['error']}',
+    };
+  }
+
+  final actual = result['value'];
+
+  return _checkValue(actual, expected, expectedContains, expectedSorted);
+}
+
+Future<Map<String, dynamic>> _verifyError(
+  Map<String, dynamic> fixture,
+) async {
+  final code = fixture['code'] as String;
+  final errorContains = fixture['errorContains'] as String?;
+  final result = _parse((await _montyRun(code.toJS).toDart).toDart);
+
+  if (result['ok'] == false) {
+    final errMsg = '${result['error']}';
+    if (errorContains != null && !errMsg.contains(errorContains)) {
+      return {
+        'passed': false,
+        'detail': 'Error did not contain "$errorContains". Got: $errMsg',
+      };
+    }
+
+    return {'passed': true, 'detail': 'Error (expected): $errMsg'};
+  }
+
+  return {
+    'passed': false,
+    'detail': 'Expected error but got value: ${result['value']}',
+  };
+}
+
+Future<Map<String, dynamic>> _runIterative(
+  Map<String, dynamic> fixture,
+) async {
+  final code = fixture['code'] as String;
+  final expected = fixture['expected'];
+  final expectedContains = fixture['expectedContains'] as String?;
+  final expectedSorted = fixture['expectedSorted'] as bool? ?? false;
+  final expectError = fixture['expectError'] as bool? ?? false;
+  final errorContains = fixture['errorContains'] as String?;
+  final extFns = (fixture['externalFunctions'] as List).cast<String>();
+  final resumeValues = (fixture['resumeValues'] as List?)?.cast<Object>();
+  final resumeErrors = (fixture['resumeErrors'] as List?)?.cast<String>();
+
+  var result = _parse(
+    (await _montyStart(code.toJS, jsonEncode(extFns).toJS).toDart).toDart,
+  );
+
+  if (result['ok'] != true) {
+    if (expectError) {
+      final errMsg = '${result['error']}';
+      if (errorContains != null && !errMsg.contains(errorContains)) {
+        return {
+          'passed': false,
+          'detail': 'Error did not contain "$errorContains". Got: $errMsg',
+        };
+      }
+
+      return {'passed': true, 'detail': 'Error (expected): $errMsg'};
+    }
+
+    return {'passed': false, 'detail': 'Start failed: ${result['error']}'};
+  }
+
+  if (resumeErrors != null) {
+    for (final errorMsg in resumeErrors) {
+      if (result['state'] != 'pending') {
+        return {'passed': false, 'detail': 'Expected pending state'};
+      }
+      result = _parse(
+        (await _montyResumeWithError(jsonEncode(errorMsg).toJS).toDart).toDart,
+      );
+    }
+  } else if (resumeValues != null) {
+    for (final value in resumeValues) {
+      if (result['state'] != 'pending') {
+        return {'passed': false, 'detail': 'Expected pending state'};
+      }
+      result = _parse(
+        (await _montyResume(jsonEncode(value).toJS).toDart).toDart,
+      );
+    }
+  }
+
+  if (result['ok'] != true) {
+    if (expectError) {
+      final errMsg = '${result['error']}';
+      if (errorContains != null && !errMsg.contains(errorContains)) {
+        return {
+          'passed': false,
+          'detail': 'Error did not contain "$errorContains". Got: $errMsg',
+        };
+      }
+
+      return {'passed': true, 'detail': 'Error (expected): $errMsg'};
+    }
+
+    return {'passed': false, 'detail': 'Run failed: ${result['error']}'};
+  }
+
+  final actual = result['value'];
+
+  return _checkValue(actual, expected, expectedContains, expectedSorted);
+}
+
+Map<String, dynamic> _checkValue(
+  Object? actual,
+  Object? expected,
+  String? expectedContains,
+  bool expectedSorted,
+) {
+  if (expectedContains != null) {
+    final str = '$actual';
+    if (str.contains(expectedContains)) {
+      return {'passed': true, 'detail': 'Contains "$expectedContains": $str'};
+    }
+
+    return {
+      'passed': false,
+      'detail': 'Expected to contain "$expectedContains". Got: $str',
+    };
+  }
+
+  if (expectedSorted && actual is List && expected is List) {
+    final sortedActual = List<Object?>.from(actual)..sort(_compareObjects);
+    final sortedExpected = List<Object?>.from(expected)..sort(_compareObjects);
+    if (_valuesMatch(sortedActual, sortedExpected)) {
+      return {'passed': true, 'detail': '$actual (sorted match)'};
+    }
+
+    return {
+      'passed': false,
+      'detail': 'Expected (sorted): $expected, got: $actual',
+    };
+  }
+
+  if (_valuesMatch(actual, expected)) {
+    return {'passed': true, 'detail': '$actual'};
+  }
+
+  return {
+    'passed': false,
+    'detail': 'Expected: $expected, got: $actual',
+  };
+}
+
+int _compareObjects(Object? a, Object? b) => '$a'.compareTo('$b');

--- a/example/web/web/coi-serviceworker.js
+++ b/example/web/web/coi-serviceworker.js
@@ -1,0 +1,146 @@
+/*! coi-serviceworker v0.1.7 - Guido Zuidhof and contributors, licensed under MIT */
+let coepCredentialless = false;
+if (typeof window === 'undefined') {
+    self.addEventListener("install", () => self.skipWaiting());
+    self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+    self.addEventListener("message", (ev) => {
+        if (!ev.data) {
+            return;
+        } else if (ev.data.type === "deregister") {
+            self.registration
+                .unregister()
+                .then(() => {
+                    return self.clients.matchAll();
+                })
+                .then(clients => {
+                    clients.forEach((client) => client.navigate(client.url));
+                });
+        } else if (ev.data.type === "coepCredentialless") {
+            coepCredentialless = ev.data.value;
+        }
+    });
+
+    self.addEventListener("fetch", function (event) {
+        const r = event.request;
+        if (r.cache === "only-if-cached" && r.mode !== "same-origin") {
+            return;
+        }
+
+        const request = (coepCredentialless && r.mode === "no-cors")
+            ? new Request(r, {
+                credentials: "omit",
+            })
+            : r;
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.status === 0) {
+                        return response;
+                    }
+
+                    const newHeaders = new Headers(response.headers);
+                    newHeaders.set("Cross-Origin-Embedder-Policy",
+                        coepCredentialless ? "credentialless" : "require-corp"
+                    );
+                    if (!coepCredentialless) {
+                        newHeaders.set("Cross-Origin-Resource-Policy", "cross-origin");
+                    }
+                    newHeaders.set("Cross-Origin-Opener-Policy", "same-origin");
+
+                    return new Response(response.body, {
+                        status: response.status,
+                        statusText: response.statusText,
+                        headers: newHeaders,
+                    });
+                })
+                .catch((e) => console.error(e))
+        );
+    });
+
+} else {
+    (() => {
+        const reloadedBySelf = window.sessionStorage.getItem("coiReloadedBySelf");
+        window.sessionStorage.removeItem("coiReloadedBySelf");
+        const coepDegrading = (reloadedBySelf == "coepdegrade");
+
+        // You can customize the behavior of this script through a global `coi` variable.
+        const coi = {
+            shouldRegister: () => !reloadedBySelf,
+            shouldDeregister: () => false,
+            coepCredentialless: () => true,
+            coepDegrade: () => true,
+            doReload: () => window.location.reload(),
+            quiet: false,
+            ...window.coi
+        };
+
+        const n = navigator;
+        const controlling = n.serviceWorker && n.serviceWorker.controller;
+
+        // Record the failure if the page is served by serviceWorker.
+        if (controlling && !window.crossOriginIsolated) {
+            window.sessionStorage.setItem("coiCoepHasFailed", "true");
+        }
+        const coepHasFailed = window.sessionStorage.getItem("coiCoepHasFailed");
+
+        if (controlling) {
+            // Reload only on the first failure.
+            const reloadToDegrade = coi.coepDegrade() && !(
+                coepDegrading || window.crossOriginIsolated
+            );
+            n.serviceWorker.controller.postMessage({
+                type: "coepCredentialless",
+                value: (reloadToDegrade || coepHasFailed && coi.coepDegrade())
+                    ? false
+                    : coi.coepCredentialless(),
+            });
+            if (reloadToDegrade) {
+                !coi.quiet && console.log("Reloading page to degrade COEP.");
+                window.sessionStorage.setItem("coiReloadedBySelf", "coepdegrade");
+                coi.doReload("coepdegrade");
+            }
+
+            if (coi.shouldDeregister()) {
+                n.serviceWorker.controller.postMessage({ type: "deregister" });
+            }
+        }
+
+        // If we're already coi: do nothing. Perhaps it's due to this script doing its job, or COOP/COEP are
+        // already set from the origin server. Also if the browser has no notion of crossOriginIsolated, just give up here.
+        if (window.crossOriginIsolated !== false || !coi.shouldRegister()) return;
+
+        if (!window.isSecureContext) {
+            !coi.quiet && console.log("COOP/COEP Service Worker not registered, a secure context is required.");
+            return;
+        }
+
+        // In some environments (e.g. Firefox private mode) this won't be available
+        if (!n.serviceWorker) {
+            !coi.quiet && console.error("COOP/COEP Service Worker not registered, perhaps due to private mode.");
+            return;
+        }
+
+        n.serviceWorker.register(window.document.currentScript.src).then(
+            (registration) => {
+                !coi.quiet && console.log("COOP/COEP Service Worker registered", registration.scope);
+
+                registration.addEventListener("updatefound", () => {
+                    !coi.quiet && console.log("Reloading page to make use of updated COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "updatefound");
+                    coi.doReload();
+                });
+
+                // If the registration is active, but it's not controlling the page
+                if (registration.active && !n.serviceWorker.controller) {
+                    !coi.quiet && console.log("Reloading page to make use of COOP/COEP Service Worker.");
+                    window.sessionStorage.setItem("coiReloadedBySelf", "notcontrolling");
+                    coi.doReload();
+                }
+            },
+            (err) => {
+                !coi.quiet && console.error("COOP/COEP Service Worker failed to register:", err);
+            }
+        );
+    })();
+}

--- a/example/web/web/demo.html
+++ b/example/web/web/demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>dart_monty Web Demo</title>
+  <style>
+    body { font-family: monospace; background: #1e1e1e; color: #d4d4d4; padding: 2rem; }
+    h1 { color: #569cd6; }
+    .nav { margin-bottom: 1rem; font-size: 0.85rem; }
+    .nav a { color: #569cd6; margin-right: 1rem; }
+    pre { white-space: pre-wrap; line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <h1>dart_monty — Run Python in the Browser</h1>
+  <div class="nav">
+    <a href="index.html">&larr; Home</a>
+    <a href="ladder.html">Ladder Showcase</a>
+  </div>
+  <p>Open DevTools console to see output, or watch below:</p>
+  <pre id="output">Loading...</pre>
+  <script>
+    // Mirror console.log to the page
+    const out = document.getElementById('output');
+    out.textContent = '';
+    const origLog = console.log.bind(console);
+    console.log = (...args) => {
+      origLog(...args);
+      out.textContent += args.join(' ') + '\n';
+    };
+  </script>
+  <script src="coi-serviceworker.js"></script>
+  <script src="dart_monty_bridge.js"></script>
+  <script src="main.dart.js"></script>
+</body>
+</html>

--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -2,28 +2,59 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>dart_monty Web Example</title>
+  <title>dart_monty</title>
   <style>
-    body { font-family: monospace; background: #1e1e1e; color: #d4d4d4; padding: 2rem; }
-    h1 { color: #569cd6; }
-    pre { white-space: pre-wrap; line-height: 1.6; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+    h1 { color: #569cd6; font-size: 1.8rem; margin-bottom: 0.5rem; }
+    .tagline { color: #808080; margin-bottom: 2rem; font-size: 0.95rem; }
+    .cards { display: flex; gap: 1.5rem; flex-wrap: wrap; justify-content: center; }
+    .card {
+      background: #252526;
+      border: 1px solid #404040;
+      border-radius: 6px;
+      padding: 1.5rem;
+      width: 280px;
+      text-decoration: none;
+      color: #d4d4d4;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .card:hover { border-color: #569cd6; transform: translateY(-2px); }
+    .card h2 { color: #dcdcaa; font-size: 1rem; margin-bottom: 0.5rem; }
+    .card p { font-size: 0.85rem; color: #808080; line-height: 1.5; }
+    .footer {
+      margin-top: 3rem;
+      font-size: 0.8rem;
+      color: #555;
+    }
+    .footer a { color: #569cd6; }
   </style>
 </head>
 <body>
-  <h1>dart_monty — Run Python in the Browser</h1>
-  <p>Open DevTools console to see output, or watch below:</p>
-  <pre id="output">Loading...</pre>
-  <script>
-    // Mirror console.log to the page
-    const out = document.getElementById('output');
-    out.textContent = '';
-    const origLog = console.log.bind(console);
-    console.log = (...args) => {
-      origLog(...args);
-      out.textContent += args.join(' ') + '\n';
-    };
-  </script>
-  <script src="dart_monty_bridge.js"></script>
-  <script src="main.dart.js"></script>
+  <h1>dart_monty</h1>
+  <p class="tagline">Run sandboxed Python from Dart — native and web</p>
+  <div class="cards">
+    <a class="card" href="demo.html">
+      <h2>Try the Demo</h2>
+      <p>Run Python expressions, functions, and iterative execution through Monty WASM in your browser.</p>
+    </a>
+    <a class="card" href="ladder.html">
+      <h2>Python Ladder</h2>
+      <p>Run all cross-platform test fixtures — expressions, variables, control flow, functions, errors, and external functions.</p>
+    </a>
+  </div>
+  <div class="footer">
+    <a href="https://github.com/runyaga/dart_monty">GitHub</a>
+  </div>
 </body>
 </html>

--- a/example/web/web/ladder.html
+++ b/example/web/web/ladder.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>dart_monty — Python Ladder Showcase</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 2rem;
+      max-width: 960px;
+      margin: 0 auto;
+    }
+    a { color: #569cd6; }
+    h1 {
+      color: #569cd6;
+      margin-bottom: 0.5rem;
+      font-size: 1.4rem;
+    }
+    .subtitle {
+      color: #808080;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+    }
+    .nav { margin-bottom: 1.5rem; }
+    .nav a { margin-right: 1rem; font-size: 0.85rem; }
+
+    /* Status bar */
+    #status {
+      background: #2d2d2d;
+      border: 1px solid #404040;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+    }
+    #status.init { border-left: 3px solid #569cd6; }
+    #status.running { border-left: 3px solid #dcdcaa; }
+    #status.done { border-left: 3px solid #6a9955; }
+    #status.error { border-left: 3px solid #f44747; }
+
+    /* Totals */
+    #totals {
+      display: none;
+      background: #2d2d2d;
+      border: 1px solid #404040;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .progress-bar {
+      background: #404040;
+      border-radius: 3px;
+      height: 8px;
+      margin-top: 0.5rem;
+      overflow: hidden;
+    }
+    .progress-fill {
+      background: #6a9955;
+      height: 100%;
+      transition: width 0.3s;
+    }
+
+    /* Tier sections */
+    .tier {
+      margin-bottom: 1.5rem;
+    }
+    .tier-header {
+      color: #dcdcaa;
+      font-size: 1rem;
+      padding: 0.5rem 0;
+      border-bottom: 1px solid #404040;
+      margin-bottom: 0.5rem;
+      cursor: pointer;
+      user-select: none;
+    }
+    .tier-header:hover { color: #e5c07b; }
+    .tier-header::before {
+      content: '▼ ';
+      font-size: 0.7rem;
+    }
+    .tier-header.collapsed::before {
+      content: '▶ ';
+    }
+    .tier-body.hidden { display: none; }
+
+    /* Test cards */
+    .test-card {
+      background: #252526;
+      border: 1px solid #333;
+      border-radius: 4px;
+      margin-bottom: 0.5rem;
+      overflow: hidden;
+    }
+    .test-card.pass { border-left: 3px solid #6a9955; }
+    .test-card.fail { border-left: 3px solid #f44747; }
+    .test-card.skip { border-left: 3px solid #808080; }
+
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.4rem 0.75rem;
+      cursor: pointer;
+      user-select: none;
+    }
+    .card-header:hover { background: #2a2d2e; }
+    .test-name { font-size: 0.85rem; }
+    .badge {
+      font-size: 0.7rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 3px;
+      font-weight: bold;
+      text-transform: uppercase;
+    }
+    .badge.pass { background: #6a9955; color: #1e1e1e; }
+    .badge.fail { background: #f44747; color: #1e1e1e; }
+    .badge.skip { background: #808080; color: #1e1e1e; }
+
+    .card-body {
+      display: none;
+      padding: 0.5rem 0.75rem;
+      border-top: 1px solid #333;
+    }
+    .card-body.open { display: block; }
+
+    .card-body label {
+      display: block;
+      color: #808080;
+      font-size: 0.75rem;
+      margin-top: 0.4rem;
+      margin-bottom: 0.2rem;
+    }
+    .card-body pre {
+      background: #1e1e1e;
+      padding: 0.5rem;
+      border-radius: 3px;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      line-height: 1.4;
+    }
+    .code-block { color: #ce9178; }
+    .result-block { color: #b5cea8; }
+    .error-block { color: #f44747; }
+  </style>
+</head>
+<body>
+  <h1>Python Ladder Showcase</h1>
+  <p class="subtitle">Running all Python ladder fixtures through Monty WASM in the browser</p>
+  <div class="nav">
+    <a href="index.html">&larr; Home</a>
+    <a href="demo.html">Demo</a>
+  </div>
+
+  <div id="status" class="init">Initializing WASM Worker...</div>
+  <div id="totals"></div>
+  <div id="tiers"></div>
+
+  <script>
+    // DOM reporting functions called by Dart
+    const tiersEl = document.getElementById('tiers');
+    const statusEl = document.getElementById('status');
+    const totalsEl = document.getElementById('totals');
+    let currentTierBody = null;
+
+    function reportInit(ok, message) {
+      if (ok) {
+        statusEl.className = 'running';
+        statusEl.textContent = 'Running fixtures...';
+      } else {
+        statusEl.className = 'error';
+        statusEl.textContent = 'Init failed: ' + message;
+      }
+    }
+
+    function reportTierHeader(label) {
+      const tier = document.createElement('div');
+      tier.className = 'tier';
+
+      const header = document.createElement('div');
+      header.className = 'tier-header';
+      header.textContent = label;
+
+      const body = document.createElement('div');
+      body.className = 'tier-body';
+
+      header.addEventListener('click', () => {
+        header.classList.toggle('collapsed');
+        body.classList.toggle('hidden');
+      });
+
+      tier.appendChild(header);
+      tier.appendChild(body);
+      tiersEl.appendChild(tier);
+      currentTierBody = body;
+    }
+
+    function reportResult(tier, id, name, code, passed, detail) {
+      const card = document.createElement('div');
+      const isSkip = detail.startsWith('Skipped');
+      card.className = 'test-card ' + (isSkip ? 'skip' : (passed ? 'pass' : 'fail'));
+
+      const header = document.createElement('div');
+      header.className = 'card-header';
+
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'test-name';
+      nameSpan.textContent = '#' + id + ' ' + name;
+
+      const badge = document.createElement('span');
+      badge.className = 'badge ' + (isSkip ? 'skip' : (passed ? 'pass' : 'fail'));
+      badge.textContent = isSkip ? 'skip' : (passed ? 'pass' : 'fail');
+
+      header.appendChild(nameSpan);
+      header.appendChild(badge);
+
+      const body = document.createElement('div');
+      body.className = 'card-body';
+
+      if (code) {
+        const codeLabel = document.createElement('label');
+        codeLabel.textContent = 'Python code';
+        const codePre = document.createElement('pre');
+        codePre.className = 'code-block';
+        codePre.textContent = code;
+        body.appendChild(codeLabel);
+        body.appendChild(codePre);
+      }
+
+      const resultLabel = document.createElement('label');
+      resultLabel.textContent = passed ? 'Result' : 'Failure detail';
+      const resultPre = document.createElement('pre');
+      resultPre.className = passed ? 'result-block' : 'error-block';
+      resultPre.textContent = detail;
+      body.appendChild(resultLabel);
+      body.appendChild(resultPre);
+
+      // Auto-expand failures
+      if (!passed && !isSkip) body.classList.add('open');
+
+      header.addEventListener('click', () => body.classList.toggle('open'));
+
+      card.appendChild(header);
+      card.appendChild(body);
+
+      if (currentTierBody) {
+        currentTierBody.appendChild(card);
+      }
+    }
+
+    function reportDone(passed, total, skipped) {
+      const failed = total - passed;
+      const pct = total > 0 ? Math.round((passed / total) * 100) : 0;
+
+      statusEl.className = failed > 0 ? 'error' : 'done';
+      statusEl.textContent = failed > 0
+        ? passed + '/' + total + ' passed (' + failed + ' failed)'
+        : 'All ' + total + ' tests passed!';
+
+      totalsEl.style.display = 'block';
+      totalsEl.innerHTML =
+        '<strong>' + passed + '/' + total + ' passed</strong>' +
+        (skipped > 0 ? '  (' + skipped + ' skipped)' : '') +
+        '  — ' + pct + '%' +
+        '<div class="progress-bar"><div class="progress-fill" style="width:' + pct + '%"></div></div>';
+    }
+  </script>
+  <script src="coi-serviceworker.js"></script>
+  <script src="dart_monty_bridge.js"></script>
+  <script src="ladder_showcase.dart.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add **ladder showcase** web page that runs all Python ladder fixtures in-browser with visual pass/fail cards
- Add **GitHub Pages** workflow deploying to `runyaga.github.io/dart_monty` on push to `main`
- Add **GitHub Releases** workflow building native CLI tarballs (macOS + Linux) and web bundle zip on `v*` tags
- Refactor web example into landing page (`index.html`), demo (`demo.html`), and ladder (`ladder.html`)
- Vendor `coi-serviceworker.js` (MIT) for COOP/COEP headers on GitHub Pages

## Changes
- **`.github/workflows/pages.yaml`**: Build JS bridge + Dart-to-JS, deploy `example/web/web/` to Pages
- **`.github/workflows/release.yaml`**: Matrix build native binaries, assemble web bundle, create GitHub Release
- **`example/web/bin/ladder_showcase.dart`**: Dart ladder runner compiled to JS, reports results to DOM
- **`example/web/web/ladder.html`**: Dark-themed showcase with collapsible tier sections and progress bar
- **`example/web/web/demo.html`**: Renamed original demo with nav links and coi-serviceworker
- **`example/web/web/index.html`**: Landing page with cards linking to demo and ladder
- **`example/web/web/coi-serviceworker.js`**: Vendored service worker for SharedArrayBuffer on Pages
- **`example/web/run.sh`**: Builds ladder, copies fixtures, updated server URLs
- **`example/.gitignore`**: Exception for `coi-serviceworker.js`

## Test plan
- [x] `dart format --set-exit-if-changed .` — 0 changes
- [x] `dart analyze` — 0 issues
- [x] DCM analyze — 0 issues in new files
- [x] M1 gate — 175 tests, 100% coverage
- [x] WASM unit tests — 66 passed
- [x] YAML validation — passed
- [x] gitleaks — passed
- [ ] Manual: `bash example/web/run.sh` → landing, demo, ladder all work
- [ ] Enable GitHub Pages (Source = GitHub Actions) in repo settings
- [ ] Tag `v0.1.0` → verify Release workflow creates artifacts