### PR TITLE
refactor(ci): composite actions + pr-labeler fix

### DIFF
--- a/.github/actions/enforce-coverage/action.yaml
+++ b/.github/actions/enforce-coverage/action.yaml
@@ -1,0 +1,66 @@
+name: Enforce Dart coverage
+description: Check lcov coverage meets minimum threshold and upload to Codecov
+
+inputs:
+  package-path:
+    description: Path to the package directory (e.g. packages/dart_monty_ffi)
+    required: true
+  min-coverage:
+    description: Minimum coverage percentage (integer)
+    required: false
+    default: '90'
+  lcov-file:
+    description: Path to lcov.info relative to package-path
+    required: false
+    default: coverage/lcov.info
+  needs-format:
+    description: Whether to run coverage:format_coverage first (dart test --coverage output)
+    required: false
+    default: 'false'
+  codecov-token:
+    description: Codecov upload token
+    required: false
+    default: ''
+  codecov-flag:
+    description: Codecov flag name
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Format coverage
+      if: inputs.needs-format == 'true'
+      shell: bash
+      working-directory: ${{ inputs.package-path }}
+      run: |
+        dart pub global activate coverage
+        dart pub global run coverage:format_coverage \
+          --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
+
+    - name: Check coverage threshold
+      shell: bash
+      working-directory: ${{ inputs.package-path }}
+      run: |
+        LCOV="${{ inputs.lcov-file }}"
+        MIN="${{ inputs.min-coverage }}"
+        TOTAL=$(grep -c '^DA:' "$LCOV" || true)
+        HIT=$(grep '^DA:' "$LCOV" | grep -cv ',0$' || true)
+        if [ "$TOTAL" -eq 0 ]; then
+          echo "ERROR: No coverage data found in $LCOV"
+          exit 1
+        fi
+        PCT=$(( HIT * 100 / TOTAL ))
+        echo "Coverage: $HIT/$TOTAL lines = ${PCT}%"
+        if [ "$PCT" -lt "$MIN" ]; then
+          echo "FAIL: Coverage ${PCT}% < ${MIN}% minimum."
+          exit 1
+        fi
+
+    - name: Upload coverage to Codecov
+      if: inputs.codecov-token != ''
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ inputs.codecov-token }}
+        files: ${{ inputs.package-path }}/${{ inputs.lcov-file }}
+        flags: ${{ inputs.codecov-flag }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,69 +101,14 @@ jobs:
         run: cd packages/${{ matrix.target }} && dart pub get
       - name: Run tests
         run: cd packages/${{ matrix.target }} && dart test --coverage=coverage
-      - name: Check coverage (platform_interface)
-        if: matrix.target == 'dart_monty_platform_interface'
-        run: |
-          cd packages/dart_monty_platform_interface
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage \
-            --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
-          TOTAL=$(grep -c '^DA:' coverage/lcov.info || true)
-          HIT=$(grep '^DA:' coverage/lcov.info | grep -cv ',0$' || true)
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "ERROR: No coverage data found."
-            exit 1
-          fi
-          PCT=$(( HIT * 100 / TOTAL ))
-          echo "Coverage: $HIT/$TOTAL lines = ${PCT}%"
-          if [ "$PCT" -lt 90 ]; then
-            echo "FAIL: Coverage ${PCT}% < 90% minimum."
-            exit 1
-          fi
-      - name: Check coverage (ffi)
-        if: matrix.target == 'dart_monty_ffi'
-        run: |
-          cd packages/dart_monty_ffi
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage \
-            --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
-          TOTAL=$(grep -c '^DA:' coverage/lcov.info || true)
-          HIT=$(grep '^DA:' coverage/lcov.info | grep -cv ',0$' || true)
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "ERROR: No coverage data found."
-            exit 1
-          fi
-          PCT=$(( HIT * 100 / TOTAL ))
-          echo "Coverage: $HIT/$TOTAL lines = ${PCT}%"
-          if [ "$PCT" -lt 90 ]; then
-            echo "FAIL: Coverage ${PCT}% < 90% minimum."
-            exit 1
-          fi
-      - name: Check coverage (wasm)
-        if: matrix.target == 'dart_monty_wasm'
-        run: |
-          cd packages/dart_monty_wasm
-          dart pub global activate coverage
-          dart pub global run coverage:format_coverage \
-            --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
-          TOTAL=$(grep -c '^DA:' coverage/lcov.info || true)
-          HIT=$(grep '^DA:' coverage/lcov.info | grep -cv ',0$' || true)
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "ERROR: No coverage data found."
-            exit 1
-          fi
-          PCT=$(( HIT * 100 / TOTAL ))
-          echo "Coverage: $HIT/$TOTAL lines = ${PCT}%"
-          if [ "$PCT" -lt 90 ]; then
-            echo "FAIL: Coverage ${PCT}% < 90% minimum."
-            exit 1
-          fi
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+      - name: Enforce coverage
+        uses: ./.github/actions/enforce-coverage
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/${{ matrix.target }}/coverage/lcov.info
-          flags: ${{ matrix.target }}
+          package-path: packages/${{ matrix.target }}
+          min-coverage: '90'
+          needs-format: 'true'
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          codecov-flag: ${{ matrix.target }}
 
   test-desktop:
     name: Test (dart_monty_desktop)
@@ -185,27 +130,13 @@ jobs:
         run: cd packages/dart_monty_desktop && flutter pub get
       - name: Run tests
         run: cd packages/dart_monty_desktop && flutter test --coverage
-      - name: Check coverage
-        run: |
-          cd packages/dart_monty_desktop
-          TOTAL=$(grep -c '^DA:' coverage/lcov.info || true)
-          HIT=$(grep '^DA:' coverage/lcov.info | grep -cv ',0$' || true)
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "ERROR: No coverage data found."
-            exit 1
-          fi
-          PCT=$(( HIT * 100 / TOTAL ))
-          echo "Coverage: $HIT/$TOTAL lines = ${PCT}%"
-          if [ "$PCT" -lt 90 ]; then
-            echo "FAIL: Coverage ${PCT}% < 90% minimum."
-            exit 1
-          fi
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+      - name: Enforce coverage
+        uses: ./.github/actions/enforce-coverage
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: packages/dart_monty_desktop/coverage/lcov.info
-          flags: dart_monty_desktop
+          package-path: packages/dart_monty_desktop
+          min-coverage: '90'
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          codecov-flag: dart_monty_desktop
 
   test-web:
     name: Test (dart_monty_web)

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,7 @@
 name: PR Labeler
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
 
 permissions:


### PR DESCRIPTION
## Summary

- Extract `enforce-coverage` composite action to replace 4 duplicated coverage bash blocks
- Fix `pr-labeler.yml` fork trigger vulnerability

## Changes

- **`.github/actions/enforce-coverage/action.yaml`** (new) — reusable composite action:
  - Optionally runs `coverage:format_coverage` (for `dart test --coverage` output)
  - Enforces minimum coverage threshold via lcov parsing
  - Uploads to Codecov (when token provided)
- **`ci.yaml`** — 4 copy-pasted coverage blocks replaced with single action calls
- **`pr-labeler.yml`** — `pull_request` → `pull_request_target` (fork PRs get 403 with write permissions on `pull_request`)

## Test plan

- [x] CI runs on this PR validate the composite action works
- [ ] Verify coverage gate still enforces 90% for Dart packages
- [ ] Verify Codecov upload still works

Closes part of #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)