### PR TITLE
chore: bump all packages to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## Unreleased
+## 0.4.2
+
+- Plumb async/futures API through desktop Isolate bridge (`resumeAsFuture()`, `resolveFutures()`, `resolveFuturesWithErrors()`)
+- Override async/futures methods in web plugin with `UnsupportedError`
+- Add tier 4 function parameter fixtures (keyword-only, mixed args/kwargs, forwarding, positional-only)
+- Enable tier 13 async ladder fixtures (remove xfail)
+- Add "Async gather" and "Function params" examples to desktop and web example apps
+- Expand web ladder runner to tiers 1-9, 13, 15
 
 ## 0.4.1
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The table below shows current coverage and what's planned.
 | **Snapshot / restore** (`MontyRun::dump/load`) | Covered | Compile-once, run-many pattern |
 | **Exception model** (excType, traceback, stack frames) | Covered | Full `MontyException` with `StackFrame` list |
 | **Call metadata** (kwargs, callId, methodCall, scriptName) | Covered | Structured external call context |
-| Async / futures (`asyncio.gather`, concurrent calls) | Planned | Native only — WASM upstream lacks `FutureSnapshot` API |
+| Async / futures (`asyncio.gather`, concurrent calls) | Covered | Native only — WASM upstream lacks `FutureSnapshot` API |
 | Rich types (tuple, set, bytes, dataclass, namedtuple) | Planned | Currently collapsed to `List`/`Map` |
 | REPL (stateful sessions, `feed()`, persistence) | Planned | `MontyRepl` multi-step sessions |
 | OS calls (`os.getenv`, `os.environ`, `os.stat`) | Planned | `OsCall` progress variant |

--- a/packages/dart_monty_desktop/CHANGELOG.md
+++ b/packages/dart_monty_desktop/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased
+## 0.4.2
+
+- Add `resumeAsFuture()`, `resolveFutures()`, `resolveFuturesWithErrors()` to `DesktopBindings`, `DesktopBindingsIsolate`, and `MontyDesktop`
+- Add mock desktop bindings for async/futures methods
+- Add async/futures integration tests for tier 13 ladder fixtures
 
 ## 0.4.1
 

--- a/packages/dart_monty_desktop/pubspec.yaml
+++ b/packages/dart_monty_desktop/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_desktop
 description: Desktop plugin for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_ffi/CHANGELOG.md
+++ b/packages/dart_monty_ffi/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.2
+
+- Add async resume path with error handling in tier 13 ladder integration tests
 
 ## 0.4.1
 

--- a/packages/dart_monty_ffi/pubspec.yaml
+++ b/packages/dart_monty_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_ffi
 description: Native FFI backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_platform_interface/CHANGELOG.md
+++ b/packages/dart_monty_platform_interface/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.2
+
+- Version bump (no package code changes)
 
 ## 0.4.1
 

--- a/packages/dart_monty_platform_interface/pubspec.yaml
+++ b/packages/dart_monty_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_platform_interface
 description: Platform interface for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_wasm/CHANGELOG.md
+++ b/packages/dart_monty_wasm/CHANGELOG.md
@@ -1,4 +1,6 @@
-## Unreleased
+## 0.4.2
+
+- Version bump (no package code changes)
 
 ## 0.4.1
 

--- a/packages/dart_monty_wasm/pubspec.yaml
+++ b/packages/dart_monty_wasm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_wasm
 description: WASM backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_web/CHANGELOG.md
+++ b/packages/dart_monty_web/CHANGELOG.md
@@ -1,4 +1,7 @@
-## Unreleased
+## 0.4.2
+
+- Override `resumeAsFuture()`, `resolveFutures()`, `resolveFuturesWithErrors()` in `DartMontyWeb` with `UnsupportedError`
+- Expand web ladder runner to tiers 1-9, 13, 15 with `nativeOnly` skip handling
 
 ## 0.4.1
 

--- a/packages/dart_monty_web/pubspec.yaml
+++ b/packages/dart_monty_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_web
 description: Flutter web plugin for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues


### PR DESCRIPTION
## Summary
- Bump all 6 packages from 0.4.1 → 0.4.2
- Consolidate CHANGELOGs (`## Unreleased` → `## 0.4.2`)
- Mark async/futures as **Covered** in README API coverage table

## Changes
- **dart_monty_desktop**: async/futures API through Isolate bridge (`resumeAsFuture()`, `resolveFutures()`, `resolveFuturesWithErrors()`)
- **dart_monty_web**: `UnsupportedError` stubs for async methods, expanded ladder tiers 1-9, 13, 15
- **dart_monty_ffi**: tier 13 async ladder integration tests
- **dart_monty_platform_interface / dart_monty_wasm**: version bump only
- **dart_monty (root)**: summary changelog, example app updates, new tier 4 function param fixtures
- **README.md**: async/futures row Planned → Covered

## Test plan
- [x] All changes are version bumps, CHANGELOGs, and README — no code changes
- [x] CI will validate analyze + tests on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)