### PR TITLE
chore(ci): add PR auto-labeler and release changelog config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,37 @@
+changelog:
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - breaking
+    - title: "Features"
+      labels:
+        - feat
+    - title: "Bug Fixes"
+      labels:
+        - fix
+    - title: "Performance"
+      labels:
+        - perf
+    - title: "Refactoring"
+      labels:
+        - refactor
+    - title: "Dependencies"
+      labels:
+        - dependencies
+    - title: "Documentation"
+      labels:
+        - docs
+    - title: "Tests"
+      labels:
+        - test
+    - title: "Chores & CI"
+      labels:
+        - chore
+        - ci
+        - build
+    - title: "Other Changes"
+      labels:
+        - "*"
+  exclude:
+    labels:
+      - skip-changelog

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,67 @@
+name: PR Labeler
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const match = title.match(/^([a-zA-Z]+)(\(.+?\))?(!)?:\s/);
+
+            const prefixMap = {
+              'feat': 'feat', 'fix': 'fix', 'refactor': 'refactor',
+              'docs': 'docs', 'test': 'test', 'chore': 'chore',
+              'perf': 'perf', 'ci': 'ci', 'build': 'build',
+            };
+
+            const expectedLabels = new Set();
+            if (match) {
+              const type = match[1].toLowerCase();
+              const scope = match[2] ? match[2].toLowerCase() : '';
+              const isBreaking = match[3] === '!';
+
+              if (prefixMap[type]) expectedLabels.add(prefixMap[type]);
+              if (isBreaking) expectedLabels.add('breaking');
+              if (scope.includes('deps')) expectedLabels.add('dependencies');
+            }
+
+            const { data: currentLabelsData } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const currentLabels = currentLabelsData.map(l => l.name);
+
+            const allManagedLabels = [...Object.values(prefixMap), 'breaking', 'dependencies'];
+
+            const labelsToAdd = [...expectedLabels].filter(l => !currentLabels.includes(l));
+            const labelsToRemove = currentLabels.filter(l =>
+              allManagedLabels.includes(l) && !expectedLabels.has(l)
+            );
+
+            if (labelsToAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labelsToAdd,
+              });
+            }
+
+            for (const label of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: label,
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,38 @@ Run these checks after every code change:
 3. `dart test` (from package dir) — must pass all tests
 4. Maintain 90%+ line coverage (enforced by CI and pre-push hooks)
 
+## Pre-Commit/Push CI Gates
+
+**Before every commit and push**, run the full local CI pipeline:
+
+```bash
+bash tool/test_m1.sh       # M1: format + analyze + unit tests (platform_interface)
+bash tool/test_m2.sh       # M2: Rust build + test + clippy (skip if no cargo)
+bash tool/test_m3a.sh      # M3A: FFI package tests
+bash tool/test_python_ladder.sh  # M3C: Python ladder parity
+```
+
+Run all gates in parallel when possible. Gates that fail due to missing
+toolchains (e.g. `cargo` not installed, WASM cpu mismatch) are acceptable
+skips — but Dart gates (M1, M3A) must pass. Do not commit or push if any
+Dart gate fails.
+
+## PR Labels for Changelogs
+
+When creating PRs, add a label matching the conventional commit type so
+GitHub auto-generated release notes are categorized correctly:
+
+| PR title prefix | Label to apply |
+|-----------------|---------------|
+| `feat(…):` | `feat` |
+| `fix(…):` | `fix` |
+| `refactor(…):` | `refactor` |
+| `docs(…):` | `docs` |
+| `test(…):` | `test` |
+| `chore(…):` | `chore` |
+
+Config: `.github/release.yml`
+
 ## Linting
 
 - **Dart**: `dart analyze --fatal-infos` per sub-package (via `tool/analyze_packages.py`)


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` for categorized auto-generated changelogs
- Add PR auto-labeler workflow that parses conventional commit title prefixes
- Document local CI gates and PR labeling rules in CLAUDE.md

## Changes
- **`.github/release.yml`**: Changelog categories (Breaking, Features, Fixes, Perf, Refactoring, Deps, Docs, Tests, Chores & CI)
- **`.github/workflows/pr-labeler.yml`**: Parses PR title → applies label, handles breaking `!`, cleans stale labels on edits, detects `(deps)` scope
- **`CLAUDE.md`**: Pre-commit/push CI gates section + PR labels table

## Test plan
- [x] Open a PR with `feat(…):` title — verify `feat` label auto-applied
- [x] Edit title to `fix(…):` — verify `feat` removed, `fix` applied
- [x] PR with `feat!:` title — verify both `feat` and `breaking` labels
- [x] Generate release notes — verify categorized output