### PR TITLE
refactor: desktop & WASM refinement + iOS prep (Slice 7)

### DIFF
--- a/example/desktop/lib/main.dart
+++ b/example/desktop/lib/main.dart
@@ -1275,11 +1275,10 @@ class _LadderPageState extends State<_LadderPage> {
                 results[id] = asyncResumeMap[key];
               }
             }
-            if (errors.isNotEmpty) {
-              progress = await monty.resolveFuturesWithErrors(results, errors);
-            } else {
-              progress = await monty.resolveFutures(results);
-            }
+            progress = await monty.resolveFutures(
+              results,
+              errors: errors.isNotEmpty ? errors : null,
+            );
           }
         }
       } on MontyException catch (e) {

--- a/packages/dart_monty_desktop/lib/src/desktop_bindings.dart
+++ b/packages/dart_monty_desktop/lib/src/desktop_bindings.dart
@@ -2,29 +2,6 @@ import 'dart:typed_data';
 
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
 
-/// Result of [DesktopBindings.run].
-///
-/// Wraps a [MontyResult] from the background Isolate.
-final class DesktopRunResult {
-  /// Creates a [DesktopRunResult].
-  const DesktopRunResult({required this.result});
-
-  /// The result from the Python execution.
-  final MontyResult result;
-}
-
-/// Result of [DesktopBindings.start], [DesktopBindings.resume], and
-/// [DesktopBindings.resumeWithError].
-///
-/// Wraps a [MontyProgress] from the background Isolate.
-final class DesktopProgressResult {
-  /// Creates a [DesktopProgressResult].
-  const DesktopProgressResult({required this.progress});
-
-  /// The progress state from the Isolate.
-  final MontyProgress progress;
-}
-
 /// Abstract interface over the desktop Isolate bridge.
 ///
 /// All methods are `Future`-based because the Isolate round-trip is
@@ -42,7 +19,7 @@ abstract class DesktopBindings {
   ///
   /// If [scriptName] is non-null, it overrides the default filename in
   /// tracebacks and error messages.
-  Future<DesktopRunResult> run(
+  Future<MontyResult> run(
     String code, {
     MontyLimits? limits,
     String? scriptName,
@@ -51,7 +28,7 @@ abstract class DesktopBindings {
   /// Starts iterative execution of [code] in the background Isolate.
   ///
   /// If [scriptName] is non-null, it overrides the default filename.
-  Future<DesktopProgressResult> start(
+  Future<MontyProgress> start(
     String code, {
     List<String>? externalFunctions,
     MontyLimits? limits,
@@ -59,22 +36,20 @@ abstract class DesktopBindings {
   });
 
   /// Resumes a paused execution with [returnValue].
-  Future<DesktopProgressResult> resume(Object? returnValue);
+  Future<MontyProgress> resume(Object? returnValue);
 
   /// Resumes a paused execution by raising an error with [errorMessage].
-  Future<DesktopProgressResult> resumeWithError(String errorMessage);
+  Future<MontyProgress> resumeWithError(String errorMessage);
 
   /// Converts the current pending call into a future and continues execution.
-  Future<DesktopProgressResult> resumeAsFuture();
+  Future<MontyProgress> resumeAsFuture();
 
-  /// Resolves one or more pending futures with their [results].
-  Future<DesktopProgressResult> resolveFutures(Map<int, Object?> results);
-
-  /// Resolves pending futures with [results] and [errors].
-  Future<DesktopProgressResult> resolveFuturesWithErrors(
-    Map<int, Object?> results,
-    Map<int, String> errors,
-  );
+  /// Resolves one or more pending futures with their [results], and
+  /// optionally [errors].
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  });
 
   /// Captures the current interpreter state as a binary snapshot.
   Future<Uint8List> snapshot();

--- a/packages/dart_monty_desktop/lib/src/monty_desktop.dart
+++ b/packages/dart_monty_desktop/lib/src/monty_desktop.dart
@@ -64,7 +64,7 @@ class MontyDesktop extends MontyPlatform with MontyStateMixin {
       limits: limits,
       scriptName: scriptName,
     );
-    return result.result;
+    return result;
   }
 
   @override
@@ -86,7 +86,7 @@ class MontyDesktop extends MontyPlatform with MontyStateMixin {
       limits: limits,
       scriptName: scriptName,
     );
-    return _handleProgress(progress.progress);
+    return _handleProgress(progress);
   }
 
   @override
@@ -95,7 +95,7 @@ class MontyDesktop extends MontyPlatform with MontyStateMixin {
     assertActive('resume');
 
     final progress = await _bindings.resume(returnValue);
-    return _handleProgress(progress.progress);
+    return _handleProgress(progress);
   }
 
   @override
@@ -104,7 +104,7 @@ class MontyDesktop extends MontyPlatform with MontyStateMixin {
     assertActive('resumeWithError');
 
     final progress = await _bindings.resumeWithError(errorMessage);
-    return _handleProgress(progress.progress);
+    return _handleProgress(progress);
   }
 
   @override
@@ -113,28 +113,19 @@ class MontyDesktop extends MontyPlatform with MontyStateMixin {
     assertActive('resumeAsFuture');
 
     final progress = await _bindings.resumeAsFuture();
-    return _handleProgress(progress.progress);
+    return _handleProgress(progress);
   }
 
   @override
-  Future<MontyProgress> resolveFutures(Map<int, Object?> results) async {
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) async {
     assertNotDisposed('resolveFutures');
     assertActive('resolveFutures');
 
-    final progress = await _bindings.resolveFutures(results);
-    return _handleProgress(progress.progress);
-  }
-
-  @override
-  Future<MontyProgress> resolveFuturesWithErrors(
-    Map<int, Object?> results,
-    Map<int, String> errors,
-  ) async {
-    assertNotDisposed('resolveFuturesWithErrors');
-    assertActive('resolveFuturesWithErrors');
-
-    final progress = await _bindings.resolveFuturesWithErrors(results, errors);
-    return _handleProgress(progress.progress);
+    final progress = await _bindings.resolveFutures(results, errors: errors);
+    return _handleProgress(progress);
   }
 
   @override

--- a/packages/dart_monty_desktop/test/integration/fail_all_pending_test.dart
+++ b/packages/dart_monty_desktop/test/integration/fail_all_pending_test.dart
@@ -1,0 +1,72 @@
+@Tags(['integration'])
+library;
+
+import 'dart:io';
+
+import 'package:dart_monty_desktop/dart_monty_desktop.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:test/test.dart';
+
+/// Integration tests for `_failAllPending` semantics in
+/// [DesktopBindingsIsolate].
+///
+/// When `dispose()` is called while an iterative execution is in-flight
+/// (state = active, a MontyPending has been returned but not yet resumed),
+/// the background Isolate is killed and all pending completer futures
+/// must complete with an error — not hang forever.
+///
+/// The "unexpected isolate exit" path (Isolate crashes without dispose) is
+/// not directly testable without Isolate introspection — documented as a
+/// known limitation.
+///
+/// Run with:
+/// ```bash
+/// cd native && cargo build --release && cd ..
+/// cd packages/dart_monty_desktop
+/// dart test --tags=integration test/integration/fail_all_pending_test.dart
+/// ```
+void main() {
+  final libPath = _resolveLibraryPath();
+
+  MontyDesktop createMonty() =>
+      MontyDesktop(bindings: DesktopBindingsIsolate(libraryPath: libPath));
+
+  test('dispose while pending does not hang', () async {
+    final monty = createMonty();
+
+    // Start iterative execution that pauses on external function call.
+    final progress = await monty.start(
+      'result = fetch("url")\nresult',
+      externalFunctions: ['fetch'],
+    );
+    expect(progress, isA<MontyPending>());
+
+    // Dispose without resuming — this triggers _failAllPending inside
+    // DesktopBindingsIsolate.dispose().
+    await monty.dispose();
+
+    // If _failAllPending works correctly, dispose() returned normally
+    // instead of hanging on an uncompleted future. The fact that we
+    // reach this line IS the assertion.
+  });
+
+  test('dispose while pending makes further resume throw', () async {
+    final monty = createMonty();
+
+    final progress = await monty.start(
+      'fetch("url")',
+      externalFunctions: ['fetch'],
+    );
+    expect(progress, isA<MontyPending>());
+
+    await monty.dispose();
+
+    // After dispose, resume must throw StateError (disposed state).
+    expect(() => monty.resume('value'), throwsStateError);
+  });
+}
+
+String _resolveLibraryPath() {
+  final ext = Platform.isMacOS ? 'dylib' : 'so';
+  return '../../native/target/release/libdart_monty_native.$ext';
+}

--- a/packages/dart_monty_desktop/test/mock_desktop_bindings.dart
+++ b/packages/dart_monty_desktop/test/mock_desktop_bindings.dart
@@ -17,25 +17,21 @@ class MockDesktopBindings extends DesktopBindings {
   bool nextInitResult = true;
 
   /// Result returned by [run].
-  DesktopRunResult nextRunResult = const DesktopRunResult(
-    result: MontyResult(
-      value: 4,
-      usage: _zeroUsage,
-    ),
+  MontyResult nextRunResult = const MontyResult(
+    value: 4,
+    usage: _zeroUsage,
   );
 
   /// Result returned by [start].
-  DesktopProgressResult nextStartResult = const DesktopProgressResult(
-    progress: MontyComplete(
-      result: MontyResult(usage: _zeroUsage),
-    ),
+  MontyProgress nextStartResult = const MontyComplete(
+    result: MontyResult(usage: _zeroUsage),
   );
 
   /// Queue of results returned by [resume]. Dequeues on each call.
-  final List<DesktopProgressResult> resumeResults = [];
+  final List<MontyProgress> resumeResults = [];
 
   /// Queue of results returned by [resumeWithError]. Dequeues on each call.
-  final List<DesktopProgressResult> resumeWithErrorResults = [];
+  final List<MontyProgress> resumeWithErrorResults = [];
 
   /// Data returned by [snapshot].
   Uint8List nextSnapshotData = Uint8List.fromList([1, 2, 3]);
@@ -96,7 +92,7 @@ class MockDesktopBindings extends DesktopBindings {
   }
 
   @override
-  Future<DesktopRunResult> run(
+  Future<MontyResult> run(
     String code, {
     MontyLimits? limits,
     String? scriptName,
@@ -106,7 +102,7 @@ class MockDesktopBindings extends DesktopBindings {
   }
 
   @override
-  Future<DesktopProgressResult> start(
+  Future<MontyProgress> start(
     String code, {
     List<String>? externalFunctions,
     MontyLimits? limits,
@@ -124,87 +120,61 @@ class MockDesktopBindings extends DesktopBindings {
   }
 
   @override
-  Future<DesktopProgressResult> resume(Object? returnValue) async {
+  Future<MontyProgress> resume(Object? returnValue) async {
     resumeCalls.add(returnValue);
     if (resumeResults.isNotEmpty) return resumeResults.removeAt(0);
-    return const DesktopProgressResult(
-      progress: MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
-      ),
+    return const MontyComplete(
+      result: MontyResult(usage: _zeroUsage),
     );
   }
 
   @override
-  Future<DesktopProgressResult> resumeWithError(String errorMessage) async {
+  Future<MontyProgress> resumeWithError(String errorMessage) async {
     resumeWithErrorCalls.add(errorMessage);
     if (resumeWithErrorResults.isNotEmpty) {
       return resumeWithErrorResults.removeAt(0);
     }
-    return const DesktopProgressResult(
-      progress: MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
-      ),
+    return const MontyComplete(
+      result: MontyResult(usage: _zeroUsage),
     );
   }
 
   /// Queue of results returned by [resumeAsFuture]. Dequeues on each call.
-  final List<DesktopProgressResult> resumeAsFutureResults = [];
+  final List<MontyProgress> resumeAsFutureResults = [];
 
   /// Number of times [resumeAsFuture] was called.
   int resumeAsFutureCalls = 0;
 
   /// Queue of results returned by [resolveFutures]. Dequeues on each call.
-  final List<DesktopProgressResult> resolveFuturesResults = [];
+  final List<MontyProgress> resolveFuturesResults = [];
 
   /// Records of results passed to [resolveFutures].
   final List<Map<int, Object?>> resolveFuturesCalls = [];
 
-  /// Queue of results returned by [resolveFuturesWithErrors].
-  final List<DesktopProgressResult> resolveFuturesWithErrorsResults = [];
-
-  /// Records of (results, errors) passed to [resolveFuturesWithErrors].
-  final List<({Map<int, Object?> results, Map<int, String> errors})>
-      resolveFuturesWithErrorsCalls = [];
+  /// Records of errors passed to [resolveFutures], in call order.
+  final List<Map<int, String>?> resolveFuturesErrorsCalls = [];
 
   @override
-  Future<DesktopProgressResult> resumeAsFuture() async {
+  Future<MontyProgress> resumeAsFuture() async {
     resumeAsFutureCalls++;
     if (resumeAsFutureResults.isNotEmpty) {
       return resumeAsFutureResults.removeAt(0);
     }
-    return const DesktopProgressResult(
-      progress: MontyResolveFutures(pendingCallIds: [0]),
-    );
+    return const MontyResolveFutures(pendingCallIds: [0]);
   }
 
   @override
-  Future<DesktopProgressResult> resolveFutures(
-    Map<int, Object?> results,
-  ) async {
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) async {
     resolveFuturesCalls.add(results);
+    resolveFuturesErrorsCalls.add(errors);
     if (resolveFuturesResults.isNotEmpty) {
       return resolveFuturesResults.removeAt(0);
     }
-    return const DesktopProgressResult(
-      progress: MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
-      ),
-    );
-  }
-
-  @override
-  Future<DesktopProgressResult> resolveFuturesWithErrors(
-    Map<int, Object?> results,
-    Map<int, String> errors,
-  ) async {
-    resolveFuturesWithErrorsCalls.add((results: results, errors: errors));
-    if (resolveFuturesWithErrorsResults.isNotEmpty) {
-      return resolveFuturesWithErrorsResults.removeAt(0);
-    }
-    return const DesktopProgressResult(
-      progress: MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
-      ),
+    return const MontyComplete(
+      result: MontyResult(usage: _zeroUsage),
     );
   }
 

--- a/packages/dart_monty_desktop/test/monty_desktop_test.dart
+++ b/packages/dart_monty_desktop/test/monty_desktop_test.dart
@@ -1,6 +1,5 @@
 import 'dart:typed_data';
 
-import 'package:dart_monty_desktop/src/desktop_bindings.dart';
 import 'package:dart_monty_desktop/src/monty_desktop.dart';
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -46,11 +45,9 @@ void main() {
   // ===========================================================================
   group('run()', () {
     test('returns result', () async {
-      mock.nextRunResult = DesktopRunResult(
-        result: MontyResult(
-          value: 4,
-          usage: _usage(memory: 100, time: 5, stack: 2),
-        ),
+      mock.nextRunResult = MontyResult(
+        value: 4,
+        usage: _usage(memory: 100, time: 5, stack: 2),
       );
 
       final result = await monty.run('2 + 2');
@@ -118,18 +115,15 @@ void main() {
     });
 
     test('throws StateError when active', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'fetch', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'fetch', arguments: []);
       await monty.start('x', externalFunctions: ['fetch']);
 
       expect(() => monty.run('y'), throwsStateError);
     });
 
     test('returns null value', () async {
-      mock.nextRunResult = const DesktopRunResult(
-        result: MontyResult(usage: _zeroUsage),
-      );
+      mock.nextRunResult = const MontyResult(usage: _zeroUsage);
 
       final result = await monty.run('None');
       expect(result.value, isNull);
@@ -137,9 +131,7 @@ void main() {
     });
 
     test('returns string value', () async {
-      mock.nextRunResult = const DesktopRunResult(
-        result: MontyResult(value: 'hello', usage: _zeroUsage),
-      );
+      mock.nextRunResult = const MontyResult(value: 'hello', usage: _zeroUsage);
 
       final result = await monty.run('"hello"');
       expect(result.value, 'hello');
@@ -151,10 +143,8 @@ void main() {
   // ===========================================================================
   group('start()', () {
     test('returns MontyComplete when code completes immediately', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyComplete(
-          result: MontyResult(value: 42, usage: _zeroUsage),
-        ),
+      mock.nextStartResult = const MontyComplete(
+        result: MontyResult(value: 42, usage: _zeroUsage),
       );
 
       final progress = await monty.start('42');
@@ -165,11 +155,9 @@ void main() {
     });
 
     test('returns MontyPending for external function call', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(
-          functionName: 'fetch',
-          arguments: ['https://example.com'],
-        ),
+      mock.nextStartResult = const MontyPending(
+        functionName: 'fetch',
+        arguments: ['https://example.com'],
       );
 
       final progress = await monty.start(
@@ -185,9 +173,8 @@ void main() {
     });
 
     test('passes multiple external functions', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'a', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'a', arguments: []);
 
       await monty.start('a()', externalFunctions: ['a', 'b', 'c']);
 
@@ -195,10 +182,8 @@ void main() {
     });
 
     test('passes null externalFunctions when empty list', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyComplete(
-          result: MontyResult(usage: _zeroUsage),
-        ),
+      mock.nextStartResult = const MontyComplete(
+        result: MontyResult(usage: _zeroUsage),
       );
 
       await monty.start('x', externalFunctions: []);
@@ -207,10 +192,8 @@ void main() {
     });
 
     test('passes null externalFunctions when null', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyComplete(
-          result: MontyResult(usage: _zeroUsage),
-        ),
+      mock.nextStartResult = const MontyComplete(
+        result: MontyResult(usage: _zeroUsage),
       );
 
       await monty.start('x');
@@ -231,19 +214,16 @@ void main() {
     });
 
     test('throws StateError when active', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'f', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'f', arguments: []);
       await monty.start('x', externalFunctions: ['f']);
 
       expect(() => monty.start('y'), throwsStateError);
     });
 
     test('applies limits', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyComplete(
-          result: MontyResult(usage: _zeroUsage),
-        ),
+      mock.nextStartResult = const MontyComplete(
+        result: MontyResult(usage: _zeroUsage),
       );
       const limits = MontyLimits(memoryBytes: 512);
 
@@ -258,18 +238,15 @@ void main() {
   // ===========================================================================
   group('resume()', () {
     setUp(() async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'fetch', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'fetch', arguments: []);
       await monty.start('x', externalFunctions: ['fetch']);
     });
 
     test('returns MontyComplete when execution finishes', () async {
       mock.resumeResults.add(
-        const DesktopProgressResult(
-          progress: MontyComplete(
-            result: MontyResult(value: 'hello', usage: _zeroUsage),
-          ),
+        const MontyComplete(
+          result: MontyResult(value: 'hello', usage: _zeroUsage),
         ),
       );
 
@@ -282,9 +259,7 @@ void main() {
 
     test('returns MontyPending for another external call', () async {
       mock.resumeResults.add(
-        const DesktopProgressResult(
-          progress: MontyPending(functionName: 'save', arguments: ['data']),
-        ),
+        const MontyPending(functionName: 'save', arguments: ['data']),
       );
 
       final progress = await monty.resume('response');
@@ -297,10 +272,8 @@ void main() {
 
     test('throws StateError when idle', () async {
       mock.resumeResults.add(
-        const DesktopProgressResult(
-          progress: MontyComplete(
-            result: MontyResult(usage: _zeroUsage),
-          ),
+        const MontyComplete(
+          result: MontyResult(usage: _zeroUsage),
         ),
       );
       await monty.resume(null);
@@ -315,10 +288,8 @@ void main() {
 
     test('passes complex return values', () async {
       mock.resumeResults.add(
-        const DesktopProgressResult(
-          progress: MontyComplete(
-            result: MontyResult(usage: _zeroUsage),
-          ),
+        const MontyComplete(
+          result: MontyResult(usage: _zeroUsage),
         ),
       );
 
@@ -337,18 +308,15 @@ void main() {
   // ===========================================================================
   group('resumeWithError()', () {
     setUp(() async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'fetch', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'fetch', arguments: []);
       await monty.start('x', externalFunctions: ['fetch']);
     });
 
     test('returns MontyComplete after error injection', () async {
       mock.resumeWithErrorResults.add(
-        const DesktopProgressResult(
-          progress: MontyComplete(
-            result: MontyResult(usage: _zeroUsage),
-          ),
+        const MontyComplete(
+          result: MontyResult(usage: _zeroUsage),
         ),
       );
 
@@ -361,9 +329,7 @@ void main() {
 
     test('returns MontyPending for continuation', () async {
       mock.resumeWithErrorResults.add(
-        const DesktopProgressResult(
-          progress: MontyPending(functionName: 'retry', arguments: []),
-        ),
+        const MontyPending(functionName: 'retry', arguments: []),
       );
 
       final progress = await monty.resumeWithError('timeout');
@@ -395,17 +361,14 @@ void main() {
   // ===========================================================================
   group('resumeAsFuture()', () {
     setUp(() async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'fetch', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'fetch', arguments: []);
       await monty.start('x', externalFunctions: ['fetch']);
     });
 
     test('returns MontyResolveFutures', () async {
       mock.resumeAsFutureResults.add(
-        const DesktopProgressResult(
-          progress: MontyResolveFutures(pendingCallIds: [0]),
-        ),
+        const MontyResolveFutures(pendingCallIds: [0]),
       );
 
       final progress = await monty.resumeAsFuture();
@@ -432,24 +395,19 @@ void main() {
   // ===========================================================================
   group('resolveFutures()', () {
     setUp(() async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'fetch', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'fetch', arguments: []);
       await monty.start('x', externalFunctions: ['fetch']);
       mock.resumeAsFutureResults.add(
-        const DesktopProgressResult(
-          progress: MontyResolveFutures(pendingCallIds: [0]),
-        ),
+        const MontyResolveFutures(pendingCallIds: [0]),
       );
       await monty.resumeAsFuture();
     });
 
     test('returns MontyComplete after resolving', () async {
       mock.resolveFuturesResults.add(
-        const DesktopProgressResult(
-          progress: MontyComplete(
-            result: MontyResult(value: 'done', usage: _zeroUsage),
-          ),
+        const MontyComplete(
+          result: MontyResult(value: 'done', usage: _zeroUsage),
         ),
       );
 
@@ -472,49 +430,42 @@ void main() {
   });
 
   // ===========================================================================
-  // resolveFuturesWithErrors()
+  // resolveFutures() with errors
   // ===========================================================================
-  group('resolveFuturesWithErrors()', () {
+  group('resolveFutures() with errors', () {
     setUp(() async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'fetch', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'fetch', arguments: []);
       await monty.start('x', externalFunctions: ['fetch']);
       mock.resumeAsFutureResults.add(
-        const DesktopProgressResult(
-          progress: MontyResolveFutures(pendingCallIds: [0, 1]),
-        ),
+        const MontyResolveFutures(pendingCallIds: [0, 1]),
       );
       await monty.resumeAsFuture();
     });
 
     test('returns MontyComplete after resolving with errors', () async {
-      mock.resolveFuturesWithErrorsResults.add(
-        const DesktopProgressResult(
-          progress: MontyComplete(
-            result: MontyResult(value: 'partial', usage: _zeroUsage),
-          ),
+      mock.resolveFuturesResults.add(
+        const MontyComplete(
+          result: MontyResult(value: 'partial', usage: _zeroUsage),
         ),
       );
 
-      final progress = await monty.resolveFuturesWithErrors(
+      final progress = await monty.resolveFutures(
         {0: 'ok'},
-        {1: 'network error'},
+        errors: {1: 'network error'},
       );
 
       expect(progress, isA<MontyComplete>());
-      expect(mock.resolveFuturesWithErrorsCalls, hasLength(1));
-      expect(mock.resolveFuturesWithErrorsCalls.first.results, {0: 'ok'});
-      expect(
-        mock.resolveFuturesWithErrorsCalls.first.errors,
-        {1: 'network error'},
-      );
+      expect(mock.resolveFuturesCalls, hasLength(1));
+      expect(mock.resolveFuturesCalls.first, {0: 'ok'});
+      expect(mock.resolveFuturesErrorsCalls, hasLength(1));
+      expect(mock.resolveFuturesErrorsCalls.first, {1: 'network error'});
     });
 
     test('throws StateError when idle', () {
       final freshMonty = MontyDesktop(bindings: mock);
       expect(
-        () => freshMonty.resolveFuturesWithErrors({}, {}),
+        () => freshMonty.resolveFutures({}, errors: {}),
         throwsStateError,
       );
     });
@@ -522,7 +473,7 @@ void main() {
     test('throws StateError when disposed', () async {
       await monty.dispose();
       expect(
-        () => monty.resolveFuturesWithErrors({}, {}),
+        () => monty.resolveFutures({}, errors: {}),
         throwsStateError,
       );
     });
@@ -533,9 +484,8 @@ void main() {
   // ===========================================================================
   group('snapshot()', () {
     setUp(() async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'f', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'f', arguments: []);
       await monty.start('x', externalFunctions: ['f']);
     });
 
@@ -582,10 +532,8 @@ void main() {
 
       // resume() should be allowed (active state).
       mock.resumeResults.add(
-        const DesktopProgressResult(
-          progress: MontyComplete(
-            result: MontyResult(value: 10, usage: _zeroUsage),
-          ),
+        const MontyComplete(
+          result: MontyResult(value: 10, usage: _zeroUsage),
         ),
       );
       final progress = await restoredDesktop.resume('val');
@@ -611,9 +559,8 @@ void main() {
     });
 
     test('throws StateError when active', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'f', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'f', arguments: []);
       await monty.start('x', externalFunctions: ['f']);
 
       expect(
@@ -652,9 +599,8 @@ void main() {
   // ===========================================================================
   group('edge cases', () {
     test('pending with empty arguments', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyPending(functionName: 'noop', arguments: []),
-      );
+      mock.nextStartResult =
+          const MontyPending(functionName: 'noop', arguments: []);
 
       final progress = await monty.start(
         'noop()',
@@ -666,10 +612,8 @@ void main() {
     });
 
     test('complete with null value', () async {
-      mock.nextStartResult = const DesktopProgressResult(
-        progress: MontyComplete(
-          result: MontyResult(usage: _zeroUsage),
-        ),
+      mock.nextStartResult = const MontyComplete(
+        result: MontyResult(usage: _zeroUsage),
       );
 
       final progress = await monty.start('None');
@@ -679,11 +623,9 @@ void main() {
     });
 
     test('resource usage is preserved from bindings', () async {
-      mock.nextRunResult = DesktopRunResult(
-        result: MontyResult(
-          value: 1,
-          usage: _usage(memory: 256, time: 10, stack: 3),
-        ),
+      mock.nextRunResult = MontyResult(
+        value: 1,
+        usage: _usage(memory: 256, time: 10, stack: 3),
       );
 
       final result = await monty.run('1');

--- a/packages/dart_monty_ffi/lib/src/monty_ffi.dart
+++ b/packages/dart_monty_ffi/lib/src/monty_ffi.dart
@@ -131,7 +131,10 @@ class MontyFfi extends MontyPlatform with MontyStateMixin {
   }
 
   @override
-  Future<MontyProgress> resolveFutures(Map<int, Object?> results) async {
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) async {
     assertNotDisposed('resolveFutures');
     assertActive('resolveFutures');
     final handle = _handle;
@@ -142,29 +145,11 @@ class MontyFfi extends MontyPlatform with MontyStateMixin {
     final resultsJson = json.encode(
       results.map((k, v) => MapEntry(k.toString(), v)),
     );
-    final progress = _bindings.resolveFutures(handle, resultsJson, '{}');
-
-    return _handleProgress(handle, progress);
-  }
-
-  @override
-  Future<MontyProgress> resolveFuturesWithErrors(
-    Map<int, Object?> results,
-    Map<int, String> errors,
-  ) async {
-    assertNotDisposed('resolveFuturesWithErrors');
-    assertActive('resolveFuturesWithErrors');
-    final handle = _handle;
-    if (handle == null) {
-      throw StateError('Cannot resolveFuturesWithErrors: no active handle');
-    }
-
-    final resultsJson = json.encode(
-      results.map((k, v) => MapEntry(k.toString(), v)),
-    );
-    final errorsJson = json.encode(
-      errors.map((k, v) => MapEntry(k.toString(), v)),
-    );
+    final errorsJson = errors != null
+        ? json.encode(
+            errors.map((k, v) => MapEntry(k.toString(), v)),
+          )
+        : '{}';
     final progress = _bindings.resolveFutures(handle, resultsJson, errorsJson);
 
     return _handleProgress(handle, progress);

--- a/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
+++ b/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
@@ -1,4 +1,5 @@
 import 'dart:ffi';
+import 'dart:io' show Platform;
 import 'dart:typed_data';
 
 import 'package:dart_monty_ffi/src/generated/dart_monty_bindings.dart';
@@ -14,11 +15,15 @@ class NativeBindingsFfi extends NativeBindings {
   /// Creates [NativeBindingsFfi] by opening the native library.
   ///
   /// Pass [libraryPath] to override the default platform resolution.
+  /// On iOS, symbols are statically linked into the main executable, so
+  /// [DynamicLibrary.process] is used instead of [DynamicLibrary.open].
   NativeBindingsFfi({String? libraryPath})
       : _lib = DartMontyBindings(
-          DynamicLibrary.open(
-            NativeLibraryLoader.resolve(overridePath: libraryPath),
-          ),
+          Platform.isIOS
+              ? DynamicLibrary.process()
+              : DynamicLibrary.open(
+                  NativeLibraryLoader.resolve(overridePath: libraryPath),
+                ),
         );
 
   final DartMontyBindings _lib;

--- a/packages/dart_monty_ffi/test/monty_ffi_test.dart
+++ b/packages/dart_monty_ffi/test/monty_ffi_test.dart
@@ -963,7 +963,7 @@ void main() {
     });
   });
 
-  group('resolveFuturesWithErrors()', () {
+  group('resolveFutures() with errors', () {
     test('passes results and errors to bindings', () async {
       mock.nextStartResult = const ProgressResult(
         tag: 1,
@@ -977,7 +977,7 @@ void main() {
       );
       await monty.resumeAsFuture();
 
-      await monty.resolveFuturesWithErrors({0: 'ok'}, {1: 'timeout'});
+      await monty.resolveFutures({0: 'ok'}, errors: {1: 'timeout'});
 
       expect(mock.resolveFuturesCalls, hasLength(1));
       final call = mock.resolveFuturesCalls.first;
@@ -987,7 +987,7 @@ void main() {
 
     test('throws StateError when idle', () {
       expect(
-        () => monty.resolveFuturesWithErrors({}, {}),
+        () => monty.resolveFutures({}, errors: {}),
         throwsStateError,
       );
     });

--- a/packages/dart_monty_platform_interface/lib/src/mock_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/mock_monty_platform.dart
@@ -91,11 +91,8 @@ class MockMontyPlatform extends MontyPlatform {
   /// Results passed to [resolveFutures], in call order.
   final List<Map<int, Object?>> resolveFuturesResultsList = [];
 
-  /// Results passed to [resolveFuturesWithErrors], in call order.
-  final List<Map<int, Object?>> resolveFuturesWithErrorsResultsList = [];
-
-  /// Errors passed to [resolveFuturesWithErrors], in call order.
-  final List<Map<int, String>> resolveFuturesWithErrorsErrorsList = [];
+  /// Errors passed to [resolveFutures], in call order.
+  final List<Map<int, String>?> resolveFuturesErrorsList = [];
 
   /// Snapshot data passed to [restore], in call order.
   final List<Uint8List> restoreDataList = [];
@@ -154,25 +151,17 @@ class MockMontyPlatform extends MontyPlatform {
   Map<int, Object?>? get lastResolveFuturesResults =>
       resolveFuturesResultsList.isEmpty ? null : resolveFuturesResultsList.last;
 
-  /// The results passed to the most recent [resolveFuturesWithErrors] call.
-  Map<int, Object?>? get lastResolveFuturesWithErrorsResults =>
-      resolveFuturesWithErrorsResultsList.isEmpty
-          ? null
-          : resolveFuturesWithErrorsResultsList.last;
-
-  /// The errors passed to the most recent [resolveFuturesWithErrors] call.
-  Map<int, String>? get lastResolveFuturesWithErrorsErrors =>
-      resolveFuturesWithErrorsErrorsList.isEmpty
-          ? null
-          : resolveFuturesWithErrorsErrorsList.last;
+  /// The errors passed to the most recent [resolveFutures] call.
+  Map<int, String>? get lastResolveFuturesErrors =>
+      resolveFuturesErrorsList.isEmpty ? null : resolveFuturesErrorsList.last;
 
   /// The snapshot data passed to the most recent [restore] call.
   Uint8List? get lastRestoreData =>
       restoreDataList.isEmpty ? null : restoreDataList.last;
 
   /// Adds a [MontyProgress] to the FIFO queue consumed by [start],
-  /// [resume], [resumeWithError], [resumeAsFuture], [resolveFutures],
-  /// and [resolveFuturesWithErrors].
+  /// [resume], [resumeWithError], [resumeAsFuture], and
+  /// [resolveFutures].
   void enqueueProgress(MontyProgress progress) {
     _progressQueue.add(progress);
   }
@@ -237,19 +226,12 @@ class MockMontyPlatform extends MontyPlatform {
   }
 
   @override
-  Future<MontyProgress> resolveFutures(Map<int, Object?> results) async {
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) async {
     resolveFuturesResultsList.add(results);
-
-    return _dequeueProgress();
-  }
-
-  @override
-  Future<MontyProgress> resolveFuturesWithErrors(
-    Map<int, Object?> results,
-    Map<int, String> errors,
-  ) async {
-    resolveFuturesWithErrorsResultsList.add(results);
-    resolveFuturesWithErrorsErrorsList.add(errors);
+    resolveFuturesErrorsList.add(errors);
 
     return _dequeueProgress();
   }
@@ -290,7 +272,7 @@ class MockMontyPlatform extends MontyPlatform {
       throw StateError(
         'No progress enqueued. Call enqueueProgress() before '
         'start(), resume(), resumeWithError(), resumeAsFuture(), '
-        'resolveFutures(), or resolveFuturesWithErrors().',
+        'or resolveFutures().',
       );
     }
 

--- a/packages/dart_monty_platform_interface/lib/src/monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_platform.dart
@@ -115,26 +115,19 @@ abstract class MontyPlatform extends PlatformInterface {
     throw UnimplementedError('resumeAsFuture() has not been implemented.');
   }
 
-  /// Resolves pending futures with their results.
+  /// Resolves pending futures with their results, and optionally errors.
   ///
   /// [results] maps call IDs to their resolved values. All pending call IDs
-  /// from [MontyResolveFutures.pendingCallIds] should be present.
-  Future<MontyProgress> resolveFutures(Map<int, Object?> results) {
-    throw UnimplementedError('resolveFutures() has not been implemented.');
-  }
-
-  /// Resolves pending futures with a mix of results and errors.
+  /// from [MontyResolveFutures.pendingCallIds] should be present in either
+  /// [results] or [errors].
   ///
-  /// [results] maps call IDs to their resolved values.
-  /// [errors] maps call IDs to error message strings (raises RuntimeError
-  /// in Python).
-  Future<MontyProgress> resolveFuturesWithErrors(
-    Map<int, Object?> results,
-    Map<int, String> errors,
-  ) {
-    throw UnimplementedError(
-      'resolveFuturesWithErrors() has not been implemented.',
-    );
+  /// [errors] optionally maps call IDs to error message strings (raises
+  /// RuntimeError in Python for each).
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) {
+    throw UnimplementedError('resolveFutures() has not been implemented.');
   }
 
   /// Captures the current interpreter state as a binary snapshot.

--- a/packages/dart_monty_platform_interface/lib/src/monty_progress.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_progress.dart
@@ -198,7 +198,7 @@ final class MontyPending extends MontyProgress {
 /// `await` expression, then yields this progress with the list of
 /// [pendingCallIds] that need resolution.
 ///
-/// Resolve futures using `resolveFutures()` or `resolveFuturesWithErrors()`:
+/// Resolve futures using `resolveFutures()`:
 /// ```dart
 /// case MontyResolveFutures(:final pendingCallIds):
 ///   final results = await Future.wait(

--- a/packages/dart_monty_platform_interface/lib/src/testing/ladder_runner.dart
+++ b/packages/dart_monty_platform_interface/lib/src/testing/ladder_runner.dart
@@ -108,11 +108,10 @@ Future<void> runIterativeFixture(
               results[id] = asyncResumeMap[key];
             }
           }
-          if (errors.isNotEmpty) {
-            progress = await platform.resolveFuturesWithErrors(results, errors);
-          } else {
-            progress = await platform.resolveFutures(results);
-          }
+          progress = await platform.resolveFutures(
+            results,
+            errors: errors.isNotEmpty ? errors : null,
+          );
         } else {
           fail('Unexpected progress type: $progress');
         }

--- a/packages/dart_monty_platform_interface/test/monty_platform_test.dart
+++ b/packages/dart_monty_platform_interface/test/monty_platform_test.dart
@@ -111,9 +111,9 @@ void main() {
         );
       });
 
-      test('resolveFuturesWithErrors() throws', () {
+      test('resolveFutures() with errors throws', () {
         expect(
-          () => platform.resolveFuturesWithErrors({0: 'x'}, {1: 'err'}),
+          () => platform.resolveFutures({0: 'x'}, errors: {1: 'err'}),
           throwsUnimplementedError,
         );
       });

--- a/packages/dart_monty_wasm/test/monty_wasm_test.dart
+++ b/packages/dart_monty_wasm/test/monty_wasm_test.dart
@@ -55,7 +55,7 @@ void main() {
       expect(result.value, 4);
       expect(result.isError, isFalse);
       expect(result.usage.memoryBytesUsed, 0);
-      expect(result.usage.timeElapsedMs, 0);
+      expect(result.usage.timeElapsedMs, greaterThanOrEqualTo(0));
       expect(result.usage.stackDepthUsed, 0);
       expect(mock.runCalls, hasLength(1));
       expect(mock.runCalls.first.code, '2 + 2');
@@ -702,13 +702,13 @@ void main() {
       expect(complete.result.value, isNull);
     });
 
-    test('synthetic resource usage is all zeros', () async {
+    test('resource usage has Dart-side wall-clock timing', () async {
       mock.nextRunResult = const WasmRunResult(ok: true, value: 1);
 
       final result = await monty.run('1');
 
       expect(result.usage.memoryBytesUsed, 0);
-      expect(result.usage.timeElapsedMs, 0);
+      expect(result.usage.timeElapsedMs, greaterThanOrEqualTo(0));
       expect(result.usage.stackDepthUsed, 0);
     });
 
@@ -901,9 +901,9 @@ void main() {
       );
     });
 
-    test('resolveFuturesWithErrors() throws UnsupportedError', () {
+    test('resolveFutures() with errors throws UnsupportedError', () {
       expect(
-        () => monty.resolveFuturesWithErrors({0: 'value'}, {1: 'err'}),
+        () => monty.resolveFutures({0: 'value'}, errors: {1: 'err'}),
         throwsA(isA<UnsupportedError>()),
       );
     });


### PR DESCRIPTION
## Summary
- Merge `resolveFutures`/`resolveFuturesWithErrors` into single method with optional `errors` parameter across all 6 packages
- Remove `DesktopRunResult`/`DesktopProgressResult` trivial wrappers; return domain types directly from `DesktopBindings`
- Add iOS library loading prep (`DynamicLibrary.process()` for static linking)
- Replace WASM synthetic zero timing with Dart-side `Stopwatch` measurements
- Extract `postProgress`/`postError` helpers in `worker_src.js` (~90 lines deduplication)
- Add `_failAllPending` integration test for isolate dispose-while-pending
- Fill 3 architecture doc sections: native execution path, cross-language memory contracts, error surface and recovery semantics

## Changes
- **platform_interface**: Collapse two `resolveFutures*` methods into one; update mock, ladder runner, tests
- **dart_monty_ffi**: Merge `resolveFutures` impl; add `Platform.isIOS` library loading branch
- **dart_monty_desktop**: Remove wrapper classes, merge API, add integration test
- **dart_monty_wasm**: Add `Stopwatch` timing, extract JS worker helpers, rebuild bundle
- **dart_monty_web**: Merge `resolveFutures` override
- **docs/architecture.md**: Fill Execution Paths — Native, Cross-Language Memory Contracts, Error Surface and Recovery Semantics

## Test plan
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart analyze --fatal-infos` per package — zero issues
- [x] platform_interface: 243 tests pass
- [x] dart_monty_ffi: 72 tests pass
- [x] dart_monty_wasm: 71 tests pass
- [x] dart_monty_desktop: 57 tests pass
- [x] WASM worker bundle rebuilt
- [x] Gemini 3.1-pro slice review: PASS (all 6 criteria)