### PR TITLE
fix(ci): add FFI codegen to publish_ffi workflow

### DIFF
--- a/.github/workflows/publish_ffi.yaml
+++ b/.github/workflows/publish_ffi.yaml
@@ -18,9 +18,16 @@ jobs:
         with:
           sdk: stable
 
+      - name: Install libclang
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
       - name: Install dependencies
         working-directory: packages/dart_monty_ffi
         run: dart pub get
+
+      - name: Generate FFI bindings
+        working-directory: packages/dart_monty_ffi
+        run: dart run ffigen --config ffigen.yaml
 
       - name: Analyze
         working-directory: packages/dart_monty_ffi


### PR DESCRIPTION
## Summary
- Add `libclang-dev` install and `dart run ffigen` step to `publish_ffi.yaml`
- Generated bindings are gitignored and must be regenerated in CI before analyze/test

## Changes
- **`publish_ffi.yaml`**: Insert `Install libclang` and `Generate FFI bindings` steps before Analyze

## Test plan
- [ ] Delete ffi-v0.3.5 tag, merge, bump to 0.3.6, re-tag, re-publish