### PR TITLE
chore(tooling): mark Slice 4 done, run full gate in slice review

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -32,7 +32,7 @@ See `docs/refactoring-plan.md` for the full plan.
 | 1 | Test Pruning + Trivial Cleanup (~1,394 lines) | Medium | **Done** |
 | 2 | Fix `restore()` State Divergence | Low | **Done** |
 | 3 | Mock & API Surface Cleanup | Low-Medium | **Done** |
-| 4 | State Machine Consolidation (mixin extraction) | Medium | Pending |
+| 4 | State Machine Consolidation (mixin extraction) | Medium | **Done** |
 | 5 | Shared Test Harness (contract tests) | Medium | Pending |
 | 6 | Web Package Simplification | **High** | Pending |
 | 7 | Desktop & WASM Refinement + iOS Prep | Low-Medium | Pending |

--- a/tool/slice_review.sh
+++ b/tool/slice_review.sh
@@ -144,12 +144,12 @@ echo "=== Phase 2: Capturing metrics ==="
 bash tool/metrics.sh > "$METRICS_AFTER"
 
 # -------------------------------------------------------
-# Phase 3: Run gate.sh --dart-only (unless --skip-gate)
+# Phase 3: Run gate.sh (unless --skip-gate)
 # -------------------------------------------------------
 if [[ "$SKIP_GATE" == false ]]; then
   echo "=== Phase 3: Running gate ==="
   set +e
-  bash tool/gate.sh --dart-only > "$GATE_OUTPUT" 2>&1
+  bash tool/gate.sh > "$GATE_OUTPUT" 2>&1
   GATE_EXIT=$?
   set -e
   if [[ $GATE_EXIT -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Mark Slice 4 as Done in PLAN.md
- Change `slice_review.sh` Phase 3 to run full `gate.sh` instead of `gate.sh --dart-only`, so the Gemini review prompt includes Rust gate status

## Changes
- **docs/PLAN.md**: Slice 4 status `Pending` → `Done`
- **tool/slice_review.sh**: Phase 3 gate invocation includes Rust

## Test plan
- [x] No code changes — tooling/docs only