### PR TITLE
feat(ci): add TruffleHog secrets scan

### DIFF
--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -1,0 +1,44 @@
+name: TruffleHog Secrets Scan
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: TruffleHog scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
+
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: [trufflehog]
+    if: failure()
+    timeout-minutes: 2
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_NOTIFY_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "channel": "#dart_monty",
+              "username": "dart_monty",
+              "text": ":rotating_light: ${{ github.workflow }} failed on ${{ github.head_ref || github.ref_name }}:\n${{ github.event.head_commit.message }}\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "icon_emoji": ":ghost:"
+            }


### PR DESCRIPTION
## Summary
- Add TruffleHog secrets scan workflow matching soliplex/soliplex-flutter config
- Scans all branches on every push with `--only-verified` flag
- Slack notification on failure (channel: `#dart_monty`)

## Changes
- **`.github/workflows/trufflehog.yaml`**: New workflow — `trufflesecurity/trufflehog@main` with Slack failure notification

## Test plan
- [x] Workflow triggers on push to this branch
- [x] Config matches soliplex reference projects