### PR TITLE
fix(print): plumb printOutput through iterative and WASM paths

### DIFF
--- a/packages/dart_monty_ffi/lib/src/ffi_core_bindings.dart
+++ b/packages/dart_monty_ffi/lib/src/ffi_core_bindings.dart
@@ -189,6 +189,7 @@ class FfiCoreBindings implements MontyCoreBindings {
           value: jsonMap['value'] as Object?,
           usage:
               usageMap != null ? MontyResourceUsage.fromJson(usageMap) : null,
+          printOutput: jsonMap['print_output'] as String?,
           error: errorMap?['message'] as String?,
           excType: errorMap?['exc_type'] as String?,
           traceback: errorMap?['traceback'] as List<Object?>?,

--- a/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
@@ -153,6 +153,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
             value: p.value,
             error: _buildError(p.error, p.excType, p.traceback),
             usage: p.usage ?? _zeroUsage,
+            printOutput: p.printOutput,
           ),
         );
       case 'pending':

--- a/packages/dart_monty_platform_interface/lib/src/core_bindings.dart
+++ b/packages/dart_monty_platform_interface/lib/src/core_bindings.dart
@@ -81,6 +81,7 @@ final class CoreProgressResult {
     required this.state,
     this.value,
     this.usage,
+    this.printOutput,
     this.functionName,
     this.arguments,
     this.kwargs,
@@ -104,6 +105,9 @@ final class CoreProgressResult {
 
   /// Resource usage statistics (when [state] is `'complete'`).
   final MontyResourceUsage? usage;
+
+  /// Captured Python `print()` output (when [state] is `'complete'`).
+  final String? printOutput;
 
   /// External function name (when [state] is `'pending'`).
   final String? functionName;

--- a/packages/dart_monty_wasm/lib/src/wasm_bindings.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_bindings.dart
@@ -10,6 +10,7 @@ final class WasmRunResult {
     this.value,
     this.error,
     this.errorType,
+    this.printOutput,
     this.excType,
     this.traceback,
   });
@@ -19,6 +20,9 @@ final class WasmRunResult {
 
   /// The return value from the Python execution (when [ok] is true).
   final Object? value;
+
+  /// Captured Python `print()` output (when [ok] is true).
+  final String? printOutput;
 
   /// The error message (when [ok] is false).
   final String? error;
@@ -48,6 +52,7 @@ final class WasmProgressResult {
     this.kwargs,
     this.callId,
     this.methodCall,
+    this.printOutput,
     this.pendingCallIds,
     this.error,
     this.errorType,
@@ -63,6 +68,9 @@ final class WasmProgressResult {
 
   /// The return value (when state is `'complete'`).
   final Object? value;
+
+  /// Captured Python `print()` output (when state is `'complete'`).
+  final String? printOutput;
 
   /// The external function name (when state is `'pending'`).
   final String? functionName;

--- a/packages/dart_monty_wasm/lib/src/wasm_bindings_js.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_bindings_js.dart
@@ -76,6 +76,7 @@ class WasmBindingsJs extends WasmBindings {
     return WasmRunResult(
       ok: map['ok'] as bool,
       value: map['value'],
+      printOutput: map['print_output'] as String?,
       error: map['error'] as String?,
       errorType: map['errorType'] as String?,
       excType: map['excType'] as String?,
@@ -195,6 +196,7 @@ class WasmBindingsJs extends WasmBindings {
       ok: map['ok'] as bool,
       state: map['state'] as String?,
       value: map['value'],
+      printOutput: map['print_output'] as String?,
       functionName: map['functionName'] as String?,
       arguments: args != null ? List<Object?>.from(args) : null,
       kwargs: rawKwargs != null ? Map<String, Object?>.from(rawKwargs) : null,

--- a/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
@@ -124,6 +124,7 @@ class WasmCoreBindings implements MontyCoreBindings {
         ok: true,
         value: result.value,
         usage: _makeUsage(elapsedMs),
+        printOutput: result.printOutput,
       );
     }
     return CoreRunResult(
@@ -153,6 +154,7 @@ class WasmCoreBindings implements MontyCoreBindings {
           state: 'complete',
           value: progress.value,
           usage: _makeUsage(elapsedMs),
+          printOutput: progress.printOutput,
         );
 
       case 'pending':


### PR DESCRIPTION
## Summary
- `CoreProgressResult` was missing `printOutput` field — iterative execution (start/resume) silently dropped captured `print()` output
- `BaseMontyPlatform.translateProgress` never passed `printOutput` to `MontyResult` in the `complete` case
- WASM path (`WasmRunResult`, `WasmProgressResult`, `WasmBindingsJs`, `WasmCoreBindings`) also missing `printOutput` plumbing

## Changes
- **dart_monty_platform_interface**: Add `printOutput` field to `CoreProgressResult`, pass it through in `translateProgress`
- **dart_monty_ffi**: Read `print_output` from JSON in `FfiCoreBindings._translateProgressResult`
- **dart_monty_wasm**: Add `printOutput` to `WasmRunResult` and `WasmProgressResult`, decode from JSON in `WasmBindingsJs`, forward in `WasmCoreBindings`

## Test plan
- [x] platform_interface: 314+ tests pass
- [x] dart_monty_wasm: 67 tests pass
- [x] dart_monty_ffi: 129 tests pass (pre-existing ffigen compile error unrelated)
- [x] `dart format` clean on all changed files
- [x] `dart analyze` clean on all packages except pre-existing dart_monty_ffi ffigen issue