### PR TITLE
chore(ci): add 90%+ patch coverage gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,6 +135,13 @@ jobs:
           needs-format: 'true'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           codecov-flag: ${{ matrix.target }}
+      - name: Upload lcov artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-${{ matrix.target }}
+          path: packages/${{ matrix.target }}/coverage/lcov.info
+          retention-days: 1
 
   test-native:
     name: Test (dart_monty_native)
@@ -163,6 +170,13 @@ jobs:
           min-coverage: '70'
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
           codecov-flag: dart_monty_native
+      - name: Upload lcov artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-dart_monty_native
+          path: packages/dart_monty_native/coverage/lcov.info
+          retention-days: 1
 
   test-web:
     name: Test (dart_monty_web)
@@ -412,3 +426,46 @@ jobs:
       - name: Build WASM
         working-directory: native
         run: cargo build --release --target wasm32-wasip1-threads
+
+  patch-coverage:
+    name: Patch coverage gate (90%)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [test, test-native]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install diff-cover
+        run: pip install diff-cover
+      - name: Download all lcov artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lcov-*
+          path: coverage-artifacts
+      - name: Merge lcov files
+        run: |
+          sudo apt-get update && sudo apt-get install -y lcov
+          LCOV_FILES=""
+          for f in coverage-artifacts/*/lcov.info; do
+            if [ -f "$f" ]; then
+              echo "Found: $f"
+              LCOV_FILES="$LCOV_FILES -a $f"
+            fi
+          done
+          if [ -z "$LCOV_FILES" ]; then
+            echo "ERROR: No lcov files found"
+            exit 1
+          fi
+          lcov $LCOV_FILES -o merged-coverage.info
+          echo "Merged coverage written to merged-coverage.info"
+      - name: Check patch coverage
+        run: |
+          diff-cover merged-coverage.info \
+            --compare-branch=origin/${{ github.base_ref }} \
+            --fail-under=90 \
+            --diff-range-notation='..'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,47 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 90%
+        threshold: 0%
+
+flags:
+  dart_monty_platform_interface:
+    paths:
+      - packages/dart_monty_platform_interface/
+    carryforward: true
+  dart_monty_ffi:
+    paths:
+      - packages/dart_monty_ffi/
+    carryforward: true
+  dart_monty_wasm:
+    paths:
+      - packages/dart_monty_wasm/
+    carryforward: true
+  dart_monty_native:
+    paths:
+      - packages/dart_monty_native/
+    carryforward: true
+  native:
+    paths:
+      - native/
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,components"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true
+  after_n_builds: 5


### PR DESCRIPTION
## Summary
- Add **90% patch coverage gate** that fails PRs where new/changed lines lack test coverage
- Two enforcement layers: Codecov status check (`codecov/patch`) + explicit `diff-cover` CI job
- Upload lcov artifacts from all Dart test jobs for merged diff analysis

## Changes
- **codecov.yml** (new): Configures Codecov patch coverage threshold at 90%, per-package flags with carryforward, and project-level tracking
- **.github/workflows/ci.yaml**: Adds `Upload lcov artifact` steps to `test` (matrix) and `test-native` jobs; adds `patch-coverage` job that merges lcov files and runs `diff-cover --fail-under=90`

## How it works
1. Existing test jobs upload their `lcov.info` as GitHub artifacts (alongside the existing Codecov upload)
2. New `patch-coverage` job downloads all lcov artifacts, merges them with `lcov`, then runs `diff-cover` against the PR's base branch
3. Codecov independently posts a `codecov/patch` status check based on the same data
4. Either mechanism failing will block the PR (Codecov requires adding `codecov/patch` as a required status check in branch protection)

## Test plan
- [x] CI workflow YAML validates (no syntax errors)
- [x] `patch-coverage` job only runs on `pull_request` events (skipped on push to main)
- [x] `diff-cover --fail-under=90` exits non-zero when patch coverage < 90%
- [ ] Verify `codecov/patch` status check appears on this PR after CI completes
- [ ] Verify lcov artifacts are uploaded correctly from all test matrix entries

Refs #101