### PR TITLE
feat(bridge): integrate struct_log for structured logging

### DIFF
--- a/packages/dart_monty_bridge/lib/dart_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/dart_monty_bridge.dart
@@ -4,6 +4,9 @@
 /// event loop support, and a plugin system for modular host function bundles.
 library;
 
+// Re-export struct_log for consumers that want to configure logging.
+export 'package:struct_log/struct_log.dart';
+
 export 'src/bridge/bridge_event.dart';
 export 'src/bridge/default_monty_bridge.dart';
 export 'src/bridge/event_loop_bridge.dart';

--- a/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
@@ -6,6 +6,8 @@ import 'package:dart_monty_bridge/src/bridge/host_function.dart';
 import 'package:dart_monty_bridge/src/bridge/host_function_schema.dart';
 import 'package:dart_monty_bridge/src/bridge/monty_bridge.dart';
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:meta/meta.dart';
+import 'package:struct_log/struct_log.dart';
 
 /// Print-override preamble injected before user code.
 ///
@@ -38,17 +40,27 @@ class _PendingFuture {
 /// calls to registered [HostFunction] handlers and emitting [BridgeEvent]s.
 class DefaultMontyBridge implements MontyBridge {
   /// Creates a [DefaultMontyBridge].
+  ///
+  /// Pass [logger] to inject a custom logger for this bridge instance.
+  /// If omitted, uses the global [LogManager] singleton.
   DefaultMontyBridge({
     MontyPlatform? platform,
     MontyLimits? limits,
     bool useFutures = true,
+    Logger? logger,
   })  : _explicitPlatform = platform,
         _limits = limits,
-        _useFutures = useFutures;
+        _useFutures = useFutures,
+        log = logger ?? LogManager.instance.getLogger('MontyBridge');
 
   final MontyPlatform? _explicitPlatform;
   final MontyLimits? _limits;
   final bool _useFutures;
+
+  /// Logger for this bridge instance.
+  @protected
+  final Logger log;
+
   final Map<String, HostFunction> _functions = {};
   final Map<int, _PendingFuture> _pendingFutures = {};
   int _idCounter = 0;
@@ -81,6 +93,10 @@ class DefaultMontyBridge implements MontyBridge {
     if (_isExecuting) {
       throw StateError('Bridge is already executing');
     }
+    log.debug(
+      'Executing code',
+      attributes: {'codeLength': code.length},
+    );
 
     final controller = StreamController<BridgeEvent>();
     _isExecuting = true;
@@ -153,9 +169,11 @@ class DefaultMontyBridge implements MontyBridge {
         }
       }
     } on MontyException catch (e) {
+      log.warning('Python error', attributes: {'error': e.message});
       _flushPrintBuffer(printBuffer, controller);
       controller.add(BridgeRunError(message: e.message));
-    } on Object catch (e) {
+    } on Object catch (e, st) {
+      log.error('Bridge infrastructure error', error: e, stackTrace: st);
       _flushPrintBuffer(printBuffer, controller);
       controller.add(BridgeRunError(message: '$e'));
     } finally {
@@ -183,6 +201,7 @@ class DefaultMontyBridge implements MontyBridge {
     // Registered host function — emit tool call events.
     final fn = _functions[name];
     if (fn != null) {
+      log.trace('Host function call', attributes: {'name': name});
       if (futuresCapable) {
         return _dispatchToolCallAsFuture(fn, pending, controller);
       }
@@ -190,6 +209,7 @@ class DefaultMontyBridge implements MontyBridge {
     }
 
     // Unknown function — raise error in Python.
+    log.warning('Unknown function', attributes: {'name': name});
     return _platform.resumeWithError('Unknown function: $name');
   }
 
@@ -210,6 +230,10 @@ class DefaultMontyBridge implements MontyBridge {
     try {
       args = fn.schema.mapAndValidate(pending);
     } on FormatException catch (e) {
+      log.warning(
+        'Argument validation failed',
+        attributes: {'function': stepName, 'error': e.message},
+      );
       controller
         ..add(BridgeToolCallResult(callId: callId, result: 'Error: $e'))
         ..add(BridgeStepFinished(stepId: stepName));
@@ -233,7 +257,13 @@ class DefaultMontyBridge implements MontyBridge {
         ..add(BridgeStepFinished(stepId: stepName));
 
       return _platform.resume(result);
-    } on Object catch (e) {
+    } on Object catch (e, st) {
+      log.error(
+        'Host handler error',
+        error: e,
+        stackTrace: st,
+        attributes: {'function': stepName},
+      );
       controller
         ..add(BridgeToolCallResult(callId: callId, result: 'Error: $e'))
         ..add(BridgeStepFinished(stepId: stepName));

--- a/packages/dart_monty_bridge/lib/src/bridge/event_loop_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/event_loop_bridge.dart
@@ -45,6 +45,7 @@ class EventLoopBridge extends DefaultMontyBridge {
   EventLoopBridge({
     super.platform,
     super.limits,
+    super.logger,
     this.onRenderUi,
   }) : super(useFutures: true) {
     _registerEventLoopFunctions();
@@ -85,6 +86,10 @@ class EventLoopBridge extends DefaultMontyBridge {
     if (_loopState == EventLoopState.disposed) {
       throw StateError('Cannot dispatch events on a disposed bridge');
     }
+    log.trace(
+      'Dispatching UI event',
+      attributes: {'eventKeys': '${event.keys.toList()}'},
+    );
 
     final completer = _pendingCompleter;
     if (completer != null && !completer.isCompleted) {
@@ -182,6 +187,7 @@ class EventLoopBridge extends DefaultMontyBridge {
 
     // No events queued — create a completer and wait.
     _loopState = EventLoopState.waitingForEvent;
+    log.trace('Waiting for event');
     _eventLoopController.add(const BridgeEventLoopWaiting());
 
     final completer = Completer<Map<String, dynamic>>();

--- a/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
@@ -4,6 +4,7 @@ import 'package:dart_monty_bridge/src/bridge/host_function_schema.dart';
 import 'package:dart_monty_bridge/src/bridge/introspection_functions.dart';
 import 'package:dart_monty_bridge/src/bridge/monty_bridge.dart';
 import 'package:dart_monty_bridge/src/bridge/monty_plugin.dart';
+import 'package:struct_log/struct_log.dart';
 
 /// Collects [MontyPlugin]s with namespace validation and function name
 /// collision detection.
@@ -15,6 +16,7 @@ class PluginRegistry {
   final List<MontyPlugin> _plugins = [];
   final Set<String> _namespaces = {};
   final Set<String> _functionNames = {};
+  final Logger _log = LogManager.instance.getLogger('PluginRegistry');
 
   static final RegExp _validNamespace = RegExp(r'^[a-z][a-z0-9_]*$');
   static const int _maxNamespaceLength = 32;
@@ -38,6 +40,13 @@ class PluginRegistry {
       _functionNames.add(fn.schema.name);
     }
     _plugins.add(plugin);
+    _log.debug(
+      'Registered plugin',
+      attributes: {
+        'namespace': plugin.namespace,
+        'functions': plugin.functions.length,
+      },
+    );
   }
 
   void _validateNamespace(String namespace) {
@@ -81,6 +90,10 @@ class PluginRegistry {
 
     // Register introspection builtins.
     buildIntrospectionFunctions(schemasByCategory).forEach(bridge.register);
+    _log.info(
+      'Attached plugins to bridge',
+      attributes: {'pluginCount': _plugins.length},
+    );
   }
 
   /// Disposes all plugins in reverse registration order.

--- a/packages/dart_monty_bridge/pubspec.yaml
+++ b/packages/dart_monty_bridge/pubspec.yaml
@@ -1,6 +1,7 @@
 name: dart_monty_bridge
 description: High-level bridge layer for dart_monty. Host functions, event loop, plugin system.
 version: 0.1.0
+publish_to: none
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,6 +16,9 @@ environment:
 dependencies:
   dart_monty_platform_interface: ^0.6.0
   meta: ^1.11.0
+  struct_log:
+    git:
+      url: https://github.com/runyaga/struct_log.git
 
 dev_dependencies:
   test: ^1.25.0


### PR DESCRIPTION
## Summary
- Add `struct_log` git dependency to `dart_monty_bridge`
- Instrument `DefaultMontyBridge`, `EventLoopBridge`, and `PluginRegistry` with structured logging
- Re-export `struct_log` from the bridge barrel for consumer access to `LogManager`/`Logger`/sinks

## Changes
- **DefaultMontyBridge**: accepts optional `Logger` param for per-instance logging; logs code execution, host function calls, unknown functions, argument validation errors, handler errors, infrastructure errors
- **EventLoopBridge**: logs UI event dispatch and wait states via inherited `log` field; passes `logger` through to super
- **PluginRegistry**: logs plugin registration (namespace + function count) and `attachTo` completion
- **Barrel**: re-exports `package:struct_log/struct_log.dart` so consumers can configure sinks without a direct dependency

## Test plan
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart test` — 48/48 passing
- [x] No breaking API changes (Logger param is optional with singleton fallback)