### PR TITLE
refactor(ci): split prepare-release into parallel validate + build jobs

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -17,6 +17,37 @@ permissions:
   contents: write
 
 jobs:
+  validate:
+    name: Format, analyze, test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Verify formatting
+        run: dart format --set-exit-if-changed .
+
+      - name: Analyze all packages
+        run: python3 tool/analyze_packages.py
+
+      - name: Run tests
+        run: |
+          for dir in packages/dart_monty_platform_interface packages/dart_monty_ffi packages/dart_monty_wasm; do
+            echo "--- ${dir} ---"
+            cd "$dir"
+            dart pub get
+            dart test
+            cd "$GITHUB_WORKSPACE"
+          done
+
   build-native:
     name: Build native (${{ matrix.label }})
     runs-on: ${{ matrix.os }}
@@ -58,11 +89,11 @@ jobs:
           name: native-${{ matrix.label }}
           path: ${{ matrix.dst }}
 
-  prepare:
-    name: Validate and tag
+  release:
+    name: Stamp, publish
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [build-native]
+    needs: [validate, build-native]
     steps:
       - uses: actions/checkout@v4
 
@@ -87,9 +118,6 @@ jobs:
              packages/dart_monty_desktop/macos/libdart_monty_native.dylib
           ls -lh packages/dart_monty_desktop/linux/
           ls -lh packages/dart_monty_desktop/macos/
-
-      - name: Verify formatting
-        run: dart format --set-exit-if-changed .
 
       - name: Bump version in all pubspecs
         run: |
@@ -118,19 +146,6 @@ jobs:
             cd "$dir"
             dart pub get
             dart doc --dry-run
-            cd "$GITHUB_WORKSPACE"
-          done
-
-      - name: Analyze all packages
-        run: python3 tool/analyze_packages.py
-
-      - name: Run tests
-        run: |
-          for dir in packages/dart_monty_platform_interface packages/dart_monty_ffi packages/dart_monty_wasm; do
-            echo "--- ${dir} ---"
-            cd "$dir"
-            dart pub get
-            dart test
             cd "$GITHUB_WORKSPACE"
           done
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,22 +125,22 @@ time the stamp script replaces it with the version heading.
 # 1. Review ## Unreleased sections, add any missing entries
 
 # 2. Stamp CHANGELOGs with the new version
-bash tool/stamp_changelogs.sh 0.2.0
+bash tool/stamp_changelogs.sh X.Y.Z
 
 # 3. Commit and push to main
-git add -A && git commit -m "chore: stamp changelogs for 0.2.0"
+git add -A && git commit -m "chore: stamp changelogs for X.Y.Z"
 git push origin main
 
 # 4. Trigger CI validation (dry-run, no publish)
-gh workflow run prepare-release.yaml -f version=0.2.0
+gh workflow run prepare-release.yaml -f version=X.Y.Z
 
 # 5. If green, re-trigger with publish
-gh workflow run prepare-release.yaml -f version=0.2.0 -f publish=true
+gh workflow run prepare-release.yaml -f version=X.Y.Z -f publish=true
 
 # 6. release.yaml auto-triggers from the tag → builds GitHub Release
 
 # 7. Verify all 6 packages are live on pub.dev
-bash tool/verify_publish.sh 0.2.0
+bash tool/verify_publish.sh X.Y.Z
 ```
 
 ### What the workflow does
@@ -149,12 +149,12 @@ bash tool/verify_publish.sh 0.2.0
 |------|--------|--------------|
 | Build native binaries (Linux + macOS) | x | |
 | `dart format --set-exit-if-changed .` | x | |
+| Analyze all packages | x | |
+| Run tests | x | |
 | Bump versions in all pubspecs | x | |
 | Stamp CHANGELOGs | x | |
 | Verify CHANGELOG entries | x | |
 | dartdoc dry-run (all 5 sub-packages) | x | |
-| Analyze all packages | x | |
-| Run tests | x | |
 | Commit version bumps | x | |
 | `dart pub publish --dry-run` | x | |
 | Tag and push | | x |


### PR DESCRIPTION
## Summary
- Split monolithic `prepare` job into 3 parallel jobs: `validate`, `build-native`, `release`
- Tests run immediately without waiting for Rust binary builds

## Changes
- **prepare-release.yaml**: Split into `validate` (format, analyze, tests), `build-native` (Linux + macOS), and `release` (stamp, dartdoc, commit, publish). `release` depends on both `validate` and `build-native`.
- **CONTRIBUTING.md**: Update workflow table to match new step order

## Before
```
build-native (Linux + macOS) ~3 min
    └── prepare (format → analyze → tests → stamp → publish) ~7 min
Total wall time: ~10 min
```

## After
```
validate (format, analyze, tests) ~3 min ──┐
                                            ├── release (stamp → publish) ~5 min
build-native (Linux + macOS)       ~3 min ──┘
Total wall time: ~8 min
```

Test failures now kill the pipeline immediately without waiting for binary builds.

## Test plan
- [x] YAML structure validated (needs dependencies correct)
- [x] CONTRIBUTING.md table matches new workflow order