### PR TITLE
feat(web-showcase): Python in the browser via Dart WASM bridge

### DIFF
--- a/example/web-showcase/analysis_options.yaml
+++ b/example/web-showcase/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/example/web-showcase/bin/showcase.dart
+++ b/example/web-showcase/bin/showcase.dart
@@ -25,6 +25,12 @@ external JSPromise<JSString> _bridgeStart(
   JSString? extFnsJson,
 ]);
 
+@JS('DartMontyBridge.snapshot')
+external JSPromise<JSString> _bridgeSnapshot();
+
+@JS('DartMontyBridge.restore')
+external JSPromise<JSString> _bridgeRestore(JSString dataBase64);
+
 @JS('DartMontyBridge.resume')
 external JSPromise<JSString> _bridgeResume(JSString valueJson);
 
@@ -100,6 +106,10 @@ const List<String> _hostFunctions = [
   'log',
   'alert',
   'now',
+  'interpreter_snapshot',
+  'interpreter_restore',
+  'download_file',
+  'upload_file',
 ];
 
 // ── Host function dispatch ─────────────────────────────────────────────────
@@ -235,6 +245,64 @@ Future<Object?> _dispatch(String fnName, List<dynamic> args) async {
 
     case 'now':
       return DateTime.now().toIso8601String();
+
+    case 'interpreter_snapshot':
+      final result = _parse(
+        (await _bridgeSnapshot().toDart).toDart,
+      );
+      if (result['ok'] == true) {
+        return result['data'] as String;
+      }
+      return 'Error: ${result['error']}';
+
+    case 'interpreter_restore':
+      final data = args[0] as String;
+      final result = _parse(
+        (await _bridgeRestore(data.toJS).toDart).toDart,
+      );
+      if (result['ok'] == true) return 'restored';
+      return 'Error: ${result['error']}';
+
+    case 'download_file':
+      final filename = args[0] as String;
+      final content = args[1] as String;
+      final anchor = document.createElement('a') as HTMLAnchorElement;
+      anchor.href =
+          'data:application/octet-stream;base64,${Uri.encodeComponent(content)}';
+      anchor.download = filename;
+      anchor.click();
+      return null;
+
+    case 'upload_file':
+      final input = document.createElement('input') as HTMLInputElement;
+      input.type = 'file';
+      final completer = Completer<String?>();
+      input.addEventListener(
+        'change',
+        (Event e) {
+          final files = input.files;
+          if (files == null || files.length == 0) {
+            completer.complete(null);
+            return;
+          }
+          final file = files.item(0)!;
+          final reader = FileReader();
+          reader.addEventListener(
+            'load',
+            (Event ev) {
+              final dataUrl = (reader.result as JSString?)?.toDart ?? '';
+              // Strip data URL prefix to get base64
+              final b64 = dataUrl.contains(',')
+                  ? dataUrl.substring(dataUrl.indexOf(',') + 1)
+                  : dataUrl;
+              completer.complete(b64);
+            }.toJS,
+          );
+          reader.readAsDataURL(file);
+        }.toJS,
+      );
+      input.click();
+      return await completer.future;
 
     default:
       return 'Unknown host function: $fnName';
@@ -674,6 +742,191 @@ dom_text(status, f"Saved {saved_count} fields to localStorage! Refresh and INVOK
 dom_style(status, "color", "#00d4ff")
 log(f"Done. {saved_count} fields persisted.")
 ''',
+  'snapshot': '''
+app = dom_query("#sandbox")
+
+title = dom_create("h2")
+dom_text(title, "Interpreter Snapshot Demo")
+dom_style(title, "color", "#dcdcaa")
+dom_style(title, "margin-bottom", "8px")
+dom_append(app, title)
+
+desc = dom_create("p")
+dom_text(desc, "This demo defines variables, snapshots the interpreter state, downloads it as a file, then lets you upload a snapshot to restore it.")
+dom_style(desc, "color", "#666")
+dom_style(desc, "font-size", "12px")
+dom_style(desc, "margin-bottom", "16px")
+dom_append(app, desc)
+
+# Step 1: Define some state
+x = 42
+y = "hello from the snapshot"
+nums = [1, 2, 3, 4, 5]
+total = sum(nums)
+
+status = dom_create("pre")
+dom_style(status, "background", "#141420")
+dom_style(status, "padding", "12px")
+dom_style(status, "border-radius", "4px")
+dom_style(status, "color", "#569cd6")
+dom_style(status, "font-size", "12px")
+dom_style(status, "white-space", "pre-wrap")
+dom_append(app, status)
+
+dom_text(status, f"Variables defined:\\n  x = {x}\\n  y = \\"{y}\\"\\n  nums = {nums}\\n  total = {total}")
+log(f"Defined: x={x}, y={y}, nums={nums}, total={total}")
+
+# Step 2: Snapshot button
+snap_btn = dom_create("button")
+dom_text(snap_btn, "SNAPSHOT + DOWNLOAD")
+dom_style(snap_btn, "display", "inline-block")
+dom_style(snap_btn, "margin-top", "16px")
+dom_style(snap_btn, "margin-right", "8px")
+dom_style(snap_btn, "padding", "10px 20px")
+dom_style(snap_btn, "background", "#00d4ff")
+dom_style(snap_btn, "color", "#0a0a0f")
+dom_style(snap_btn, "border", "none")
+dom_style(snap_btn, "border-radius", "4px")
+dom_style(snap_btn, "font-family", "monospace")
+dom_style(snap_btn, "font-size", "13px")
+dom_style(snap_btn, "font-weight", "bold")
+dom_style(snap_btn, "cursor", "pointer")
+dom_append(app, snap_btn)
+
+# Step 3: Upload + Restore button
+restore_btn = dom_create("button")
+dom_text(restore_btn, "UPLOAD + RESTORE")
+dom_style(restore_btn, "display", "inline-block")
+dom_style(restore_btn, "margin-top", "16px")
+dom_style(restore_btn, "padding", "10px 20px")
+dom_style(restore_btn, "background", "#dcdcaa")
+dom_style(restore_btn, "color", "#0a0a0f")
+dom_style(restore_btn, "border", "none")
+dom_style(restore_btn, "border-radius", "4px")
+dom_style(restore_btn, "font-family", "monospace")
+dom_style(restore_btn, "font-size", "13px")
+dom_style(restore_btn, "font-weight", "bold")
+dom_style(restore_btn, "cursor", "pointer")
+dom_append(app, restore_btn)
+
+result_div = dom_create("pre")
+dom_style(result_div, "background", "#141420")
+dom_style(result_div, "padding", "12px")
+dom_style(result_div, "border-radius", "4px")
+dom_style(result_div, "color", "#888")
+dom_style(result_div, "font-size", "12px")
+dom_style(result_div, "margin-top", "12px")
+dom_style(result_div, "white-space", "pre-wrap")
+dom_text(result_div, "Click Snapshot to capture state, or Upload to restore from file.")
+dom_append(app, result_div)
+
+log("Ready. Click Snapshot or Upload.")
+
+# Wait for snapshot button
+dom_on_click(snap_btn)
+
+# Take snapshot
+log("Taking snapshot...")
+snapshot_data = interpreter_snapshot()
+
+if snapshot_data and not snapshot_data.startswith("Error"):
+    size = len(snapshot_data)
+    dom_text(result_div, f"Snapshot captured!\\n  Size: {size} bytes (base64)\\n  Downloading as monty_snapshot.b64...\\nYou can upload this file later to restore the interpreter state.")
+    log(f"Snapshot: {size} bytes base64")
+
+    # Store in localStorage too
+    storage_set("monty_snapshot", snapshot_data)
+    log("Snapshot also saved to localStorage.")
+
+    # Download it
+    download_file("monty_snapshot.b64", snapshot_data)
+    log("Download triggered.")
+
+    dom_style(result_div, "color", "#00d4ff")
+else:
+    dom_text(result_div, f"Snapshot failed: {snapshot_data}")
+    dom_style(result_div, "color", "#f44747")
+    log(f"Snapshot error: {snapshot_data}")
+''',
+  'restore': '''
+app = dom_query("#sandbox")
+
+title = dom_create("h2")
+dom_text(title, "Restore Interpreter State")
+dom_style(title, "color", "#dcdcaa")
+dom_style(title, "margin-bottom", "8px")
+dom_append(app, title)
+
+desc = dom_create("p")
+dom_text(desc, "Upload a .b64 snapshot file, or restore from localStorage if a snapshot was saved.")
+dom_style(desc, "color", "#666")
+dom_style(desc, "font-size", "12px")
+dom_style(desc, "margin-bottom", "16px")
+dom_append(app, desc)
+
+result_div = dom_create("pre")
+dom_style(result_div, "background", "#141420")
+dom_style(result_div, "padding", "12px")
+dom_style(result_div, "border-radius", "4px")
+dom_style(result_div, "color", "#888")
+dom_style(result_div, "font-size", "12px")
+dom_style(result_div, "white-space", "pre-wrap")
+dom_append(app, result_div)
+
+# Try localStorage first
+saved = storage_get("monty_snapshot")
+if saved:
+    dom_text(result_div, f"Found snapshot in localStorage ({len(saved)} bytes base64).\\nRestoring...")
+    log(f"Found snapshot in localStorage: {len(saved)} bytes")
+
+    result = interpreter_restore(saved)
+    if result == "restored":
+        dom_text(result_div, f"Interpreter restored from localStorage!\\n\\nThe interpreter is now in the state it was when snapshot was taken.\\nVariables, stack, everything -- restored from binary data.")
+        dom_style(result_div, "color", "#00d4ff")
+        log("Restore successful!")
+    else:
+        dom_text(result_div, f"Restore failed: {result}")
+        dom_style(result_div, "color", "#f44747")
+        log(f"Restore error: {result}")
+else:
+    # Upload flow
+    upload_btn = dom_create("button")
+    dom_text(upload_btn, "UPLOAD SNAPSHOT FILE")
+    dom_style(upload_btn, "display", "block")
+    dom_style(upload_btn, "margin-bottom", "12px")
+    dom_style(upload_btn, "padding", "10px 20px")
+    dom_style(upload_btn, "background", "#dcdcaa")
+    dom_style(upload_btn, "color", "#0a0a0f")
+    dom_style(upload_btn, "border", "none")
+    dom_style(upload_btn, "border-radius", "4px")
+    dom_style(upload_btn, "font-family", "monospace")
+    dom_style(upload_btn, "font-size", "13px")
+    dom_style(upload_btn, "font-weight", "bold")
+    dom_style(upload_btn, "cursor", "pointer")
+    dom_append(app, upload_btn)
+
+    dom_text(result_div, "No snapshot in localStorage. Click to upload a .b64 file.")
+    log("No snapshot in localStorage. Upload one.")
+
+    dom_on_click(upload_btn)
+
+    file_data = upload_file()
+    if file_data:
+        dom_text(result_div, f"File loaded ({len(file_data)} bytes). Restoring...")
+        log(f"Uploaded: {len(file_data)} bytes")
+
+        result = interpreter_restore(file_data)
+        if result == "restored":
+            dom_text(result_div, "Interpreter restored from uploaded file!\\n\\nThe interpreter is now in the state when the snapshot was taken.")
+            dom_style(result_div, "color", "#00d4ff")
+            log("Restore successful!")
+        else:
+            dom_text(result_div, f"Restore failed: {result}")
+            dom_style(result_div, "color", "#f44747")
+    else:
+        dom_text(result_div, "No file selected.")
+        log("Upload cancelled.")
+''',
 };
 
 // ── UI wiring ──────────────────────────────────────────────────────────────
@@ -690,6 +943,8 @@ void _populateDemoSelector() {
     'counter': 'Persistent Pilgrimage Counter',
     'dashboard': 'Dart Evangelism Dashboard',
     'form': 'Stateful Form (localStorage)',
+    'snapshot': 'Snapshot + Download State',
+    'restore': 'Upload + Restore State',
   };
 
   for (final entry in _demos.entries) {

--- a/example/web-showcase/bin/showcase.dart
+++ b/example/web-showcase/bin/showcase.dart
@@ -8,6 +8,7 @@
 ///   storage_get, storage_set, log, alert, now
 library;
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:js_interop';
 
@@ -91,6 +92,7 @@ const List<String> _hostFunctions = [
   'dom_remove',
   'dom_set_value',
   'dom_get_value',
+  'dom_on_click',
   'fetch_text',
   'fetch_json',
   'storage_get',
@@ -186,6 +188,19 @@ Future<Object?> _dispatch(String fnName, List<dynamic> args) async {
         return (gvEl as HTMLSelectElement).value;
       }
       return null;
+
+    case 'dom_on_click':
+      final h = args[0] as int;
+      final el = _get(h);
+      if (el == null) return null;
+      final completer = Completer<String>();
+      el.addEventListener(
+        'click',
+        (Event e) {
+          if (!completer.isCompleted) completer.complete('clicked');
+        }.toJS,
+      );
+      return await completer.future;
 
     case 'fetch_text':
       final url = args[0] as String;
@@ -573,7 +588,7 @@ dom_style(title, "margin-bottom", "12px")
 dom_append(app, title)
 
 subtitle = dom_create("p")
-dom_text(subtitle, "Your answers are saved to localStorage. Refresh the page and run again -- they persist.")
+dom_text(subtitle, "Fill in the form, click Save. Refresh the page and INVOKE again -- your answers persist.")
 dom_style(subtitle, "color", "#666")
 dom_style(subtitle, "font-size", "12px")
 dom_style(subtitle, "margin-bottom", "16px")
@@ -587,7 +602,6 @@ fields = [
 ]
 
 for key, label_text, field_type in fields:
-    # Label
     lbl = dom_create("label")
     dom_text(lbl, label_text)
     dom_style(lbl, "display", "block")
@@ -597,7 +611,6 @@ for key, label_text, field_type in fields:
     dom_style(lbl, "margin-top", "12px")
     dom_append(app, lbl)
 
-    # Field
     field = dom_create(field_type)
     dom_style(field, "width", "100%")
     dom_style(field, "padding", "8px")
@@ -611,93 +624,55 @@ for key, label_text, field_type in fields:
         dom_attr(field, "rows", "3")
     dom_append(app, field)
 
-    # Restore saved value
     saved = storage_get(key)
     if saved:
         dom_set_value(field, saved)
         log(f"Restored {key}: {saved}")
 
-    # Store handle for save button
     dom_attr(field, "data-key", key)
 
-# Summary section
-summary_title = dom_create("h3")
-dom_text(summary_title, "Saved State:")
-dom_style(summary_title, "color", "#dcdcaa")
-dom_style(summary_title, "margin-top", "20px")
-dom_style(summary_title, "margin-bottom", "8px")
-dom_append(app, summary_title)
+# Save button
+btn = dom_create("button")
+dom_text(btn, "SAVE TO LOCALSTORAGE")
+dom_style(btn, "display", "block")
+dom_style(btn, "margin-top", "20px")
+dom_style(btn, "padding", "10px 24px")
+dom_style(btn, "background", "#00d4ff")
+dom_style(btn, "color", "#0a0a0f")
+dom_style(btn, "border", "none")
+dom_style(btn, "border-radius", "4px")
+dom_style(btn, "font-family", "monospace")
+dom_style(btn, "font-size", "14px")
+dom_style(btn, "font-weight", "bold")
+dom_style(btn, "cursor", "pointer")
+dom_append(app, btn)
 
-summary = dom_create("pre")
-dom_style(summary, "background", "#141420")
-dom_style(summary, "padding", "12px")
-dom_style(summary, "border-radius", "4px")
-dom_style(summary, "color", "#888")
-dom_style(summary, "font-size", "12px")
-dom_append(app, summary)
+status = dom_create("p")
+dom_style(status, "color", "#888")
+dom_style(status, "font-size", "12px")
+dom_style(status, "margin-top", "8px")
+dom_text(status, "Fill in the form, then click Save.")
+dom_append(app, status)
 
-# Show all saved state
-lines = []
+log("Form ready. Fill in fields and click Save.")
+
+# Wait for click
+dom_on_click(btn)
+
+# Save all fields
+saved_count = 0
 for key, label_text, field_type in fields:
-    val = storage_get(key)
-    if val:
-        lines.append(f"  {key} = {val}")
-    else:
-        lines.append(f"  {key} = (empty)")
-
-if lines:
-    dom_text(summary, "localStorage contents:\\n" + "\\n".join(lines))
-else:
-    dom_text(summary, "No saved state yet. Fill in the form and run the Save demo.")
-
-note = dom_create("p")
-dom_text(note, "Edit the fields above, then run the Save demo to persist.")
-dom_style(note, "color", "#555")
-dom_style(note, "font-size", "11px")
-dom_style(note, "margin-top", "8px")
-dom_append(app, note)
-
-log("Form rendered. Existing state restored from localStorage.")
-''',
-  'form_save': '''
-app = dom_query("#sandbox")
-
-# Read all input/textarea values by querying them
-fields = [
-    "dart_form_name",
-    "dart_form_language",
-    "dart_form_testimony",
-    "dart_form_slack_level",
-]
-
-saved = 0
-for key in fields:
-    # Find the element with data-key attribute
     el = dom_query(f"[data-key=\\"{key}\\"]")
     if el:
         val = dom_get_value(el)
         if val:
             storage_set(key, val)
             log(f"Saved {key} = {val}")
-            saved += 1
-        else:
-            log(f"Skipped {key} (empty)")
-    else:
-        log(f"Field not found: {key}")
+            saved_count += 1
 
-title = dom_create("h2")
-dom_style(title, "color", "#00d4ff")
-dom_style(title, "text-align", "center")
-dom_style(title, "margin-top", "20px")
-
-if saved > 0:
-    dom_text(title, f"Saved {saved} fields to localStorage!")
-    log(f"\\nDone. {saved} fields persisted. Refresh the page and run Form again to see them restored.")
-else:
-    dom_text(title, "Nothing to save. Run the Form demo first.")
-    log("No fields found. Run the Form demo first to create the form.")
-
-dom_append(app, title)
+dom_text(status, f"Saved {saved_count} fields to localStorage! Refresh and INVOKE to see them restored.")
+dom_style(status, "color", "#00d4ff")
+log(f"Done. {saved_count} fields persisted.")
 ''',
 };
 
@@ -715,7 +690,6 @@ void _populateDemoSelector() {
     'counter': 'Persistent Pilgrimage Counter',
     'dashboard': 'Dart Evangelism Dashboard',
     'form': 'Stateful Form (localStorage)',
-    'form_save': 'Save Form State',
   };
 
   for (final entry in _demos.entries) {

--- a/example/web-showcase/bin/showcase.dart
+++ b/example/web-showcase/bin/showcase.dart
@@ -82,12 +82,15 @@ void _clearSandbox() {
 const List<String> _hostFunctions = [
   'dom_create',
   'dom_text',
+  'dom_get_text',
   'dom_append',
   'dom_query',
   'dom_style',
   'dom_attr',
   'dom_html',
   'dom_remove',
+  'dom_set_value',
+  'dom_get_value',
   'fetch_text',
   'fetch_json',
   'storage_get',
@@ -111,6 +114,10 @@ Future<Object?> _dispatch(String fnName, List<dynamic> args) async {
       final text = args[1] as String;
       _get(h)?.textContent = text;
       return null;
+
+    case 'dom_get_text':
+      final h = args[0] as int;
+      return _get(h)?.textContent;
 
     case 'dom_append':
       final parentH = args[0] as int;
@@ -153,6 +160,31 @@ Future<Object?> _dispatch(String fnName, List<dynamic> args) async {
       final h = args[0] as int;
       _get(h)?.remove();
       _free(h);
+      return null;
+
+    case 'dom_set_value':
+      final h = args[0] as int;
+      final val = args[1] as String;
+      final svEl = _get(h);
+      if (svEl != null && svEl.isA<HTMLInputElement>()) {
+        (svEl as HTMLInputElement).value = val;
+      } else if (svEl != null && svEl.isA<HTMLTextAreaElement>()) {
+        (svEl as HTMLTextAreaElement).value = val;
+      } else if (svEl != null && svEl.isA<HTMLSelectElement>()) {
+        (svEl as HTMLSelectElement).value = val;
+      }
+      return null;
+
+    case 'dom_get_value':
+      final h = args[0] as int;
+      final gvEl = _get(h);
+      if (gvEl != null && gvEl.isA<HTMLInputElement>()) {
+        return (gvEl as HTMLInputElement).value;
+      } else if (gvEl != null && gvEl.isA<HTMLTextAreaElement>()) {
+        return (gvEl as HTMLTextAreaElement).value;
+      } else if (gvEl != null && gvEl.isA<HTMLSelectElement>()) {
+        return (gvEl as HTMLSelectElement).value;
+      }
       return null;
 
     case 'fetch_text':
@@ -531,6 +563,142 @@ dom_append(app, footer)
 
 log("Dashboard rendered. The truth speaks for itself.")
 ''',
+  'form': '''
+app = dom_query("#sandbox")
+
+title = dom_create("h2")
+dom_text(title, "Dart Conversion Form")
+dom_style(title, "color", "#dcdcaa")
+dom_style(title, "margin-bottom", "12px")
+dom_append(app, title)
+
+subtitle = dom_create("p")
+dom_text(subtitle, "Your answers are saved to localStorage. Refresh the page and run again -- they persist.")
+dom_style(subtitle, "color", "#666")
+dom_style(subtitle, "font-size", "12px")
+dom_style(subtitle, "margin-bottom", "16px")
+dom_append(app, subtitle)
+
+fields = [
+    ("dart_form_name", "What is your name, seeker?", "input"),
+    ("dart_form_language", "What language did you use before Dart?", "input"),
+    ("dart_form_testimony", "Describe your moment of Dart enlightenment:", "textarea"),
+    ("dart_form_slack_level", "On a scale of 1-10, how much do you Slack Off?", "input"),
+]
+
+for key, label_text, field_type in fields:
+    # Label
+    lbl = dom_create("label")
+    dom_text(lbl, label_text)
+    dom_style(lbl, "display", "block")
+    dom_style(lbl, "color", "#569cd6")
+    dom_style(lbl, "font-size", "13px")
+    dom_style(lbl, "margin-bottom", "4px")
+    dom_style(lbl, "margin-top", "12px")
+    dom_append(app, lbl)
+
+    # Field
+    field = dom_create(field_type)
+    dom_style(field, "width", "100%")
+    dom_style(field, "padding", "8px")
+    dom_style(field, "background", "#1e1e2e")
+    dom_style(field, "color", "#d4d4d4")
+    dom_style(field, "border", "1px solid #333")
+    dom_style(field, "border-radius", "3px")
+    dom_style(field, "font-family", "monospace")
+    dom_style(field, "font-size", "13px")
+    if field_type == "textarea":
+        dom_attr(field, "rows", "3")
+    dom_append(app, field)
+
+    # Restore saved value
+    saved = storage_get(key)
+    if saved:
+        dom_set_value(field, saved)
+        log(f"Restored {key}: {saved}")
+
+    # Store handle for save button
+    dom_attr(field, "data-key", key)
+
+# Summary section
+summary_title = dom_create("h3")
+dom_text(summary_title, "Saved State:")
+dom_style(summary_title, "color", "#dcdcaa")
+dom_style(summary_title, "margin-top", "20px")
+dom_style(summary_title, "margin-bottom", "8px")
+dom_append(app, summary_title)
+
+summary = dom_create("pre")
+dom_style(summary, "background", "#141420")
+dom_style(summary, "padding", "12px")
+dom_style(summary, "border-radius", "4px")
+dom_style(summary, "color", "#888")
+dom_style(summary, "font-size", "12px")
+dom_append(app, summary)
+
+# Show all saved state
+lines = []
+for key, label_text, field_type in fields:
+    val = storage_get(key)
+    if val:
+        lines.append(f"  {key} = {val}")
+    else:
+        lines.append(f"  {key} = (empty)")
+
+if lines:
+    dom_text(summary, "localStorage contents:\\n" + "\\n".join(lines))
+else:
+    dom_text(summary, "No saved state yet. Fill in the form and run the Save demo.")
+
+note = dom_create("p")
+dom_text(note, "Edit the fields above, then run the Save demo to persist.")
+dom_style(note, "color", "#555")
+dom_style(note, "font-size", "11px")
+dom_style(note, "margin-top", "8px")
+dom_append(app, note)
+
+log("Form rendered. Existing state restored from localStorage.")
+''',
+  'form_save': '''
+app = dom_query("#sandbox")
+
+# Read all input/textarea values by querying them
+fields = [
+    "dart_form_name",
+    "dart_form_language",
+    "dart_form_testimony",
+    "dart_form_slack_level",
+]
+
+saved = 0
+for key in fields:
+    # Find the element with data-key attribute
+    el = dom_query(f"[data-key=\\"{key}\\"]")
+    if el:
+        val = dom_get_value(el)
+        if val:
+            storage_set(key, val)
+            log(f"Saved {key} = {val}")
+            saved += 1
+        else:
+            log(f"Skipped {key} (empty)")
+    else:
+        log(f"Field not found: {key}")
+
+title = dom_create("h2")
+dom_style(title, "color", "#00d4ff")
+dom_style(title, "text-align", "center")
+dom_style(title, "margin-top", "20px")
+
+if saved > 0:
+    dom_text(title, f"Saved {saved} fields to localStorage!")
+    log(f"\\nDone. {saved} fields persisted. Refresh the page and run Form again to see them restored.")
+else:
+    dom_text(title, "Nothing to save. Run the Form demo first.")
+    log("No fields found. Run the Form demo first to create the form.")
+
+dom_append(app, title)
+''',
 };
 
 // ── UI wiring ──────────────────────────────────────────────────────────────
@@ -546,6 +714,8 @@ void _populateDemoSelector() {
     'todo': 'The Dart Commandments',
     'counter': 'Persistent Pilgrimage Counter',
     'dashboard': 'Dart Evangelism Dashboard',
+    'form': 'Stateful Form (localStorage)',
+    'form_save': 'Save Form State',
   };
 
   for (final entry in _demos.entries) {

--- a/example/web-showcase/bin/showcase.dart
+++ b/example/web-showcase/bin/showcase.dart
@@ -1,0 +1,671 @@
+/// Web Showcase — Python manipulating the browser via Dart host functions.
+///
+/// Host function dispatch loop:
+///   start(code, extFns) → pending? → handler → resume(result) → ...
+///
+/// Host functions: dom_create, dom_text, dom_append, dom_query, dom_style,
+///   dom_attr, dom_html, dom_remove, fetch_text, fetch_json,
+///   storage_get, storage_set, log, alert, now
+library;
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
+// ── JS interop bindings ────────────────────────────────────────────────────
+
+@JS('DartMontyBridge.init')
+external JSPromise<JSBoolean> _bridgeInit();
+
+@JS('DartMontyBridge.start')
+external JSPromise<JSString> _bridgeStart(
+  JSString code, [
+  JSString? extFnsJson,
+]);
+
+@JS('DartMontyBridge.resume')
+external JSPromise<JSString> _bridgeResume(JSString valueJson);
+
+@JS('DartMontyBridge.resumeWithError')
+external JSPromise<JSString> _bridgeResumeWithError(JSString errorJson);
+
+@JS('fetch')
+external JSPromise<_JsResponse> _jsFetch(JSString url);
+
+extension type _JsResponse(JSObject _) implements JSObject {
+  external JSPromise<JSString> text();
+}
+
+Map<String, dynamic> _parse(String json) =>
+    jsonDecode(json) as Map<String, dynamic>;
+
+// ── Opaque handle system ───────────────────────────────────────────────────
+
+int _nextHandle = 1;
+final Map<int, Element> _handles = {};
+
+int _store(Element el) {
+  final h = _nextHandle++;
+  _handles[h] = el;
+  return h;
+}
+
+Element? _get(int h) => _handles[h];
+
+void _free(int h) => _handles.remove(h);
+
+// ── Output logging ─────────────────────────────────────────────────────────
+
+void _log(String msg) {
+  final el = document.getElementById('output');
+  if (el != null) {
+    el.textContent = '${el.textContent}$msg\n';
+  }
+  print(msg);
+}
+
+void _clearOutput() {
+  final el = document.getElementById('output');
+  if (el != null) el.textContent = '';
+}
+
+void _clearSandbox() {
+  final el = document.getElementById('sandbox');
+  if (el != null) el.innerHTML = ''.toJS;
+  _handles.clear();
+  _nextHandle = 1;
+}
+
+// ── Host function list ─────────────────────────────────────────────────────
+
+const List<String> _hostFunctions = [
+  'dom_create',
+  'dom_text',
+  'dom_append',
+  'dom_query',
+  'dom_style',
+  'dom_attr',
+  'dom_html',
+  'dom_remove',
+  'fetch_text',
+  'fetch_json',
+  'storage_get',
+  'storage_set',
+  'log',
+  'alert',
+  'now',
+];
+
+// ── Host function dispatch ─────────────────────────────────────────────────
+
+Future<Object?> _dispatch(String fnName, List<dynamic> args) async {
+  switch (fnName) {
+    case 'dom_create':
+      final tag = args.isNotEmpty ? args[0] as String : 'div';
+      final el = document.createElement(tag);
+      return _store(el);
+
+    case 'dom_text':
+      final h = args[0] as int;
+      final text = args[1] as String;
+      _get(h)?.textContent = text;
+      return null;
+
+    case 'dom_append':
+      final parentH = args[0] as int;
+      final childH = args[1] as int;
+      final parent = _get(parentH);
+      final child = _get(childH);
+      if (parent != null && child != null) parent.appendChild(child);
+      return null;
+
+    case 'dom_query':
+      final selector = args[0] as String;
+      final el = document.querySelector(selector);
+      if (el == null) return null;
+      return _store(el);
+
+    case 'dom_style':
+      final h = args[0] as int;
+      final prop = args[1] as String;
+      final val = args[2] as String;
+      final el = _get(h);
+      if (el != null) {
+        (el as HTMLElement).style.setProperty(prop, val);
+      }
+      return null;
+
+    case 'dom_attr':
+      final h = args[0] as int;
+      final attr = args[1] as String;
+      final val = args[2] as String;
+      _get(h)?.setAttribute(attr, val);
+      return null;
+
+    case 'dom_html':
+      final h = args[0] as int;
+      final html = args[1] as String;
+      _get(h)?.innerHTML = html.toJS;
+      return null;
+
+    case 'dom_remove':
+      final h = args[0] as int;
+      _get(h)?.remove();
+      _free(h);
+      return null;
+
+    case 'fetch_text':
+      final url = args[0] as String;
+      final resp = await _jsFetch(url.toJS).toDart;
+      return (await resp.text().toDart).toDart;
+
+    case 'fetch_json':
+      final url = args[0] as String;
+      final resp = await _jsFetch(url.toJS).toDart;
+      final body = (await resp.text().toDart).toDart;
+      return jsonDecode(body);
+
+    case 'storage_get':
+      final key = args[0] as String;
+      return window.localStorage.getItem(key);
+
+    case 'storage_set':
+      final key = args[0] as String;
+      final val = args[1] as String;
+      window.localStorage.setItem(key, val);
+      return null;
+
+    case 'log':
+      final msg = args.isNotEmpty ? args[0].toString() : '';
+      _log(msg);
+      return null;
+
+    case 'alert':
+      final msg = args.isNotEmpty ? args[0].toString() : '';
+      window.alert(msg);
+      return null;
+
+    case 'now':
+      return DateTime.now().toIso8601String();
+
+    default:
+      return 'Unknown host function: $fnName';
+  }
+}
+
+// ── Execution loop ─────────────────────────────────────────────────────────
+
+Future<Map<String, dynamic>> _runWithHostFunctions(String code) async {
+  final extFnsJson = jsonEncode(_hostFunctions);
+  var result = _parse(
+    (await _bridgeStart(code.toJS, extFnsJson.toJS).toDart).toDart,
+  );
+
+  while (result['state'] == 'pending') {
+    final fnName = result['functionName'] as String;
+    final fnArgs = (result['args'] as List<dynamic>?) ?? [];
+
+    try {
+      final value = await _dispatch(fnName, fnArgs);
+      result = _parse(
+        (await _bridgeResume(jsonEncode(value).toJS).toDart).toDart,
+      );
+    } on Exception catch (e) {
+      result = _parse(
+        (await _bridgeResumeWithError(jsonEncode(e.toString()).toJS).toDart)
+            .toDart,
+      );
+    }
+  }
+
+  return result;
+}
+
+// ── Demo scripts ───────────────────────────────────────────────────────────
+
+const Map<String, String> _demos = {
+  'hello': '''
+app = dom_query("#sandbox")
+h1 = dom_create("h1")
+dom_text(h1, "HEAR YE, HEAR YE!")
+dom_style(h1, "color", "#00d4ff")
+dom_style(h1, "text-shadow", "0 0 20px #00d4ff, 0 0 40px #0066ff")
+dom_style(h1, "font-family", "monospace")
+dom_append(app, h1)
+
+p = dom_create("p")
+dom_text(p, "This text was created by PYTHON running inside your BROWSER.")
+dom_style(p, "color", "#aaa")
+dom_style(p, "font-size", "14px")
+dom_append(app, p)
+
+p2 = dom_create("p")
+dom_text(p2, "No server. No native binary. Just Dart bridging Python to the DOM.")
+dom_style(p2, "color", "#569cd6")
+dom_style(p2, "margin-top", "8px")
+dom_append(app, p2)
+
+log("The Word of Dart has been spoken.")
+''',
+  'altar': '''
+app = dom_query("#sandbox")
+
+# The Sacred Stencil of "Bob"
+bob = dom_create("pre")
+dom_style(bob, "color", "#00d4ff")
+dom_style(bob, "font-size", "8px")
+dom_style(bob, "line-height", "1.05")
+dom_style(bob, "text-align", "center")
+dom_style(bob, "text-shadow", "0 0 6px #0066ff")
+
+stencil = """
+                     ######################
+                  ############################
+                ########################### #####
+               ##############  #######  ##   # ####
+             ###########   ##   ###  ##  #   #  ####
+            ####.###  # #   ##   ###  #  #   ## # ##
+           ####..###   # #   ##   ###  #  ##  # # ###
+          #####..####  # #    #    ##  #  ### # ## ####
+         #####...##### ####   #  # ##   # ##### ## #####
+        ######...###########  ## # #### # ################
+       ######...############### ###### #####################
+      ######...##......############### #########   ########
+      ######..##.........############ #######     ####.###
+      ######.##...........#################        ####..###
+      ########.............###########             ####..###
+     #######...            ########                 ###..###
+     ######...                                      ###..##
+     ######...                                      ###..##
+     #####....                                    . ###..##
+     #####....                                    .  ##..##
+     #####....                                    .  ##..##
+     #####....                                   ..  ###.##
+     #####....                                  ...  ###.##
+     #####....                                   ..  ###.##
+     #####....                                   ..  ###.##
+     #####....                                   ..  ###.##
+      ####....                             ####  .. ####.##
+     # ###.... #########                #########.. #######
+    ### ##...  ##########              ###########.. ######
+    ####  ...          ###           ####       ##.. ######
+    ######...    ##### ####         ##########   #.. ######
+     #### ...  ###     #####       ######    ###  ... #####
+     ####     ######### ####      ##############   .  #####
+     ####     ###  # ##  ####    ######  # #  ##      ####
+     ####      #   ### ...###         .. ###          ####
+     ####             .... ##         ......  ...     ####
+      ####      ... .....   #           .......       ####
+      ####        .....    ##             ...         ## #
+      ## #          ..     #                          # ##
+      # ##                 #                          #  #
+      # ##  #             .#                         ##  #
+      #  #  #            ..#                          ####
+       ###  ##         # ...                       # # ##
+        ##  ##        # ....          # ###       ## #
+         # ###     ##  ....        ###  ###     ### #
+         # ###    ##  ...###     ####    ####  #### #
+         #########   ##############      ######### #
+          #######   ##############         ######## #
+          ###### ..##############      ##############
+          ### ##  .##########      #########    ####
+           ##  #   ####     ########    ##      ###
+           ##  #   .####               ##      ####
+            #  #   ....### #############       ###
+            ## ##   ....             ##       ####
+            ## ##    ..#### ########          ###
+             #  #    #####..........         ####
+             ## ##  #####...                 ###
+              #  # #### ..............      ###
+              ##  ####  .............       ###
+     ###       # ####   #....              ###
+   ##   ##      #####  ####               ###
+  #  ##  ##   ######   ###                ###
+ # ####  ##  ######   ####               ###
+#  ###  ### ###### #######              ###
+#      ##########   ######             ###
+#  ##   ########     ###############  ###
+#####   #######       ##################
+######   #####                  ######
+ #####   ####
+ ######  ###
+  #####  ###
+   ########
+    ######
+"""
+
+dom_text(bob, stencil)
+dom_append(app, bob)
+
+# The Altar beneath "Bob"
+altar = dom_create("pre")
+dom_style(altar, "color", "#dcdcaa")
+dom_style(altar, "font-size", "10px")
+dom_style(altar, "line-height", "1.15")
+dom_style(altar, "text-align", "center")
+dom_style(altar, "margin-top", "4px")
+
+slab = """
+
+    __|______________________________________________|__
+   |  |                                              |  |
+   |  |                                              |  |
+   |  |                                              |  |
+   |  |          S  L  A  C  K     O  F  F           |  |
+   |  |                                              |  |
+   |  |                                              |  |
+   |  |      Dart is the Way, the Truth,             |  |
+   |  |      and the Compiled Language.               |  |
+   |  |                                              |  |
+   |  |      Python runneth sandboxed                |  |
+   |  |      within the browser.                     |  |
+   |  |                                              |  |
+   |  |      No server. No binary.                   |  |
+   |  |      Only Dart.                              |  |
+   |  |                                              |  |
+   |  |______________________________________________|  |
+   |____________________________________________________|
+        |    |                            |    |
+        |    |     ~ PRAISE  "BOB" ~      |    |
+        |    |     ~ PRAISE  DART  ~      |    |
+        |    |     ~ SLACK   OFF   ~      |    |
+        |____|                            |____|
+       /______\\                          /______\\
+"""
+
+dom_text(altar, slab)
+dom_append(app, altar)
+
+# Proclamation
+proc = dom_create("h2")
+dom_text(proc, "The Church of the SubGenius of Dart Welcomes You")
+dom_style(proc, "color", "#dcdcaa")
+dom_style(proc, "text-align", "center")
+dom_style(proc, "margin-top", "16px")
+dom_style(proc, "font-family", "monospace")
+dom_append(app, proc)
+
+verse = dom_create("p")
+dom_html(verse, "<em>\\"And \\'Bob\\' spake unto the mass:<br>Slack Off, for Dart compiles all things unto JavaScript,<br>and Python runneth sandboxed within the browser.<br>Give me your 35 dollars and eternal Slack shall be yours.\\"</em>")
+dom_style(verse, "color", "#888")
+dom_style(verse, "text-align", "center")
+dom_style(verse, "font-style", "italic")
+dom_style(verse, "margin-top", "8px")
+dom_append(app, verse)
+
+log("The stencil of \\"Bob\\" has been rendered. Slack Off in peace.")
+log("Dart is the future. The pipe does not lie.")
+''',
+  'todo': '''
+app = dom_query("#sandbox")
+
+title = dom_create("h2")
+dom_text(title, "The Dart Commandments")
+dom_style(title, "color", "#dcdcaa")
+dom_style(title, "margin-bottom", "8px")
+dom_append(app, title)
+
+ul = dom_create("ul")
+dom_style(ul, "list-style", "none")
+dom_style(ul, "padding", "0")
+
+commandments = [
+    "I. Thou shalt compile to JavaScript and question nothing",
+    "II. Thou shalt bridge Python unto the browser via WASM",
+    "III. Thou shalt not require a server for what Dart can do alone",
+    "IV. Honor thy sandboxed interpreter and its resource limits",
+    "V. Thou shalt Slack Off, for productivity is overrated",
+    "VI. Thou shalt spread the Word of Dart unto all platforms",
+    "VII. Thou shalt use opaque handles, for DOM refs cannot be serialized",
+]
+
+for i, cmd in enumerate(commandments):
+    li = dom_create("li")
+    dom_text(li, cmd)
+    dom_style(li, "padding", "6px 0")
+    dom_style(li, "border-bottom", "1px solid #333")
+    if i % 2 == 0:
+        dom_style(li, "color", "#569cd6")
+    else:
+        dom_style(li, "color", "#d4d4d4")
+    dom_append(ul, li)
+
+dom_append(app, ul)
+log("The commandments have been inscribed.")
+''',
+  'counter': '''
+count = storage_get("dart_altar_visits")
+count = int(count) if count else 0
+count += 1
+storage_set("dart_altar_visits", str(count))
+
+app = dom_query("#sandbox")
+
+div = dom_create("div")
+dom_style(div, "text-align", "center")
+dom_style(div, "padding", "24px")
+
+h = dom_create("h1")
+dom_style(h, "font-size", "72px")
+dom_style(h, "color", "#00d4ff")
+dom_style(h, "text-shadow", "0 0 30px #0066ff")
+dom_text(h, str(count))
+dom_append(div, h)
+
+label = dom_create("p")
+dom_style(label, "color", "#888")
+dom_style(label, "font-size", "14px")
+
+if count == 1:
+    dom_text(label, "First pilgrimage to the Altar of Dart")
+elif count < 5:
+    dom_text(label, f"You have visited the Altar {count} times. The faith grows.")
+elif count < 10:
+    dom_text(label, f"{count} visits. You are becoming a true Dart disciple.")
+else:
+    dom_text(label, f"{count} visits. You have achieved Dart enlightenment. Slack Off.")
+
+dom_append(div, label)
+dom_append(app, div)
+
+log(f"Pilgrimage #{count} recorded in localStorage.")
+''',
+  'dashboard': '''
+app = dom_query("#sandbox")
+
+title = dom_create("h2")
+dom_text(title, "Dart Evangelism Dashboard")
+dom_style(title, "color", "#dcdcaa")
+dom_style(title, "margin-bottom", "12px")
+dom_append(app, title)
+
+# Build a table showing the superiority of Dart
+table = dom_create("table")
+dom_style(table, "border-collapse", "collapse")
+dom_style(table, "width", "100%")
+
+headers = ["Language", "Compiles to JS", "Runs Python", "Has Monty", "Verdict"]
+header_row = dom_create("tr")
+for h in headers:
+    th = dom_create("th")
+    dom_text(th, h)
+    dom_style(th, "border", "1px solid #555")
+    dom_style(th, "padding", "8px")
+    dom_style(th, "background", "#252526")
+    dom_style(th, "color", "#dcdcaa")
+    dom_append(header_row, th)
+dom_append(table, header_row)
+
+data = [
+    ["Dart",       "Yes", "Yes (Monty)", "YES",  "THE FUTURE"],
+    ["JavaScript", "N/A", "No",          "Nope", "Adequate"],
+    ["TypeScript", "Yes", "No",          "Nah",  "Trying"],
+    ["Rust",       "WASM","Backend only","Helps","Honorable ally"],
+    ["Python",     "No",  "Is Python",   "IS Monty","The guest of honor"],
+]
+
+for row_data in data:
+    row = dom_create("tr")
+    for i, val in enumerate(row_data):
+        td = dom_create("td")
+        dom_text(td, val)
+        dom_style(td, "border", "1px solid #555")
+        dom_style(td, "padding", "6px 10px")
+        if row_data[0] == "Dart":
+            dom_style(td, "color", "#00d4ff")
+            dom_style(td, "font-weight", "bold")
+        elif i == len(row_data) - 1:
+            dom_style(td, "color", "#888")
+        dom_append(row, td)
+    dom_append(table, row)
+
+dom_append(app, table)
+
+footer = dom_create("p")
+dom_text(footer, "* All data confirmed by the Church of Dart. Slack Off.")
+dom_style(footer, "color", "#555")
+dom_style(footer, "font-size", "11px")
+dom_style(footer, "margin-top", "12px")
+dom_append(app, footer)
+
+log("Dashboard rendered. The truth speaks for itself.")
+''',
+};
+
+// ── UI wiring ──────────────────────────────────────────────────────────────
+
+void _populateDemoSelector() {
+  final select =
+      document.getElementById('demo-select')! as HTMLSelectElement;
+  select.innerHTML = '<option value="">-- Select a Demo --</option>'.toJS;
+
+  final labels = {
+    'hello': 'Hello from Python',
+    'altar': 'The Sacred Altar (ASCII)',
+    'todo': 'The Dart Commandments',
+    'counter': 'Persistent Pilgrimage Counter',
+    'dashboard': 'Dart Evangelism Dashboard',
+  };
+
+  for (final entry in _demos.entries) {
+    final option = document.createElement('option') as HTMLOptionElement;
+    option.value = entry.key;
+    option.textContent = labels[entry.key] ?? entry.key;
+    select.appendChild(option);
+  }
+
+  select.addEventListener(
+    'change',
+    (Event e) {
+      final key = select.value;
+      if (key.isNotEmpty && _demos.containsKey(key)) {
+        final editor =
+            document.getElementById('editor')! as HTMLTextAreaElement;
+        editor.value = _demos[key]!.trim();
+      }
+    }.toJS,
+  );
+}
+
+Future<void> _runCode() async {
+  final editor = document.getElementById('editor')! as HTMLTextAreaElement;
+  final code = editor.value.trim();
+  if (code.isEmpty) return;
+
+  _clearOutput();
+  _clearSandbox();
+
+  final statusEl =
+      document.getElementById('status')! as HTMLElement;
+  statusEl.textContent = 'Running...';
+  statusEl.style.color = '#dcdcaa';
+
+  final sw = Stopwatch()..start();
+
+  try {
+    final result = await _runWithHostFunctions(code);
+    sw.stop();
+
+    final usage = result['usage'] as Map<String, dynamic>?;
+    final mem = usage?['memory_bytes_used'] as int? ?? 0;
+    final time = usage?['time_elapsed_ms'] as int? ?? sw.elapsedMilliseconds;
+    final stack = usage?['stack_depth_used'] as int? ?? 0;
+
+    statusEl.textContent =
+        'Done in ${time}ms | Memory: ${(mem / 1024).toStringAsFixed(1)}KB | Stack: $stack';
+    statusEl.style.color = '#569cd6';
+
+    if (result['error'] != null) {
+      _log('Error: ${result['error']}');
+      statusEl.style.color = '#f44747';
+    }
+
+    // Show return value if present and meaningful
+    if (result['value'] != null && result['value'] != 'None') {
+      _log('=> ${result['value']}');
+    }
+  } on Exception catch (e) {
+    sw.stop();
+    statusEl.textContent = 'Error';
+    statusEl.style.color = '#f44747';
+    _log('Exception: $e');
+  }
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────
+
+Future<void> main() async {
+  final statusEl =
+      document.getElementById('status')! as HTMLElement;
+  statusEl.textContent = 'Initializing Monty WASM...';
+
+  final ok = (await _bridgeInit().toDart).toDart;
+  if (!ok) {
+    statusEl.textContent = 'Failed to initialize Monty WASM';
+    statusEl.style.color = '#f44747';
+    return;
+  }
+
+  statusEl.textContent = 'Ready. Choose a demo or write Python.';
+  statusEl.style.color = '#569cd6';
+
+  _populateDemoSelector();
+
+  // Run button
+  document.getElementById('run-btn')!.addEventListener(
+    'click',
+    (Event e) {
+      _runCode();
+    }.toJS,
+  );
+
+  // Clear button
+  document.getElementById('clear-btn')!.addEventListener(
+    'click',
+    (Event e) {
+      _clearOutput();
+      _clearSandbox();
+      (document.getElementById('status')! as HTMLElement)
+        ..textContent = 'Cleared. The altar awaits.'
+        ..style.color = '#569cd6';
+    }.toJS,
+  );
+
+  // Ctrl+Enter to run
+  document.getElementById('editor')!.addEventListener(
+    'keydown',
+    (KeyboardEvent e) {
+      if (e.key == 'Enter' && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        _runCode();
+      }
+    }.toJS,
+  );
+
+  // Auto-load the altar demo
+  final editor = document.getElementById('editor')! as HTMLTextAreaElement;
+  editor.value = _demos['altar']!.trim();
+  (document.getElementById('demo-select')! as HTMLSelectElement).value =
+      'altar';
+}

--- a/example/web-showcase/pubspec.yaml
+++ b/example/web-showcase/pubspec.yaml
@@ -1,0 +1,11 @@
+name: web_showcase
+description: Python in the browser — DOM, fetch, localStorage via Dart bridge.
+publish_to: none
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+
+dependencies:
+  web: ^1.1.1
+dev_dependencies:
+  lints: ^6.1.0

--- a/example/web-showcase/run.sh
+++ b/example/web-showcase/run.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Web Showcase Runner — The Altar of Dart
+# =============================================================================
+# Builds the JS bridge, compiles Dart to JS, starts a COOP/COEP server,
+# and opens the showcase in your default browser.
+#
+# Usage: bash example/web-showcase/run.sh
+# =============================================================================
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+WASM_PKG="$ROOT/packages/dart_monty_wasm"
+EXAMPLE="$ROOT/example/web-showcase"
+WEB_DIR="$EXAMPLE/web"
+
+echo "=== The Altar of Dart — Web Showcase ==="
+
+# ── Step 1: Build JS bridge (if assets missing) ─────────────────────────
+if [ ! -f "$WASM_PKG/assets/dart_monty_bridge.js" ]; then
+  echo ""
+  echo "--- Building JS bridge ---"
+  cd "$WASM_PKG/js"
+  npm install
+  npm run build
+  echo "  JS build: OK"
+fi
+
+# ── Step 2: Copy assets to web dir ───────────────────────────────────────
+echo ""
+echo "--- Copying WASM assets ---"
+cp "$WASM_PKG/assets/dart_monty_bridge.js" "$WEB_DIR/"
+cp "$WASM_PKG/assets/dart_monty_worker.js" "$WEB_DIR/"
+cp "$WASM_PKG/assets/wasi-worker-browser.mjs" "$WEB_DIR/"
+cp "$WASM_PKG/assets/"*.wasm "$WEB_DIR/"
+
+# Copy coi-serviceworker from the existing web example
+if [ -f "$ROOT/example/web/web/coi-serviceworker.js" ]; then
+  cp "$ROOT/example/web/web/coi-serviceworker.js" "$WEB_DIR/"
+fi
+echo "  Assets copied."
+
+# ── Step 3: Compile Dart to JS ───────────────────────────────────────────
+echo ""
+echo "--- Compiling Dart to JS ---"
+cd "$EXAMPLE"
+dart pub get
+dart compile js bin/showcase.dart -o "$WEB_DIR/showcase.dart.js"
+echo "  Compiled: web/showcase.dart.js"
+
+# ── Step 4: Start COOP/COEP server ──────────────────────────────────────
+PORT=8089
+cleanup() {
+  if [ -n "${SERVER_PID:-}" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  # Clean up copied files
+  rm -f "$WEB_DIR/dart_monty_bridge.js" \
+        "$WEB_DIR/dart_monty_worker.js" \
+        "$WEB_DIR/wasi-worker-browser.mjs" \
+        "$WEB_DIR/"*.wasm \
+        "$WEB_DIR/showcase.dart.js" \
+        "$WEB_DIR/showcase.dart.js.deps" \
+        "$WEB_DIR/showcase.dart.js.map"
+}
+trap cleanup EXIT
+
+echo ""
+echo "--- Starting server on http://localhost:$PORT ---"
+python3 -c "
+import http.server, functools
+
+class H(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Cache-Control', 'no-store')
+        super().end_headers()
+    def guess_type(self, path):
+        if path.endswith('.mjs'): return 'application/javascript'
+        if path.endswith('.wasm'): return 'application/wasm'
+        return super().guess_type(path)
+
+handler = functools.partial(H, directory='$WEB_DIR')
+http.server.HTTPServer(('127.0.0.1', $PORT), handler).serve_forever()
+" &
+SERVER_PID=$!
+sleep 1
+
+echo ""
+echo "  ============================================"
+echo "   THE ALTAR OF DART"
+echo "   http://localhost:$PORT/showcase.html"
+echo "  ============================================"
+echo "   Dart is the future."
+echo "   Python runs in your browser."
+echo "   No server needed. Just faith."
+echo "   Press Ctrl+C to close the temple."
+echo "  ============================================"
+echo ""
+
+# Open browser (macOS)
+if command -v open &>/dev/null; then
+  open "http://localhost:$PORT/showcase.html"
+fi
+
+wait "$SERVER_PID"

--- a/example/web-showcase/web/showcase.html
+++ b/example/web-showcase/web/showcase.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>The Altar of Dart — Python in the Browser</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      background: #0a0a0f;
+      color: #d4d4d4;
+      min-height: 100vh;
+    }
+
+    /* ── Header / Altar Banner ── */
+    .altar-banner {
+      display: flex;
+      align-items: center;
+      padding: 12px 16px;
+      background: linear-gradient(180deg, #0d1117 0%, #0a0a0f 100%);
+      border-bottom: 1px solid #1a1a2e;
+    }
+    .altar-text {
+      flex: 1;
+    }
+    .altar-title {
+      color: #00d4ff;
+      font-size: 1.4rem;
+      text-shadow: 0 0 20px rgba(0, 212, 255, 0.5);
+      letter-spacing: 4px;
+    }
+    .altar-subtitle {
+      color: #569cd6;
+      font-size: 0.75rem;
+      margin-top: 4px;
+      letter-spacing: 2px;
+    }
+    .altar-verse {
+      color: #555;
+      font-size: 0.7rem;
+      margin-top: 4px;
+      font-style: italic;
+    }
+    .altar-links {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      align-items: flex-end;
+    }
+    .altar-links a {
+      color: #569cd6;
+      text-decoration: none;
+      font-size: 0.75rem;
+    }
+    .altar-links a:hover { text-decoration: underline; }
+
+    /* ── Layout ── */
+    .main-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0;
+      height: calc(100vh - 200px);
+      min-height: 400px;
+    }
+
+    /* ── Left Panel: Editor ── */
+    .editor-panel {
+      display: flex;
+      flex-direction: column;
+      border-right: 1px solid #1a1a2e;
+    }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: #141420;
+      border-bottom: 1px solid #1a1a2e;
+      flex-wrap: wrap;
+    }
+    .toolbar select {
+      background: #1e1e2e;
+      color: #d4d4d4;
+      border: 1px solid #333;
+      padding: 4px 8px;
+      font-family: inherit;
+      font-size: 0.8rem;
+      border-radius: 3px;
+    }
+    .toolbar button {
+      padding: 5px 14px;
+      border: 1px solid #333;
+      border-radius: 3px;
+      font-family: inherit;
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    #run-btn {
+      background: #00d4ff;
+      color: #0a0a0f;
+      border-color: #00d4ff;
+      font-weight: bold;
+    }
+    #run-btn:hover { background: #33ddff; }
+    #clear-btn {
+      background: #1e1e2e;
+      color: #888;
+    }
+    #clear-btn:hover { background: #252535; color: #aaa; }
+    .toolbar .hint {
+      color: #444;
+      font-size: 0.7rem;
+      margin-left: auto;
+    }
+    textarea#editor {
+      flex: 1;
+      background: #0d0d18;
+      color: #d4d4d4;
+      border: none;
+      padding: 12px;
+      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      resize: none;
+      outline: none;
+      tab-size: 4;
+    }
+    textarea#editor::selection { background: #264f78; }
+
+    /* ── Right Panel: Output ── */
+    .output-panel {
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .output-header {
+      padding: 8px 12px;
+      background: #141420;
+      border-bottom: 1px solid #1a1a2e;
+      font-size: 0.8rem;
+      color: #569cd6;
+      display: flex;
+      justify-content: space-between;
+    }
+    #sandbox {
+      flex: 1;
+      padding: 12px;
+      overflow: auto;
+      background: #0d0d18;
+      border-bottom: 1px solid #1a1a2e;
+    }
+    #output {
+      height: 120px;
+      padding: 8px 12px;
+      overflow: auto;
+      background: #0a0a12;
+      font-size: 12px;
+      color: #888;
+      white-space: pre-wrap;
+      line-height: 1.5;
+    }
+
+    /* ── Status Bar ── */
+    .status-bar {
+      padding: 6px 12px;
+      background: #141420;
+      border-top: 1px solid #1a1a2e;
+      font-size: 0.75rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    #status { color: #555; }
+    .status-bar .creed {
+      color: #333;
+      font-style: italic;
+    }
+
+  </style>
+</head>
+<body>
+
+  <!-- ═══ HEADER ═══ -->
+  <div class="altar-banner">
+    <div class="altar-text">
+      <div class="altar-title">THE ALTAR OF DART</div>
+      <div class="altar-subtitle">PYTHON IN THE BROWSER &mdash; NO SERVER, NO BINARY, JUST DART</div>
+      <div class="altar-verse">"And 'Bob' spake from within the WASM, and Dart carried the word unto the DOM." &mdash; Book of Monty 3:14</div>
+    </div>
+    <div class="altar-links">
+      <a href="https://github.com/pydantic/monty">pydantic/monty</a>
+      <a href="https://pub.dev/packages/dart_monty">pub.dev/dart_monty</a>
+      <a href="https://github.com/runyaga/dart_monty">runyaga/dart_monty</a>
+    </div>
+  </div>
+
+  <!-- ═══ MAIN CONTENT ═══ -->
+  <div class="main-grid">
+    <!-- Left: Python Editor -->
+    <div class="editor-panel">
+      <div class="toolbar">
+        <select id="demo-select"></select>
+        <button id="run-btn">INVOKE</button>
+        <button id="clear-btn">PURGE</button>
+        <span class="hint">Ctrl+Enter to invoke</span>
+      </div>
+      <textarea id="editor" spellcheck="false" placeholder="# Write Python here. It runs in your browser.&#10;# Dart bridges every call to the DOM.&#10;# There is no server. Only Dart."></textarea>
+    </div>
+
+    <!-- Right: DOM Sandbox + Log -->
+    <div class="output-panel">
+      <div class="output-header">
+        <span>DOM Sandbox</span>
+        <span>Python &rarr; Dart &rarr; Browser</span>
+      </div>
+      <div id="sandbox"></div>
+      <div id="output"></div>
+    </div>
+  </div>
+
+  <!-- ═══ STATUS BAR ═══ -->
+  <div class="status-bar">
+    <span id="status">Loading the sacred interpreter...</span>
+    <span class="creed">Dart is the way. Slack off.</span>
+  </div>
+
+  <!-- ═══ SCRIPTS ═══ -->
+  <script src="coi-serviceworker.js"></script>
+  <script src="dart_monty_bridge.js"></script>
+  <script src="showcase.dart.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Web showcase demonstrating sandboxed Python execution in the browser via dart_monty's WASM bridge.

## Changes

- **Base demo** — execute Python via Dart WASM bridge in a web page
- **Stateful form** — form demo with localStorage persistence
- **DOM interaction** — `dom_on_click` host function, single-page form with Save button
- **Snapshot/restore** — serialize interpreter state to file, download/upload, restore execution
- **`run.sh`** — build and serve script for local development

## Test plan

- [x] Manual: `./run.sh` builds and serves at localhost
- [x] Manual: Python execution produces output in browser
- [x] Manual: Form state persists across page reloads via localStorage
- [x] Manual: Snapshot download/upload restores interpreter state

🤖 Generated with [Claude Code](https://claude.com/claude-code)