### PR TITLE
feat(ci): add GitHub Pages, release workflows, and doc updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,12 @@ Prefer using the milestone gate scripts — they run all checks for that
 milestone in one shot:
 
 ```bash
-bash tool/test_m1.sh    # Dart format + analyze + test + coverage
-bash tool/test_m2.sh    # Rust fmt + clippy + test + tarpaulin + WASM build
+bash tool/test_m1.sh                     # Dart format + analyze + test + coverage
+bash tool/test_m2.sh                     # Rust fmt + clippy + test + tarpaulin + WASM build
+bash tool/test_m3a.sh                    # FFI package (unit + integration)
+bash tool/test_wasm.sh                   # WASM package (unit + Chrome integration)
+bash tool/test_python_ladder.sh          # Python ladder (all backends)
+bash tool/test_cross_path_parity.sh      # JSONL parity diff (native vs web)
 ```
 
 Do not commit unless the relevant gate script passes.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bash example/native/run.sh
 <details>
 <summary>Expected output</summary>
 
-```
+```text
 ── Simple expression ──
   2 + 2 = 4
   Memory: 0 bytes
@@ -78,7 +78,7 @@ bash example/web/run.sh
 <details>
 <summary>Expected output (in browser and DevTools console)</summary>
 
-```
+```text
 === dart_monty Web Example ===
 Worker initialized.
 


### PR DESCRIPTION
## Summary
- Add GitHub Pages workflow to deploy the web example as a live demo site
- Add Release workflow to produce native + web tarballs on version tags
- Add ladder showcase page and demo page to the web example
- Update AGENTS.md with M3/M4 gate scripts
- Fix README.md markdown lint issues (MD040)

## Changes
- **`.github/workflows/pages.yaml`**: Builds JS bridge, compiles Dart to JS, assembles site, deploys to GitHub Pages
- **`.github/workflows/release.yaml`**: Builds native binaries (Linux + macOS) and web bundle on `v*` tags, creates GitHub Release
- **`example/web/`**: Add `demo.html`, `ladder.html`, `ladder_showcase.dart`, `coi-serviceworker.js`
- **`AGENTS.md`**: Add M3A, WASM, Python ladder, cross-path parity gate scripts
- **`README.md`**: Fix fenced code blocks missing language specifiers

## Test plan
- [x] `pre-commit run pymarkdown` passes on all .md files
- [ ] GitHub Pages workflow deploys successfully after merge
- [ ] Live site loads at `https://runyaga.github.io/dart_monty/`
- [ ] Release workflow triggers on `v*` tag push (test after merge)