### PR TITLE
fix(ladder): remove xfail on syntax error test

### DIFF
--- a/test/fixtures/python_ladder/tier_05_errors.json
+++ b/test/fixtures/python_ladder/tier_05_errors.json
@@ -44,8 +44,7 @@
     "externalFunctions": null,
     "resumeValues": null,
     "resumeErrors": null,
-    "nativeOnly": false,
-    "xfail": "monty_create throws StateError for syntax errors, not MontyException"
+    "nativeOnly": false
   },
   {
     "id": 43,


### PR DESCRIPTION
## Summary
- Remove `xfail` marker from tier_05_errors syntax error test
- Fork migration (#99) fixed `monty_create` to throw `MontyException` instead of `StateError` for syntax errors
- Ladder now passes 112/112 natively

## Test plan
- [x] `dart test --tags=ladder --run-skipped` — 112/112 pass