### PR TITLE
refactor(ci): reusable publish workflow

### DIFF
--- a/.github/workflows/_publish-dart-package.yaml
+++ b/.github/workflows/_publish-dart-package.yaml
@@ -1,0 +1,100 @@
+name: Publish Dart package
+
+on:
+  workflow_call:
+    inputs:
+      package-name:
+        description: Human-readable package name (for logs)
+        type: string
+        required: true
+      tag-prefix:
+        description: Tag prefix to strip for version verification (e.g. "ffi-v")
+        type: string
+        required: true
+      package-path:
+        description: Working directory for the package
+        type: string
+        default: '.'
+      uses-flutter:
+        description: Whether to set up Flutter SDK (for Flutter plugins/packages)
+        type: boolean
+        default: false
+      needs-ffigen:
+        description: Whether to install libclang and generate FFI bindings
+        type: boolean
+        default: false
+      has-tests:
+        description: Whether to run tests before publishing
+        type: boolean
+        default: true
+      analyze-scope:
+        description: Optional path argument for analyze (e.g. "lib" for root package)
+        type: string
+        default: ''
+
+jobs:
+  publish:
+    name: Publish ${{ inputs.package-name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        if: inputs.uses-flutter
+        with:
+          channel: stable
+
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install libclang
+        if: inputs.needs-ffigen
+        run: sudo apt-get update && sudo apt-get install -y libclang-dev
+
+      - name: Install dependencies
+        working-directory: ${{ inputs.package-path }}
+        run: ${{ inputs.uses-flutter && 'flutter' || 'dart' }} pub get
+
+      - name: Generate FFI bindings
+        if: inputs.needs-ffigen
+        working-directory: ${{ inputs.package-path }}
+        run: dart run ffigen --config ffigen.yaml
+
+      - name: Analyze
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          if [ "${{ inputs.uses-flutter }}" = "true" ]; then
+            flutter analyze ${{ inputs.analyze-scope }}
+          else
+            dart analyze --fatal-infos ${{ inputs.analyze-scope }}
+          fi
+
+      - name: Run tests
+        if: inputs.has-tests
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          if [ "${{ inputs.uses-flutter }}" = "true" ]; then
+            flutter test
+          else
+            dart test
+          fi
+
+      - name: Verify version matches tag
+        working-directory: ${{ inputs.package-path }}
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#${{ inputs.tag-prefix }}}"
+          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' \r')
+          echo "Tag: $TAG_VERSION | Pubspec: $PUBSPEC_VERSION"
+          [ "$TAG_VERSION" = "$PUBSPEC_VERSION" ] || { echo "MISMATCH"; exit 1; }
+
+      - name: Dry run
+        working-directory: ${{ inputs.package-path }}
+        run: dart pub publish --dry-run
+
+      - name: Publish
+        working-directory: ${{ inputs.package-path }}
+        run: dart pub publish --force

--- a/.github/workflows/publish_dart_monty.yaml
+++ b/.github/workflows/publish_dart_monty.yaml
@@ -7,36 +7,12 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/_publish-dart-package.yaml
     permissions:
-      id-token: write # Required for OIDC
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: Install dependencies
-        run: flutter pub get
-
-      - name: Analyze
-        run: flutter analyze lib
-
-      - name: Verify version matches tag
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#dart_monty-v}"
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' \r')
-          echo "Tag: $TAG_VERSION | Pubspec: $PUBSPEC_VERSION"
-          [ "$TAG_VERSION" = "$PUBSPEC_VERSION" ] || { echo "MISMATCH"; exit 1; }
-
-      - name: Dry run
-        run: dart pub publish --dry-run
-
-      - name: Publish
-        run: dart pub publish --force
+      id-token: write
+    with:
+      package-name: dart_monty
+      tag-prefix: dart_monty-v
+      uses-flutter: true
+      has-tests: false
+      analyze-scope: lib

--- a/.github/workflows/publish_desktop.yaml
+++ b/.github/workflows/publish_desktop.yaml
@@ -7,45 +7,11 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/_publish-dart-package.yaml
     permissions:
-      id-token: write # Required for OIDC
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: Install dependencies
-        working-directory: packages/dart_monty_desktop
-        run: flutter pub get
-
-      - name: Analyze
-        working-directory: packages/dart_monty_desktop
-        run: flutter analyze
-
-      - name: Run tests
-        working-directory: packages/dart_monty_desktop
-        run: flutter test
-
-      - name: Verify version matches tag
-        working-directory: packages/dart_monty_desktop
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#desktop-v}"
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' \r')
-          echo "Tag: $TAG_VERSION | Pubspec: $PUBSPEC_VERSION"
-          [ "$TAG_VERSION" = "$PUBSPEC_VERSION" ] || { echo "MISMATCH"; exit 1; }
-
-      - name: Dry run
-        working-directory: packages/dart_monty_desktop
-        run: dart pub publish --dry-run
-
-      - name: Publish
-        working-directory: packages/dart_monty_desktop
-        run: dart pub publish --force
+      id-token: write
+    with:
+      package-name: dart_monty_desktop
+      tag-prefix: desktop-v
+      package-path: packages/dart_monty_desktop
+      uses-flutter: true

--- a/.github/workflows/publish_ffi.yaml
+++ b/.github/workflows/publish_ffi.yaml
@@ -7,48 +7,11 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/_publish-dart-package.yaml
     permissions:
-      id-token: write # Required for OIDC
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: Install libclang
-        run: sudo apt-get update && sudo apt-get install -y libclang-dev
-
-      - name: Install dependencies
-        working-directory: packages/dart_monty_ffi
-        run: dart pub get
-
-      - name: Generate FFI bindings
-        working-directory: packages/dart_monty_ffi
-        run: dart run ffigen --config ffigen.yaml
-
-      - name: Analyze
-        working-directory: packages/dart_monty_ffi
-        run: dart analyze --fatal-infos
-
-      - name: Run tests
-        working-directory: packages/dart_monty_ffi
-        run: dart test
-
-      - name: Verify version matches tag
-        working-directory: packages/dart_monty_ffi
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#ffi-v}"
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' \r')
-          echo "Tag: $TAG_VERSION | Pubspec: $PUBSPEC_VERSION"
-          [ "$TAG_VERSION" = "$PUBSPEC_VERSION" ] || { echo "MISMATCH"; exit 1; }
-
-      - name: Dry run
-        working-directory: packages/dart_monty_ffi
-        run: dart pub publish --dry-run
-
-      - name: Publish
-        working-directory: packages/dart_monty_ffi
-        run: dart pub publish --force
+      id-token: write
+    with:
+      package-name: dart_monty_ffi
+      tag-prefix: ffi-v
+      package-path: packages/dart_monty_ffi
+      needs-ffigen: true

--- a/.github/workflows/publish_platform_interface.yaml
+++ b/.github/workflows/publish_platform_interface.yaml
@@ -7,41 +7,10 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/_publish-dart-package.yaml
     permissions:
-      id-token: write # Required for OIDC
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: Install dependencies
-        working-directory: packages/dart_monty_platform_interface
-        run: dart pub get
-
-      - name: Analyze
-        working-directory: packages/dart_monty_platform_interface
-        run: dart analyze --fatal-infos
-
-      - name: Run tests
-        working-directory: packages/dart_monty_platform_interface
-        run: dart test
-
-      - name: Verify version matches tag
-        working-directory: packages/dart_monty_platform_interface
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#platform_interface-v}"
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' \r')
-          echo "Tag: $TAG_VERSION | Pubspec: $PUBSPEC_VERSION"
-          [ "$TAG_VERSION" = "$PUBSPEC_VERSION" ] || { echo "MISMATCH"; exit 1; }
-
-      - name: Dry run
-        working-directory: packages/dart_monty_platform_interface
-        run: dart pub publish --dry-run
-
-      - name: Publish
-        working-directory: packages/dart_monty_platform_interface
-        run: dart pub publish --force
+      id-token: write
+    with:
+      package-name: dart_monty_platform_interface
+      tag-prefix: platform_interface-v
+      package-path: packages/dart_monty_platform_interface

--- a/.github/workflows/publish_wasm.yaml
+++ b/.github/workflows/publish_wasm.yaml
@@ -7,41 +7,10 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/_publish-dart-package.yaml
     permissions:
-      id-token: write # Required for OIDC
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: Install dependencies
-        working-directory: packages/dart_monty_wasm
-        run: dart pub get
-
-      - name: Analyze
-        working-directory: packages/dart_monty_wasm
-        run: dart analyze --fatal-infos
-
-      - name: Run tests
-        working-directory: packages/dart_monty_wasm
-        run: dart test
-
-      - name: Verify version matches tag
-        working-directory: packages/dart_monty_wasm
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#wasm-v}"
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' \r')
-          echo "Tag: $TAG_VERSION | Pubspec: $PUBSPEC_VERSION"
-          [ "$TAG_VERSION" = "$PUBSPEC_VERSION" ] || { echo "MISMATCH"; exit 1; }
-
-      - name: Dry run
-        working-directory: packages/dart_monty_wasm
-        run: dart pub publish --dry-run
-
-      - name: Publish
-        working-directory: packages/dart_monty_wasm
-        run: dart pub publish --force
+      id-token: write
+    with:
+      package-name: dart_monty_wasm
+      tag-prefix: wasm-v
+      package-path: packages/dart_monty_wasm

--- a/.github/workflows/publish_web.yaml
+++ b/.github/workflows/publish_web.yaml
@@ -7,41 +7,12 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
+    uses: ./.github/workflows/_publish-dart-package.yaml
     permissions:
-      id-token: write # Required for OIDC
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - name: Install dependencies
-        working-directory: packages/dart_monty_web
-        run: flutter pub get
-
-      - name: Analyze
-        working-directory: packages/dart_monty_web
-        run: flutter analyze
-
-      - name: Verify version matches tag
-        working-directory: packages/dart_monty_web
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#web-v}"
-          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | tr -d ' \r')
-          echo "Tag: $TAG_VERSION | Pubspec: $PUBSPEC_VERSION"
-          [ "$TAG_VERSION" = "$PUBSPEC_VERSION" ] || { echo "MISMATCH"; exit 1; }
-
-      - name: Dry run
-        working-directory: packages/dart_monty_web
-        run: dart pub publish --dry-run
-
-      - name: Publish
-        working-directory: packages/dart_monty_web
-        run: dart pub publish --force
+      id-token: write
+    with:
+      package-name: dart_monty_web
+      tag-prefix: web-v
+      package-path: packages/dart_monty_web
+      uses-flutter: true
+      has-tests: false


### PR DESCRIPTION
## Summary
- Extract a single reusable `_publish-dart-package.yaml` workflow using `workflow_call`
- Refactor all 6 `publish_*.yaml` files from ~45 lines each to ~15-line thin callers
- Net reduction: **228 lines deleted**, 142 added (86 lines saved, single source of truth)

## Changes
- **`_publish-dart-package.yaml`** (NEW): Reusable workflow with inputs for `package-name`, `tag-prefix`, `package-path`, `uses-flutter`, `needs-ffigen`, `has-tests`, `analyze-scope`
- **`publish_platform_interface.yaml`**: Thin caller (pure Dart, with tests)
- **`publish_ffi.yaml`**: Thin caller (pure Dart, with ffigen + tests)
- **`publish_wasm.yaml`**: Thin caller (pure Dart, with tests)
- **`publish_web.yaml`**: Thin caller (Flutter, no tests)
- **`publish_desktop.yaml`**: Thin caller (Flutter, with tests)
- **`publish_dart_monty.yaml`**: Thin caller (Flutter, no tests, analyze scoped to `lib`)

## Design decisions
- OIDC `id-token: write` declared in both caller and callee (required for reusable workflows)
- Conditional steps via `if: inputs.uses-flutter` / `if: inputs.needs-ffigen` / `if: inputs.has-tests`
- `analyze-scope` input allows root package to scope `flutter analyze lib` while sub-packages analyze everything

## Test plan
- [x] Reusable workflow can't be tested via tag push without actually publishing — verified structure manually
- [x] All 6 callers pass correct inputs matching their original behavior
- [x] OIDC permissions propagate correctly (id-token: write in both layers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)