### PR TITLE
chore: release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased
+## 0.4.1
+
+- Extract reusable publish workflow for all 6 packages
+- Add path filters to skip CI on docs-only changes
+- Extract enforce-coverage composite action (DRY)
 
 ## 0.4.0
 

--- a/packages/dart_monty_desktop/CHANGELOG.md
+++ b/packages/dart_monty_desktop/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.1
+
+- CI improvements (no package code changes)
 
 ## 0.4.0
 

--- a/packages/dart_monty_desktop/pubspec.yaml
+++ b/packages/dart_monty_desktop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_desktop
 description: Desktop plugin for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_ffi/CHANGELOG.md
+++ b/packages/dart_monty_ffi/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.1
+
+- CI improvements (no package code changes)
 
 ## 0.4.0
 

--- a/packages/dart_monty_ffi/pubspec.yaml
+++ b/packages/dart_monty_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_ffi
 description: Native FFI backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_platform_interface/CHANGELOG.md
+++ b/packages/dart_monty_platform_interface/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.1
+
+- CI improvements (no package code changes)
 
 ## 0.4.0
 

--- a/packages/dart_monty_platform_interface/pubspec.yaml
+++ b/packages/dart_monty_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_platform_interface
 description: Platform interface for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_wasm/CHANGELOG.md
+++ b/packages/dart_monty_wasm/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.1
+
+- CI improvements (no package code changes)
 
 ## 0.4.0
 

--- a/packages/dart_monty_wasm/pubspec.yaml
+++ b/packages/dart_monty_wasm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_wasm
 description: WASM backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_web/CHANGELOG.md
+++ b/packages/dart_monty_web/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.1
+
+- CI improvements (no package code changes)
 
 ## 0.4.0
 

--- a/packages/dart_monty_web/pubspec.yaml
+++ b/packages/dart_monty_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_web
 description: Flutter web plugin for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues


### PR DESCRIPTION
## Summary
- Bump all 6 packages + root to 0.4.1
- Update CHANGELOGs for 0.4.1 release

## Changes
CI-only release covering PRs #38, #40, #41, #42:
- Reusable publish workflow (`_publish-dart-package.yaml`)
- Path filters to skip CI on docs-only changes
- `enforce-coverage` composite action
- FFI bindings generated once as artifact
- Merged Rust jobs, removed gitleaks/build-native

## Test plan
- [x] `dart pub publish --dry-run` passes for platform_interface
- [ ] After merge: tag all packages in dependency order, verify OIDC publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)