### PR TITLE
fix(ladder): use npm install --force for ARM64 WASM compatibility

### DIFF
--- a/tool/test_python_ladder.sh
+++ b/tool/test_python_ladder.sh
@@ -136,7 +136,10 @@ echo "  Native ladder: PASSED"
 echo ""
 echo "--- Building web bundle ---"
 cd "$SPIKE"
-npm install
+# --force: @pydantic/monty-wasm32-wasi declares cpu:wasm32 but the WASM binary
+# is architecture-independent. Without --force, npm refuses on ARM64 hosts.
+# See: https://github.com/runyaga/monty/issues/4
+npm install --force
 
 echo "  esbuild: bundle worker"
 npx esbuild web/monty_worker_src.js \
@@ -291,7 +294,7 @@ echo ""
 echo "--- Building WASM package bridge ---"
 if [ -d "$WASM_PKG/js" ]; then
   cd "$WASM_PKG/js"
-  npm install
+  npm install --force
   npm run build
 
   # -------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `--force` to both `npm install` calls in `tool/test_python_ladder.sh`
- `@pydantic/monty-wasm32-wasi` declares `cpu:wasm32` but the WASM binary is architecture-independent
- Without `--force`, the ladder script fails on ARM64 (Apple Silicon) and x86_64 hosts

## Related
- runyaga/monty#4 — proper fix (remove cpu restriction from npm package)

## Test plan
- [x] `npm install --force` succeeds on ARM64 Mac
- [x] WASM web bundle builds after forced install