### PR TITLE
fix(ci): make DCM non-blocking for test and wasm-ladder jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
     name: Test (${{ matrix.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [lint, dcm]
+    needs: [lint]
     strategy:
       matrix:
         target:
@@ -198,7 +198,7 @@ jobs:
     name: WASM ladder integration
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [lint, dcm]
+    needs: [lint]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Remove `dcm` from `needs` for `test` and `wasm-ladder` jobs so they run even when DCM fails

## Changes
- **ci.yaml**: `test` needs `[lint]` instead of `[lint, dcm]`
- **ci.yaml**: `wasm-ladder` needs `[lint]` instead of `[lint, dcm]`

## Context
DCM license seat quota is exhausted this month, causing all downstream jobs to skip. DCM is still useful as an advisory check but shouldn't block tests from running.

## Test plan
- [x] CI will validate this PR itself — test and wasm-ladder should now run