### PR TITLE
feat(cancel): wire CancellableTracker across Dart layer stack

### DIFF
--- a/native/include/dart_monty.h
+++ b/native/include/dart_monty.h
@@ -266,6 +266,60 @@ void monty_set_time_limit_ms(MontyHandle *handle, uint64_t ms);
 void monty_set_stack_limit(MontyHandle *handle, size_t depth);
 
 /* ------------------------------------------------------------------ */
+/* Cancellation (CancellableTracker)                                  */
+/* ------------------------------------------------------------------ */
+
+/* Direct-pointer API — same-isolate only, requires valid handle.     */
+
+/**
+ * Request cancellation. Sets the atomic cancel flag.
+ * The next bytecode boundary check raises KeyboardInterrupt.
+ * Idempotent — safe to call multiple times. Thread-safe.
+ * No-op if handle is NULL.
+ */
+void monty_cancel(const MontyHandle *handle);
+
+/**
+ * Check whether the cancel flag is set.
+ * Returns 1 if cancelled, 0 if not, -1 if handle is NULL.
+ */
+int monty_is_cancelled(const MontyHandle *handle);
+
+/**
+ * Reset the cancel flag. Call before reusing a handle after cancel.
+ * No-op if handle is NULL.
+ */
+void monty_reset_cancel(const MontyHandle *handle);
+
+/* Registry API — cross-isolate safe, UAF-immune.                     */
+
+/**
+ * Get the monotonic handle ID for cross-isolate cancel.
+ * Returns 0 if handle is NULL or not registered.
+ */
+uint64_t monty_get_handle_id(const MontyHandle *handle);
+
+/**
+ * Cancel a handle by its registry ID. Works from any thread/isolate.
+ * Returns 0 on success, -1 if not found, -2 if cancel flag was dropped.
+ */
+int monty_cancel_by_id(uint64_t handle_id);
+
+/**
+ * Check whether a handle is cancelled by registry ID.
+ * Returns 1 if cancelled, 0 if not cancelled, -1 if not found.
+ */
+int monty_is_cancelled_by_id(uint64_t handle_id);
+
+/**
+ * Free a MontyHandle by its registry ID. Safe from any thread.
+ * Returns 1 if the handle was found and freed, 0 if not found.
+ * Used by supervisor to clean up after crash-only disposal when the
+ * worker isolate was killed before it could call monty_free().
+ */
+int monty_free_by_id(uint64_t handle_id);
+
+/* ------------------------------------------------------------------ */
 /* Memory management                                                  */
 /* ------------------------------------------------------------------ */
 

--- a/native/src/handle.rs
+++ b/native/src/handle.rs
@@ -24,6 +24,13 @@ use crate::error::monty_exception_to_json;
 static CANCEL_REGISTRY: LazyLock<RwLock<HashMap<u64, Weak<AtomicBool>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// Global registry mapping handle IDs to raw pointers (as `usize` for Send+Sync).
+/// Used by `free_by_id` to free a handle when the owning isolate is dead.
+/// Entries are added by `register_handle_ptr` (called from `monty_create`)
+/// and removed by `MontyHandle::Drop` or `free_by_id`.
+static HANDLE_REGISTRY: LazyLock<RwLock<HashMap<u64, usize>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
 /// Monotonic handle ID counter. Eliminates ABA problem from address reuse.
 static NEXT_HANDLE_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -735,9 +742,47 @@ pub fn is_cancelled_by_id(handle_id: u64) -> i32 {
     }
 }
 
+/// Register a raw handle pointer in the handle registry.
+/// Called from `monty_create` after `Box::into_raw`.
+pub fn register_handle_ptr(handle_id: u64, ptr: *mut MontyHandle) {
+    HANDLE_REGISTRY
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(handle_id, ptr as usize);
+}
+
+/// Free a handle by its registry ID. Returns `true` if found and freed.
+/// Used by the supervisor to clean up after crash-only disposal when the
+/// worker isolate was killed before it could call `monty_free`.
+///
+/// # Safety
+/// The caller MUST ensure that no other thread is using the handle.
+/// In the crash-only model, this means the worker isolate must have exited
+/// (or timed out) before calling this.
+pub fn free_by_id(handle_id: u64) -> bool {
+    let ptr = HANDLE_REGISTRY
+        .write()
+        .unwrap_or_else(|e| e.into_inner())
+        .remove(&handle_id);
+
+    match ptr {
+        Some(addr) => {
+            // SAFETY: The pointer was created by Box::into_raw in monty_create,
+            // and the caller guarantees no other thread is using it.
+            drop(unsafe { Box::from_raw(addr as *mut MontyHandle) });
+            true
+        }
+        None => false,
+    }
+}
+
 impl Drop for MontyHandle {
     fn drop(&mut self) {
         CANCEL_REGISTRY
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&self.handle_id);
+        HANDLE_REGISTRY
             .write()
             .unwrap_or_else(|e| e.into_inner())
             .remove(&self.handle_id);

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -86,7 +86,12 @@ pub unsafe extern "C" fn monty_create(
     };
 
     match catch_ffi_panic(|| MontyHandle::new(code_str, ext_fn_list, name)) {
-        Ok(Ok(handle)) => Box::into_raw(Box::new(handle)),
+        Ok(Ok(handle)) => {
+            let id = handle.handle_id();
+            let ptr = Box::into_raw(Box::new(handle));
+            handle::register_handle_ptr(id, ptr);
+            ptr
+        }
         Ok(Err(exc)) => {
             if !out_error.is_null() {
                 unsafe { *out_error = to_c_string(&exc.summary()) };
@@ -174,6 +179,19 @@ pub extern "C" fn monty_cancel_by_id(handle_id: u64) -> c_int {
 #[unsafe(no_mangle)]
 pub extern "C" fn monty_is_cancelled_by_id(handle_id: u64) -> c_int {
     handle::is_cancelled_by_id(handle_id) as c_int
+}
+
+/// Free a handle by its registry ID. Safe from any thread.
+/// Returns 1 if found and freed, 0 if not found.
+///
+/// Used by the supervisor to clean up after crash-only disposal when the
+/// worker isolate was killed before it could call `monty_free`.
+///
+/// # Safety
+/// The caller MUST ensure that the worker isolate has exited before calling.
+#[unsafe(no_mangle)]
+pub extern "C" fn monty_free_by_id(handle_id: u64) -> c_int {
+    if handle::free_by_id(handle_id) { 1 } else { 0 }
 }
 
 // ---------------------------------------------------------------------------
@@ -486,7 +504,12 @@ pub unsafe extern "C" fn monty_restore(
 
     let bytes = unsafe { std::slice::from_raw_parts(data, len) };
     match catch_ffi_panic(|| MontyHandle::restore(bytes)) {
-        Ok(Ok(handle)) => Box::into_raw(Box::new(handle)),
+        Ok(Ok(handle)) => {
+            let id = handle.handle_id();
+            let ptr = Box::into_raw(Box::new(handle));
+            handle::register_handle_ptr(id, ptr);
+            ptr
+        }
         Ok(Err(msg)) => {
             if !out_error.is_null() {
                 unsafe { *out_error = to_c_string(&msg) };

--- a/packages/dart_monty_ffi/lib/src/ffi_core_bindings.dart
+++ b/packages/dart_monty_ffi/lib/src/ffi_core_bindings.dart
@@ -19,10 +19,29 @@ import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart
 /// ```
 class FfiCoreBindings implements MontyCoreBindings {
   /// Creates an [FfiCoreBindings] backed by [bindings].
-  FfiCoreBindings({required NativeBindings bindings}) : _bindings = bindings;
+  ///
+  /// If [onHandleCreated] is provided, it is called synchronously after a
+  /// handle is created (in [run] and [start]) with the monotonic handle ID.
+  /// Used by the isolate worker to send the handle ID to the supervisor
+  /// before entering a potentially blocking FFI call.
+  FfiCoreBindings({
+    required NativeBindings bindings,
+    this.onHandleCreated,
+  }) : _bindings = bindings;
 
   final NativeBindings _bindings;
   int? _handle;
+
+  /// Monotonic handle ID for cross-isolate cancel.
+  int? _handleId;
+
+  /// The handle ID, available after [run] or [start] calls `create()`.
+  @override
+  int? get handleId => _handleId;
+
+  /// Optional callback invoked after a handle is created, before blocking
+  /// execution begins.
+  final void Function(int handleId)? onHandleCreated;
 
   @override
   Future<bool> init() async => true;
@@ -34,6 +53,11 @@ class FfiCoreBindings implements MontyCoreBindings {
     String? scriptName,
   }) async {
     final handle = _bindings.create(code, scriptName: scriptName);
+    final hid = _bindings.getHandleId(handle);
+    _handleId = hid;
+    if (hid > 0) {
+      onHandleCreated?.call(hid);
+    }
     try {
       _applyLimits(handle, limitsJson);
       final result = _bindings.run(handle);
@@ -41,6 +65,7 @@ class FfiCoreBindings implements MontyCoreBindings {
       return _translateRunResult(result);
     } finally {
       _bindings.free(handle);
+      _handleId = null;
     }
   }
 
@@ -57,12 +82,18 @@ class FfiCoreBindings implements MontyCoreBindings {
       externalFunctions: extFns,
       scriptName: scriptName,
     );
+    final hid = _bindings.getHandleId(handle);
+    _handleId = hid;
+    if (hid > 0) {
+      onHandleCreated?.call(hid);
+    }
     final ProgressResult progress;
     try {
       _applyLimits(handle, limitsJson);
       progress = _bindings.start(handle);
     } catch (e) {
       _bindings.free(handle);
+      _handleId = null;
       rethrow;
     }
     // Translation assumes ownership of handle lifecycle
@@ -115,6 +146,15 @@ class FfiCoreBindings implements MontyCoreBindings {
   @override
   Future<void> restoreSnapshot(Uint8List data) async {
     _handle = _bindings.restore(data);
+    _handleId = _bindings.getHandleId(_handle!);
+  }
+
+  @override
+  Future<void> cancel() async {
+    final handle = _handle;
+    if (handle != null) {
+      _bindings.cancel(handle);
+    }
   }
 
   @override
@@ -123,6 +163,7 @@ class FfiCoreBindings implements MontyCoreBindings {
     if (handle != null) {
       _bindings.free(handle);
       _handle = null;
+      _handleId = null;
     }
   }
 
@@ -152,6 +193,7 @@ class FfiCoreBindings implements MontyCoreBindings {
     }
 
     // tag == 1: error
+
     final resultJson = result.resultJson;
     if (resultJson != null) {
       final jsonMap = json.decode(resultJson) as Map<String, dynamic>;
@@ -230,6 +272,10 @@ class FfiCoreBindings implements MontyCoreBindings {
         );
 
       case 2: // error
+        // TODO(WU-5): Map excType to sealed MontyError hierarchy:
+        //   KeyboardInterrupt → MontyCancelledError
+        //   MemoryLimitExceeded/timeout → MontyResourceError
+        //   Other excTypes → MontyScriptError(message, excType: excType)
         _freeHandle(handle);
         final errorResultJson = progress.resultJson;
         if (errorResultJson != null) {
@@ -291,6 +337,7 @@ class FfiCoreBindings implements MontyCoreBindings {
   void _freeHandle(int handle) {
     if (_handle == handle) {
       _handle = null;
+      _handleId = null;
     }
     _bindings.free(handle);
   }

--- a/packages/dart_monty_ffi/lib/src/generated/dart_monty_bindings.dart
+++ b/packages/dart_monty_ffi/lib/src/generated/dart_monty_bindings.dart
@@ -499,6 +499,122 @@ class DartMontyBindings {
   late final _monty_set_stack_limit = _monty_set_stack_limitPtr
       .asFunction<void Function(ffi.Pointer<MontyHandle>, int)>();
 
+  /// Request cancellation. Sets the atomic cancel flag.
+  /// The next bytecode boundary check raises KeyboardInterrupt.
+  /// Idempotent — safe to call multiple times. Thread-safe.
+  /// No-op if handle is NULL.
+  void monty_cancel(
+    ffi.Pointer<MontyHandle> handle,
+  ) {
+    return _monty_cancel(
+      handle,
+    );
+  }
+
+  late final _monty_cancelPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MontyHandle>)>>(
+          'monty_cancel');
+  late final _monty_cancel =
+      _monty_cancelPtr.asFunction<void Function(ffi.Pointer<MontyHandle>)>();
+
+  /// Check whether the cancel flag is set.
+  /// Returns 1 if cancelled, 0 if not, -1 if handle is NULL.
+  int monty_is_cancelled(
+    ffi.Pointer<MontyHandle> handle,
+  ) {
+    return _monty_is_cancelled(
+      handle,
+    );
+  }
+
+  late final _monty_is_cancelledPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Pointer<MontyHandle>)>>(
+          'monty_is_cancelled');
+  late final _monty_is_cancelled = _monty_is_cancelledPtr
+      .asFunction<int Function(ffi.Pointer<MontyHandle>)>();
+
+  /// Reset the cancel flag. Call before reusing a handle after cancel.
+  /// No-op if handle is NULL.
+  void monty_reset_cancel(
+    ffi.Pointer<MontyHandle> handle,
+  ) {
+    return _monty_reset_cancel(
+      handle,
+    );
+  }
+
+  late final _monty_reset_cancelPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MontyHandle>)>>(
+          'monty_reset_cancel');
+  late final _monty_reset_cancel = _monty_reset_cancelPtr
+      .asFunction<void Function(ffi.Pointer<MontyHandle>)>();
+
+  /// Get the monotonic handle ID for cross-isolate cancel.
+  /// Returns 0 if handle is NULL or not registered.
+  int monty_get_handle_id(
+    ffi.Pointer<MontyHandle> handle,
+  ) {
+    return _monty_get_handle_id(
+      handle,
+    );
+  }
+
+  late final _monty_get_handle_idPtr = _lookup<
+          ffi.NativeFunction<ffi.Uint64 Function(ffi.Pointer<MontyHandle>)>>(
+      'monty_get_handle_id');
+  late final _monty_get_handle_id = _monty_get_handle_idPtr
+      .asFunction<int Function(ffi.Pointer<MontyHandle>)>();
+
+  /// Cancel a handle by its registry ID. Works from any thread/isolate.
+  /// Returns 0 on success, -1 if not found, -2 if cancel flag was dropped.
+  int monty_cancel_by_id(
+    int handle_id,
+  ) {
+    return _monty_cancel_by_id(
+      handle_id,
+    );
+  }
+
+  late final _monty_cancel_by_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Uint64)>>(
+          'monty_cancel_by_id');
+  late final _monty_cancel_by_id =
+      _monty_cancel_by_idPtr.asFunction<int Function(int)>();
+
+  /// Check whether a handle is cancelled by registry ID.
+  /// Returns 1 if cancelled, 0 if not cancelled, -1 if not found.
+  int monty_is_cancelled_by_id(
+    int handle_id,
+  ) {
+    return _monty_is_cancelled_by_id(
+      handle_id,
+    );
+  }
+
+  late final _monty_is_cancelled_by_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Uint64)>>(
+          'monty_is_cancelled_by_id');
+  late final _monty_is_cancelled_by_id =
+      _monty_is_cancelled_by_idPtr.asFunction<int Function(int)>();
+
+  /// Free a MontyHandle by its registry ID. Safe from any thread.
+  /// Returns 1 if the handle was found and freed, 0 if not found.
+  /// Used by supervisor to clean up after crash-only disposal when the
+  /// worker isolate was killed before it could call monty_free().
+  int monty_free_by_id(
+    int handle_id,
+  ) {
+    return _monty_free_by_id(
+      handle_id,
+    );
+  }
+
+  late final _monty_free_by_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Uint64)>>(
+          'monty_free_by_id');
+  late final _monty_free_by_id =
+      _monty_free_by_idPtr.asFunction<int Function(int)>();
+
   /// Free a string returned by any monty_* function. Safe with NULL.
   void monty_string_free(
     ffi.Pointer<ffi.Char> ptr,

--- a/packages/dart_monty_ffi/lib/src/monty_ffi.dart
+++ b/packages/dart_monty_ffi/lib/src/monty_ffi.dart
@@ -25,6 +25,16 @@ class MontyFfi extends BaseMontyPlatform
     return MontyFfi._(coreBindings: core, nativeBindings: bindings);
   }
 
+  /// Creates a [MontyFfi] with pre-built [FfiCoreBindings].
+  ///
+  /// Used by the isolate worker to inject callback-configured core bindings
+  /// (e.g. with [FfiCoreBindings.onHandleCreated] for cancel support).
+  MontyFfi.withCore({
+    required FfiCoreBindings coreBindings,
+    required NativeBindings nativeBindings,
+  })  : _nativeBindings = nativeBindings,
+        super(bindings: coreBindings);
+
   MontyFfi._({
     required FfiCoreBindings coreBindings,
     required NativeBindings nativeBindings,

--- a/packages/dart_monty_ffi/lib/src/native_bindings.dart
+++ b/packages/dart_monty_ffi/lib/src/native_bindings.dart
@@ -135,4 +135,34 @@ abstract class NativeBindings {
   ///
   /// Returns the new handle address as an `int`, or throws on error.
   int restore(Uint8List data);
+
+  // ---------------------------------------------------------------------------
+  // Cancellation (CancellableTracker)
+  // ---------------------------------------------------------------------------
+
+  /// Cancel the interpreter. Sets atomic cancel flag. Idempotent.
+  /// No-op if handle is 0.
+  void cancel(int handle);
+
+  /// Check if the cancel flag is set.
+  /// Returns `true` if cancelled, `false` if not, or throws if handle invalid.
+  bool isCancelled(int handle);
+
+  /// Reset the cancel flag. Only valid after cancel (v2 — rarely needed).
+  /// No-op if handle is 0.
+  void resetCancel(int handle);
+
+  /// Get the monotonic handle ID for cross-isolate cancel.
+  /// Returns 0 if handle is invalid.
+  int getHandleId(int handle);
+
+  /// Cancel by registry ID. Returns `true` if found and cancelled.
+  bool cancelById(int handleId);
+
+  /// Check if cancelled by registry ID.
+  /// Returns `null` if handle not found, `true` if cancelled, `false` if not.
+  bool? isCancelledById(int handleId);
+
+  /// Free a handle by its registry ID. Returns `true` if found and freed.
+  bool freeById(int handleId);
 }

--- a/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
+++ b/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
@@ -25,9 +25,32 @@ class NativeBindingsFfi extends NativeBindings {
               : DynamicLibrary.open(
                   NativeLibraryLoader.resolve(overridePath: libraryPath),
                 ),
-        );
+        ) {
+    _instance ??= this;
+    BaseMontyPlatform.registerNativeCancel(
+      cancelById: (id) => instanceOrNull?.cancelById(id) ?? false,
+      isCancelledById: (id) => instanceOrNull?.isCancelledById(id),
+      ensureInitialized: NativeBindingsFfi.ensureInitialized,
+    );
+  }
 
   final DartMontyBindings _lib;
+
+  // ---------------------------------------------------------------------------
+  // Singleton for cross-isolate cancelById access
+  // ---------------------------------------------------------------------------
+
+  static NativeBindingsFfi? _instance;
+
+  /// Nullable accessor for cancelById callers that check initialization.
+  static NativeBindingsFfi? get instanceOrNull => _instance;
+
+  /// Ensure the FFI library is loaded in the current isolate.
+  /// Must be called before static cancel operations.
+  /// Safe to call multiple times (idempotent, first-write-wins).
+  static void ensureInitialized([String? libraryPath]) {
+    _instance ??= NativeBindingsFfi(libraryPath: libraryPath);
+  }
 
   @override
   int create(
@@ -239,6 +262,58 @@ class NativeBindingsFfi extends NativeBindings {
         ..free(cData)
         ..free(outError);
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cancellation (CancellableTracker)
+  // ---------------------------------------------------------------------------
+
+  @override
+  void cancel(int handle) {
+    if (handle == 0) return;
+    _lib.monty_cancel(Pointer<MontyHandle>.fromAddress(handle));
+  }
+
+  @override
+  bool isCancelled(int handle) {
+    if (handle == 0) return false;
+    final result = _lib.monty_is_cancelled(
+      Pointer<MontyHandle>.fromAddress(handle),
+    );
+    return result == 1;
+  }
+
+  @override
+  void resetCancel(int handle) {
+    if (handle == 0) return;
+    _lib.monty_reset_cancel(Pointer<MontyHandle>.fromAddress(handle));
+  }
+
+  @override
+  int getHandleId(int handle) {
+    if (handle == 0) return 0;
+    return _lib.monty_get_handle_id(
+      Pointer<MontyHandle>.fromAddress(handle),
+    );
+  }
+
+  @override
+  bool cancelById(int handleId) {
+    final result = _lib.monty_cancel_by_id(handleId);
+    return result == 0;
+  }
+
+  @override
+  bool? isCancelledById(int handleId) {
+    final result = _lib.monty_is_cancelled_by_id(handleId);
+    if (result == -1) return null; // not found
+    return result == 1;
+  }
+
+  @override
+  bool freeById(int handleId) {
+    final result = _lib.monty_free_by_id(handleId);
+    return result == 1;
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/dart_monty_ffi/lib/src/native_isolate_bindings_impl.dart
+++ b/packages/dart_monty_ffi/lib/src/native_isolate_bindings_impl.dart
@@ -121,6 +121,21 @@ final class _GenericErrorResponse extends _Response {
   final String message;
 }
 
+/// Carries a sealed [MontyError] subtype across the isolate boundary.
+final class _MontyErrorResponse extends _Response {
+  const _MontyErrorResponse(super.id, this.error);
+  final MontyError error;
+}
+
+/// Notification sent from the worker isolate to the supervisor with the
+/// monotonic handle ID, immediately after create() and before blocking
+/// run()/start(). This prevents the handleId-routing deadlock where an
+/// infinite loop would never send a response containing the handleId.
+final class _HandleIdNotification {
+  const _HandleIdNotification(this.handleId);
+  final int handleId;
+}
+
 // =============================================================================
 // Isolate entry point
 // =============================================================================
@@ -134,8 +149,16 @@ Future<void> _isolateMain(_InitMessage init) async {
   final receivePort = ReceivePort();
   init.mainSendPort.send(_ReadyMessage(receivePort.sendPort));
 
-  var monty = MontyFfi(
-    bindings: NativeBindingsFfi(libraryPath: init.libraryPath),
+  final nativeBindings = NativeBindingsFfi(libraryPath: init.libraryPath);
+  final ffiCoreBindings = FfiCoreBindings(
+    bindings: nativeBindings,
+    onHandleCreated: (handleId) {
+      init.mainSendPort.send(_HandleIdNotification(handleId));
+    },
+  );
+  var monty = MontyFfi.withCore(
+    coreBindings: ffiCoreBindings,
+    nativeBindings: nativeBindings,
   );
 
   await for (final message in receivePort) {
@@ -203,6 +226,8 @@ Future<void> _isolateMain(_InitMessage init) async {
 
           return;
       }
+    } on MontyError catch (e) {
+      init.mainSendPort.send(_MontyErrorResponse(message.id, e));
     } on MontyException catch (e) {
       init.mainSendPort.send(_ErrorResponse(message.id, e));
     } on Object catch (e) {
@@ -229,10 +254,17 @@ class NativeIsolateBindingsImpl extends NativeIsolateBindings {
   ///
   /// If [libraryPath] is provided, it is forwarded to [NativeBindingsFfi]
   /// inside the Isolate to override the default library lookup.
-  NativeIsolateBindingsImpl({this.libraryPath});
+  ///
+  /// If [initTimeout] is provided, the isolate must send [_ReadyMessage]
+  /// within this duration or [init] throws a [StateError].
+  NativeIsolateBindingsImpl({this.libraryPath, this.initTimeout});
 
   /// Optional path to the native shared library.
   final String? libraryPath;
+
+  /// Timeout for the worker isolate to send [_ReadyMessage] during [init].
+  /// Defaults to 30 seconds if not provided.
+  final Duration? initTimeout;
 
   Isolate? _isolate;
   SendPort? _sendPort;
@@ -240,15 +272,37 @@ class NativeIsolateBindingsImpl extends NativeIsolateBindings {
   int _nextId = 0;
   final Map<int, Completer<_Response>> _pending = {};
 
+  /// Monotonic handle ID received from the worker isolate via
+  /// [_HandleIdNotification]. Available after the first run/start request.
+  int? _handleId;
+
+  /// The handle ID for cross-isolate cancel, or `null` if not yet available.
+  int? get handleId => _handleId;
+
+  Completer<void>? _exitCompleter;
+
+  /// Number of worker isolates that failed to exit within the terminate
+  /// timeout and were force-killed.
+  static int _zombieCount = 0;
+
+  /// The number of zombie worker isolates observed so far.
+  static int get zombieCount => _zombieCount;
+
   @override
   Future<bool> init() async {
     final receivePort = ReceivePort();
     _receivePort = receivePort;
+    _exitCompleter = Completer<void>();
     final completer = Completer<SendPort>();
 
     receivePort.listen((message) {
       if (message is _ReadyMessage) {
         completer.complete(message.sendPort);
+
+        return;
+      }
+      if (message is _HandleIdNotification) {
+        _handleId = message.handleId;
 
         return;
       }
@@ -258,13 +312,27 @@ class NativeIsolateBindingsImpl extends NativeIsolateBindings {
 
         return;
       }
-      // Isolate exit (null) or error (List<String>) — fail pending futures.
+      // Isolate exit (null from addOnExitListener).
+      if (message == null) {
+        if (_exitCompleter != null && !_exitCompleter!.isCompleted) {
+          _exitCompleter!.complete();
+        }
+        if (!completer.isCompleted) {
+          completer.completeError(
+            StateError('Isolate exited before sending _ReadyMessage'),
+          );
+        }
+        _failAllPending('Isolate exited');
+
+        return;
+      }
+      // Isolate error (List from addErrorListener) — fail pending futures.
       if (!completer.isCompleted) {
         completer.completeError(
           StateError('Isolate failed to start: $message'),
         );
       }
-      _failAllPending('Isolate exited unexpectedly: $message');
+      _failAllPending('Isolate error: $message');
     });
 
     final isolate = await Isolate.spawn(
@@ -277,7 +345,19 @@ class NativeIsolateBindingsImpl extends NativeIsolateBindings {
       ..addOnExitListener(receivePort.sendPort)
       ..addErrorListener(receivePort.sendPort);
 
-    _sendPort = await completer.future;
+    _sendPort = await completer.future.timeout(
+      initTimeout ?? const Duration(seconds: 30),
+      onTimeout: () => throw StateError(
+        'Worker isolate failed to initialize within timeout. '
+        'Possible silent crash before _ReadyMessage was sent.',
+      ),
+    );
+
+    // Initialize FFI on the main isolate so that MontyCancelToken and
+    // direct NativeBindingsFfi access work cross-isolate.  Dart static
+    // state is per-isolate, so the worker's NativeBindingsFfi registration
+    // does not propagate here.
+    NativeBindingsFfi.ensureInitialized(libraryPath);
 
     return true;
   }
@@ -383,7 +463,66 @@ class NativeIsolateBindingsImpl extends NativeIsolateBindings {
       _isolate = null;
       _sendPort = null;
       _receivePort = null;
+      _handleId = null;
     }
+  }
+
+  /// Cancel the current execution via `cancelById` (cross-isolate safe).
+  ///
+  /// No-op if the handle ID has not been received yet.
+  Future<void> cancel() async {
+    final hid = _handleId;
+    if (hid != null) {
+      NativeBindingsFfi.ensureInitialized(libraryPath);
+      NativeBindingsFfi.instanceOrNull?.cancelById(hid);
+    }
+  }
+
+  /// Cancel and force-kill the worker isolate.
+  ///
+  /// Waits up to 5 seconds for the isolate to exit gracefully after cancel.
+  /// If the isolate does not exit in time, it is killed and counted as a
+  /// zombie (the Rust handle may leak because `freeById` is skipped to
+  /// avoid use-after-free on the Rust handle).
+  Future<void> terminate() async {
+    await cancel();
+    // Ask the worker to exit cleanly.  After cancel halts execution the
+    // worker is idle in its event loop; sending dispose lets it shut down
+    // gracefully so we avoid the zombie/skip-freeById path.
+    _sendPort?.send(_DisposeRequest(_nextId++));
+    if (_exitCompleter != null && !_exitCompleter!.isCompleted) {
+      final exited = await _exitCompleter!.future
+          .timeout(const Duration(seconds: 5))
+          .then((_) => true)
+          .onError((_, __) => false);
+      if (!exited) {
+        _zombieCount++;
+        _cleanupAfterCrashDisposal(skipFreeById: true);
+
+        return;
+      }
+    }
+    _cleanupAfterCrashDisposal();
+  }
+
+  /// Crash-only cleanup: kill isolate, close port, free Rust handle.
+  ///
+  /// If [skipFreeById] is `true`, the Rust handle is NOT freed via
+  /// `freeById` — used when the isolate did not exit cleanly and the
+  /// handle may already be invalid (prevents use-after-free).
+  void _cleanupAfterCrashDisposal({bool skipFreeById = false}) {
+    _isolate?.kill(priority: Isolate.immediate);
+    _receivePort?.close();
+    _receivePort = null;
+    _isolate = null;
+    _failAllPending('Isolate crashed or was force-killed');
+    if (_handleId != null) {
+      if (!skipFreeById) {
+        NativeBindingsFfi.instanceOrNull?.freeById(_handleId!);
+      }
+      _handleId = null;
+    }
+    _sendPort = null;
   }
 
   // ---------------------------------------------------------------------------
@@ -399,6 +538,9 @@ class NativeIsolateBindingsImpl extends NativeIsolateBindings {
     _sendPort?.send(request);
 
     return completer.future.then((response) {
+      if (response is _MontyErrorResponse) {
+        throw response.error;
+      }
       if (response is _ErrorResponse) {
         throw response.exception;
       }

--- a/packages/dart_monty_ffi/test/cancel_t1_1_end_to_end_test.dart
+++ b/packages/dart_monty_ffi/test/cancel_t1_1_end_to_end_test.dart
@@ -1,0 +1,110 @@
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:dart_monty_ffi/dart_monty_ffi.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:test/test.dart';
+
+String _resolveLibraryPath() {
+  final ext = Platform.isMacOS ? 'dylib' : 'so';
+  return '../../native/target/release/libdart_monty_native.$ext';
+}
+
+/// T1-1: End-to-End Cancellation & Idempotency
+///
+/// Verifies that cancel() reliably halts a running interpreter and surfaces
+/// exactly MontyCancelledError, and that repeated cancellation is safe.
+void main() {
+  const infiniteLoop = 'while True: pass';
+  const trivial = '2 + 2';
+  final libPath = _resolveLibraryPath();
+
+  group('cancel during execution', () {
+    for (var trial = 1; trial <= 5; trial++) {
+      test('trial $trial: cancel halts infinite loop with MontyCancelledError',
+          () async {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
+
+        final startFuture = isolate.start(
+          infiniteLoop,
+          externalFunctions: ['__never_called__'],
+        );
+
+        // Give the interpreter time to enter the infinite loop.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        await isolate.cancel();
+
+        await expectLater(
+          startFuture,
+          throwsA(isA<MontyCancelledError>()),
+        );
+
+        await isolate.terminate();
+      });
+    }
+  });
+
+  group('double-cancel idempotency', () {
+    test('second cancel does not throw', () async {
+      final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+      await isolate.init();
+
+      final startFuture = isolate.start(
+        infiniteLoop,
+        externalFunctions: ['__never_called__'],
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      // First cancel — triggers MontyCancelledError.
+      await isolate.cancel();
+      await expectLater(startFuture, throwsA(isA<MontyCancelledError>()));
+
+      // Second cancel — should be a no-op, no throw.
+      await expectLater(isolate.cancel(), completes);
+
+      await isolate.terminate();
+    });
+
+    test('triple cancel does not throw', () async {
+      final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+      await isolate.init();
+
+      final startFuture = isolate.start(
+        infiniteLoop,
+        externalFunctions: ['__never_called__'],
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      await isolate.cancel();
+      await expectLater(startFuture, throwsA(isA<MontyCancelledError>()));
+
+      // Second and third cancel — both should be no-ops.
+      await expectLater(isolate.cancel(), completes);
+      await expectLater(isolate.cancel(), completes);
+
+      await isolate.terminate();
+    });
+  });
+
+  group('cancel after completion', () {
+    test('cancel on completed interpreter is a no-op', () async {
+      final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+      await isolate.init();
+
+      final result = await isolate.run(trivial);
+      expect(result.value, 4);
+
+      // Cancel after completion — should be a no-op.
+      await expectLater(isolate.cancel(), completes);
+
+      await isolate.dispose();
+    });
+  });
+}

--- a/packages/dart_monty_ffi/test/cancel_t1_2_cross_boundary_test.dart
+++ b/packages/dart_monty_ffi/test/cancel_t1_2_cross_boundary_test.dart
@@ -1,0 +1,118 @@
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:dart_monty_ffi/dart_monty_ffi.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:test/test.dart';
+
+String _resolveLibraryPath() {
+  final ext = Platform.isMacOS ? 'dylib' : 'so';
+  return '../../native/target/release/libdart_monty_native.$ext';
+}
+
+/// T1-2: Cross-Boundary CancelToken Routing
+///
+/// Verifies that MontyCancelToken.cancel() correctly routes cancellation
+/// across isolate boundaries. The token is obtained from the worker isolate's
+/// handleId and used to cancel from the supervisor (test) context.
+void main() {
+  const infiniteLoop = 'while True: pass';
+  final libPath = _resolveLibraryPath();
+
+  group('cross-isolate token cancel', () {
+    for (var trial = 1; trial <= 5; trial++) {
+      test('trial $trial: token.cancel() halts worker', () async {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
+
+        final startFuture = isolate.start(
+          infiniteLoop,
+          externalFunctions: ['__never_called__'],
+        );
+
+        // Wait for handleId to arrive via _HandleIdNotification.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final hid = isolate.handleId;
+        expect(hid, isNotNull, reason: 'handleId should be set after start');
+        expect(hid, greaterThan(0));
+
+        // Construct a cancel token and cancel from this isolate.
+        final token = MontyCancelToken(hid!);
+        expect(token.isAlive, isTrue);
+
+        final cancelled = token.cancel();
+        expect(cancelled, isTrue, reason: 'cancel should find the handle');
+
+        await expectLater(
+          startFuture,
+          throwsA(isA<MontyCancelledError>()),
+        );
+
+        await isolate.terminate();
+      });
+    }
+  });
+
+  group('token.isAlive', () {
+    test('isAlive is false after terminate', () async {
+      final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+      await isolate.init();
+
+      final startFuture = isolate.start(
+        infiniteLoop,
+        externalFunctions: ['__never_called__'],
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final hid = isolate.handleId!;
+      final token = MontyCancelToken(hid);
+
+      expect(token.isAlive, isTrue);
+
+      await isolate.cancel();
+      try {
+        await startFuture;
+      } on MontyCancelledError {
+        // Expected.
+      }
+      await isolate.terminate();
+
+      expect(token.isAlive, isFalse);
+    });
+  });
+
+  group('auto-initialization', () {
+    test('token.cancel() auto-initializes FFI without StateError', () async {
+      final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+      await isolate.init();
+
+      final startFuture = isolate.start(
+        infiniteLoop,
+        externalFunctions: ['__never_called__'],
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final hid = isolate.handleId!;
+
+      // MontyCancelToken.cancel() calls BaseMontyPlatform.cancelById()
+      // which calls NativeBindingsFfi.ensureInitialized() automatically.
+      // This should not throw StateError.
+      final token = MontyCancelToken(hid);
+      expect(token.cancel, returnsNormally);
+
+      try {
+        await startFuture;
+      } on MontyCancelledError {
+        // Expected.
+      }
+
+      await isolate.terminate();
+    });
+  });
+}

--- a/packages/dart_monty_ffi/test/cancel_t1_3_terminate_release_test.dart
+++ b/packages/dart_monty_ffi/test/cancel_t1_3_terminate_release_test.dart
@@ -1,0 +1,87 @@
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:dart_monty_ffi/dart_monty_ffi.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:test/test.dart';
+
+String _resolveLibraryPath() {
+  final ext = Platform.isMacOS ? 'dylib' : 'so';
+  return '../../native/target/release/libdart_monty_native.$ext';
+}
+
+/// T1-3: Terminate Resource Release
+///
+/// Verifies that terminate() frees ALL resources: the Rust MontyHandle
+/// (via freeById), the handleId reference, and the isolate.
+void main() {
+  const infiniteLoop = 'while True: pass';
+  final libPath = _resolveLibraryPath();
+
+  group('terminate resource cleanup', () {
+    for (var trial = 1; trial <= 5; trial++) {
+      test('trial $trial: terminate frees Rust registry entry', () async {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
+
+        final startFuture = isolate.start(
+          infiniteLoop,
+          externalFunctions: ['__never_called__'],
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final hid = isolate.handleId;
+        expect(hid, isNotNull);
+        expect(hid, greaterThan(0));
+
+        // Before terminate: handle exists in Rust registry.
+        final preState =
+            NativeBindingsFfi.instanceOrNull?.isCancelledById(hid!);
+        expect(preState, isNotNull, reason: 'handle should be in registry');
+
+        // Guard startFuture so its error does not escape the test zone
+        // during the terminate() await.
+        Object? startError;
+        unawaited(
+          startFuture.then<void>(
+            (_) {},
+            onError: (Object e) {
+              startError = e;
+            },
+          ),
+        );
+
+        await isolate.terminate();
+
+        expect(
+          startError,
+          anyOf(isA<MontyCancelledError>(), isA<MontyException>()),
+        );
+
+        // After terminate: handleId should be null on the Dart side.
+        expect(isolate.handleId, isNull);
+
+        // After terminate: Rust registry should not contain the handle.
+        final postState =
+            NativeBindingsFfi.instanceOrNull?.isCancelledById(hid!);
+        expect(
+          postState,
+          isNull,
+          reason: 'handle should be freed from Rust registry',
+        );
+      });
+    }
+  });
+
+  group('zombie tracking', () {
+    test('zombie count starts at zero or a known baseline', () {
+      // Just verify the static counter is accessible. It should be zero
+      // if no tests have triggered zombie conditions.
+      expect(NativeIsolateBindingsImpl.zombieCount, greaterThanOrEqualTo(0));
+    });
+  });
+}

--- a/packages/dart_monty_ffi/test/mock_native_bindings.dart
+++ b/packages/dart_monty_ffi/test/mock_native_bindings.dart
@@ -237,4 +237,84 @@ class MockNativeBindings extends NativeBindings {
 
     return nextRestoreHandle;
   }
+
+  // ---------------------------------------------------------------------------
+  // Cancellation (CancellableTracker)
+  // ---------------------------------------------------------------------------
+
+  /// Whether cancel has been called and on which handles.
+  final List<int> cancelCalls = [];
+
+  /// Whether isCancelled has been called.
+  final List<int> isCancelledCalls = [];
+
+  /// Return value for [isCancelled]. Defaults to false.
+  bool nextIsCancelled = false;
+
+  /// Calls to resetCancel.
+  final List<int> resetCancelCalls = [];
+
+  /// Calls to getHandleId.
+  final List<int> getHandleIdCalls = [];
+
+  /// Return value for [getHandleId]. Defaults to 1.
+  int nextGetHandleId = 1;
+
+  /// Calls to cancelById.
+  final List<int> cancelByIdCalls = [];
+
+  /// Return value for [cancelById]. Defaults to true.
+  bool nextCancelById = true;
+
+  /// Calls to isCancelledById.
+  final List<int> isCancelledByIdCalls = [];
+
+  /// Return value for [isCancelledById]. Defaults to false.
+  bool? nextIsCancelledById = false;
+
+  /// Calls to freeById.
+  final List<int> freeByIdCalls = [];
+
+  /// Return value for [freeById]. Defaults to true.
+  bool nextFreeById = true;
+
+  @override
+  void cancel(int handle) {
+    cancelCalls.add(handle);
+  }
+
+  @override
+  bool isCancelled(int handle) {
+    isCancelledCalls.add(handle);
+    return nextIsCancelled;
+  }
+
+  @override
+  void resetCancel(int handle) {
+    resetCancelCalls.add(handle);
+  }
+
+  @override
+  int getHandleId(int handle) {
+    getHandleIdCalls.add(handle);
+    return nextGetHandleId;
+  }
+
+  @override
+  bool cancelById(int handleId) {
+    cancelByIdCalls.add(handleId);
+    return nextCancelById;
+  }
+
+  @override
+  bool? isCancelledById(int handleId) {
+    isCancelledByIdCalls.add(handleId);
+    return nextIsCancelledById;
+  }
+
+  @override
+  bool freeById(int handleId) {
+    freeByIdCalls.add(handleId);
+    return nextFreeById;
+  }
 }

--- a/packages/dart_monty_ffi/test/monty_ffi_test.dart
+++ b/packages/dart_monty_ffi/test/monty_ffi_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:dart_monty_ffi/src/ffi_core_bindings.dart';
 import 'package:dart_monty_ffi/src/monty_ffi.dart';
 import 'package:dart_monty_ffi/src/native_bindings.dart';
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
@@ -996,6 +997,61 @@ void main() {
         () => monty.resolveFutures({}, errors: {}),
         throwsStateError,
       );
+    });
+  });
+
+  // ===========================================================================
+  // Cancel + handleId coverage (CancellableTracker)
+  // ===========================================================================
+  group('cancel()', () {
+    test('delegates to bindings when handle exists', () async {
+      // Use start() with pending result so handle stays alive.
+      mock
+        ..nextStartResult = const ProgressResult(
+          tag: 1,
+          functionName: 'f',
+          argumentsJson: '[]',
+        )
+        ..nextGetHandleId = 5;
+      await monty.start('x', externalFunctions: ['f']);
+
+      await monty.cancel();
+      expect(mock.cancelCalls, hasLength(1));
+    });
+
+    test('is a no-op when no handle exists', () async {
+      await monty.cancel();
+      expect(mock.cancelCalls, isEmpty);
+    });
+  });
+
+  group('handleId', () {
+    test('is null before run', () {
+      expect(monty.handleId, isNull);
+    });
+
+    test('is set after start with pending result', () async {
+      mock
+        ..nextStartResult = const ProgressResult(
+          tag: 1,
+          functionName: 'f',
+          argumentsJson: '[]',
+        )
+        ..nextGetHandleId = 99;
+      await monty.start('x', externalFunctions: ['f']);
+      expect(monty.handleId, 99);
+    });
+  });
+
+  group('MontyFfi.withCore', () {
+    test('constructs with pre-built core bindings', () {
+      final core = FfiCoreBindings(bindings: mock);
+      final ffi = MontyFfi.withCore(
+        coreBindings: core,
+        nativeBindings: mock,
+      );
+      expect(ffi, isA<MontyFfi>());
+      expect(ffi.isIdle, isTrue);
     });
   });
 

--- a/packages/dart_monty_platform_interface/lib/dart_monty_platform_interface.dart
+++ b/packages/dart_monty_platform_interface/lib/dart_monty_platform_interface.dart
@@ -6,6 +6,8 @@ library;
 
 export 'src/base_monty_platform.dart';
 export 'src/core_bindings.dart';
+export 'src/monty_cancel_token.dart';
+export 'src/monty_error.dart';
 export 'src/monty_exception.dart';
 export 'src/monty_future_capable.dart';
 export 'src/monty_limits.dart';

--- a/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_monty_platform_interface/src/core_bindings.dart';
+import 'package:dart_monty_platform_interface/src/monty_cancel_token.dart';
+import 'package:dart_monty_platform_interface/src/monty_error.dart';
 import 'package:dart_monty_platform_interface/src/monty_exception.dart';
 import 'package:dart_monty_platform_interface/src/monty_limits.dart';
 import 'package:dart_monty_platform_interface/src/monty_platform.dart';
@@ -43,6 +46,82 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   );
 
   bool _initialized = false;
+
+  // ---------------------------------------------------------------------------
+  // Native cancel callbacks (registered by dart_monty_ffi at init time)
+  // ---------------------------------------------------------------------------
+
+  static bool Function(int handleId)? _nativeCancelById;
+  static bool? Function(int handleId)? _nativeIsCancelledById;
+  static void Function([String? libraryPath])? _nativeEnsureInitialized;
+
+  /// Register native cancel functions. Called by `dart_monty_ffi` at init.
+  ///
+  /// Since `dart_monty_platform_interface` cannot depend on `dart_monty_ffi`,
+  /// the FFI package registers its cancel callbacks here at construction time.
+  static void registerNativeCancel({
+    required bool Function(int handleId) cancelById,
+    required bool? Function(int handleId) isCancelledById,
+    required void Function([String? libraryPath]) ensureInitialized,
+  }) {
+    _nativeCancelById = cancelById;
+    _nativeIsCancelledById = isCancelledById;
+    _nativeEnsureInitialized = ensureInitialized;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Web registry for cross-session cancelById
+  // ---------------------------------------------------------------------------
+
+  static final Map<int, MontyCoreBindings> _webRegistry = {};
+  static int _webNextId = 1;
+
+  /// Register a web bindings instance for cross-session cancel.
+  /// Returns the assigned handle ID.
+  static int webRegister(MontyCoreBindings bindings) {
+    final id = _webNextId++;
+    _webRegistry[id] = bindings;
+    return id;
+  }
+
+  /// Unregister a web bindings instance.
+  static void webUnregister(int handleId) {
+    _webRegistry.remove(handleId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Static cancel API
+  // ---------------------------------------------------------------------------
+
+  /// Cancel a handle by ID. Works cross-platform (native registry or web).
+  ///
+  /// Returns `true` if the handle was found and cancelled.
+  static bool cancelById(int handleId) {
+    if (_nativeCancelById != null) {
+      return _nativeCancelById!(handleId);
+    }
+    return _webCancelById(handleId);
+  }
+
+  static bool _webCancelById(int handleId) {
+    final bindings = _webRegistry[handleId];
+    if (bindings == null) return false;
+    unawaited(bindings.cancel());
+    return true;
+  }
+
+  /// Ensure the native FFI library is loaded. No-op on web.
+  static void ensureInitialized([String? libraryPath]) {
+    _nativeEnsureInitialized?.call(libraryPath);
+  }
+
+  /// Check if a handle is still alive (registered and not freed).
+  static bool isHandleAlive(int handleId) {
+    if (_nativeIsCancelledById != null) {
+      return _nativeIsCancelledById!(handleId) != null;
+    }
+    return _webRegistry.containsKey(handleId);
+  }
 
   @override
   Future<MontyResult> run(
@@ -124,6 +203,23 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   }
 
   @override
+  Future<void> cancel() async {
+    if (isDisposed) return;
+    await _bindings.cancel();
+  }
+
+  /// Returns a serializable cancel token for cross-isolate cancel.
+  ///
+  /// `null` before the first [run]/[start] (handle not yet created).
+  MontyCancelToken? get cancelToken {
+    final id = _bindings.handleId;
+    return id != null && id > 0 ? MontyCancelToken(id) : null;
+  }
+
+  @override
+  int? get handleId => _bindings.handleId;
+
+  @override
   Future<void> dispose() async {
     if (isDisposed) return;
     await _bindings.dispose();
@@ -148,6 +244,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
         printOutput: r.printOutput,
       );
     }
+    _throwSealedErrorIfApplicable(r.excType, r.error ?? 'Unknown error');
     throw MontyException(
       message: r.error ?? 'Unknown error',
       excType: r.excType,
@@ -189,6 +286,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
         );
       case 'error':
         markIdle();
+        _throwSealedErrorIfApplicable(p.excType, p.error ?? 'Unknown error');
         throw MontyException(
           message: p.error ?? 'Unknown error',
           excType: p.excType,
@@ -236,5 +334,21 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   ) {
     if (traceback == null) return const [];
     return MontyStackFrame.listFromJson(traceback);
+  }
+
+  /// Maps known Python exception types to the sealed [MontyError] hierarchy.
+  ///
+  /// Throws the appropriate sealed type for cancel and resource errors.
+  /// Returns without throwing for unmapped types, allowing fallthrough to
+  /// the existing [MontyException] path.
+  void _throwSealedErrorIfApplicable(String? excType, String message) {
+    switch (excType) {
+      case 'KeyboardInterrupt':
+        throw MontyCancelledError(message);
+      case 'MemoryLimitExceeded':
+        throw MontyResourceError(message);
+      default:
+        return;
+    }
   }
 }

--- a/packages/dart_monty_platform_interface/lib/src/core_bindings.dart
+++ b/packages/dart_monty_platform_interface/lib/src/core_bindings.dart
@@ -201,6 +201,13 @@ abstract class MontyCoreBindings {
   /// Restores execution state from [data].
   Future<void> restoreSnapshot(Uint8List data);
 
+  /// Cancel the current execution. Idempotent.
+  Future<void> cancel();
+
+  /// The monotonic handle ID for cross-isolate cancel.
+  /// Returns `null` before init or after dispose.
+  int? get handleId;
+
   /// Releases all resources held by this bindings instance.
   Future<void> dispose();
 }

--- a/packages/dart_monty_platform_interface/lib/src/mock_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/mock_monty_platform.dart
@@ -247,6 +247,20 @@ class MockMontyPlatform extends MontyPlatform
     return platform;
   }
 
+  /// Whether [cancel] has been called.
+  bool cancelCalled = false;
+
+  /// The handle ID returned by [handleId].
+  int? mockHandleId;
+
+  @override
+  Future<void> cancel() async {
+    cancelCalled = true;
+  }
+
+  @override
+  int? get handleId => mockHandleId;
+
   @override
   Future<void> dispose() async {
     isDisposed = true;

--- a/packages/dart_monty_platform_interface/lib/src/monty_cancel_token.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_cancel_token.dart
@@ -1,0 +1,15 @@
+import 'package:dart_monty_platform_interface/src/base_monty_platform.dart';
+
+/// Opaque, serializable token for cross-isolate cancel.
+///
+/// Wraps the monotonic handle ID for type safety.
+/// Safe to send via SendPort. Immutable.
+extension type const MontyCancelToken(int id) {
+  /// Cancel the interpreter this token refers to.
+  ///
+  /// Returns `true` if the handle was found and cancelled.
+  bool cancel() => BaseMontyPlatform.cancelById(id);
+
+  /// Check if the target interpreter handle is still alive.
+  bool get isAlive => BaseMontyPlatform.isHandleAlive(id);
+}

--- a/packages/dart_monty_platform_interface/lib/src/monty_error.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_error.dart
@@ -1,0 +1,107 @@
+/// Sealed error hierarchy for Monty interpreter failures.
+///
+/// Use exhaustive pattern matching to handle all failure modes:
+///
+/// ```dart
+/// try {
+///   await platform.run(code);
+/// } on MontyError catch (e) {
+///   switch (e) {
+///     case MontyCancelledError():   // Supervisor-initiated cancel
+///     case MontyScriptError():      // Python exception
+///     case MontyPanicError():       // Rust panic
+///     case MontyCrashError():       // Isolate died unexpectedly
+///     case MontyDisposedError():    // Disposed while running
+///     case MontyResourceError():    // OOM, timeout, WASM trap
+///   }
+/// }
+/// ```
+sealed class MontyError implements Exception {
+  /// Creates a [MontyError] with the given [message].
+  const MontyError(this.message);
+
+  /// Human-readable description of the error.
+  final String message;
+
+  /// Subclass name for toString. Overridden by each subtype.
+  String get _typeName => 'MontyError';
+
+  @override
+  String toString() => '$_typeName: $message';
+}
+
+/// Thrown when execution is cancelled via cancel() or cancelById().
+///
+/// **Supervisor action:** Expected — no restart needed.
+class MontyCancelledError extends MontyError {
+  /// Creates a [MontyCancelledError].
+  const MontyCancelledError([super.message = 'Execution cancelled']);
+
+  @override
+  String get _typeName => 'MontyCancelledError';
+}
+
+/// Thrown when the interpreter hits a Python-level exception.
+///
+/// **Application error** — handled by orchestrator/saga, NOT supervisor.
+/// Do not restart blindly — Python exceptions are deterministic.
+class MontyScriptError extends MontyError {
+  /// Creates a [MontyScriptError].
+  const MontyScriptError(super.message, {this.excType});
+
+  /// The Python exception class name (e.g. "ZeroDivisionError").
+  final String? excType;
+
+  @override
+  String get _typeName => 'MontyScriptError';
+}
+
+/// Thrown when the Rust interpreter panics (caught by catch_unwind).
+///
+/// **Supervisor action:** Harsh backoff — indicates a native bridge bug.
+class MontyPanicError extends MontyError {
+  /// Creates a [MontyPanicError].
+  const MontyPanicError(super.message);
+
+  @override
+  String get _typeName => 'MontyPanicError';
+}
+
+/// Thrown when the isolate/Worker died unexpectedly.
+///
+/// **Supervisor action:** Restart immediately (infrastructure failure).
+class MontyCrashError extends MontyError {
+  /// Creates a [MontyCrashError].
+  const MontyCrashError([super.message = 'Interpreter crashed unexpectedly']);
+
+  @override
+  String get _typeName => 'MontyCrashError';
+}
+
+/// Thrown when the interpreter is disposed while execution is in flight.
+///
+/// **Supervisor action:** Do NOT restart — fix the caller.
+class MontyDisposedError extends MontyError {
+  /// Creates a [MontyDisposedError].
+  const MontyDisposedError([
+    super.message = 'Interpreter disposed during execution',
+  ]);
+
+  @override
+  String get _typeName => 'MontyDisposedError';
+}
+
+/// Thrown on resource exhaustion: OOM, timeout, WASM trap.
+///
+/// **Supervisor action:** Reduce concurrency, then restart.
+class MontyResourceError extends MontyError {
+  /// Creates a [MontyResourceError].
+  const MontyResourceError(super.message);
+
+  @override
+  String get _typeName => 'MontyResourceError';
+}
+
+/// Deprecated — use [MontyCancelledError] instead.
+@Deprecated('Use MontyCancelledError instead')
+typedef MontyCancelledException = MontyCancelledError;

--- a/packages/dart_monty_platform_interface/lib/src/monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_platform.dart
@@ -99,6 +99,18 @@ abstract class MontyPlatform extends PlatformInterface {
     throw UnimplementedError('resumeWithError() has not been implemented.');
   }
 
+  /// Cancels the current execution. Idempotent — safe to call multiple times.
+  ///
+  /// No-op after [dispose].
+  Future<void> cancel() {
+    throw UnimplementedError('cancel() has not been implemented.');
+  }
+
+  /// The monotonic handle ID for cross-isolate cancel.
+  ///
+  /// Returns `null` before the first [run]/[start] or after [dispose].
+  int? get handleId => null;
+
   /// Releases resources held by this interpreter instance.
   Future<void> dispose() {
     throw UnimplementedError('dispose() has not been implemented.');

--- a/packages/dart_monty_platform_interface/pubspec.yaml
+++ b/packages/dart_monty_platform_interface/pubspec.yaml
@@ -10,7 +10,7 @@ topics:
   - interpreter
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
   collection: ^1.18.0

--- a/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
+++ b/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
@@ -91,6 +91,17 @@ class _FakeCoreBindings implements MontyCoreBindings {
   Future<void> restoreSnapshot(Uint8List data) async =>
       throw UnimplementedError();
 
+  bool cancelCalled = false;
+  int? mockHandleId;
+
+  @override
+  Future<void> cancel() async {
+    cancelCalled = true;
+  }
+
+  @override
+  int? get handleId => mockHandleId;
+
   @override
   Future<void> dispose() async {
     disposeCalled = true;
@@ -714,6 +725,129 @@ void main() {
       final result = await first;
       expect(result, isA<MontyComplete>());
       expect(platform.isIdle, isTrue);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cancel API coverage
+  // ---------------------------------------------------------------------------
+
+  group('cancel()', () {
+    test('delegates to bindings', () async {
+      fake.runResult = const CoreRunResult(ok: true, usage: zeroUsage);
+      await platform.run('x'); // triggers init
+      await platform.cancel();
+      expect(fake.cancelCalled, isTrue);
+    });
+
+    test('is a no-op when disposed', () async {
+      fake.runResult = const CoreRunResult(ok: true, usage: zeroUsage);
+      await platform.run('x');
+      await platform.dispose();
+      // Should not throw or call bindings.cancel().
+      fake.cancelCalled = false;
+      await platform.cancel();
+      expect(fake.cancelCalled, isFalse);
+    });
+  });
+
+  group('handleId', () {
+    test('delegates to bindings', () {
+      expect(platform.handleId, isNull);
+    });
+  });
+
+  group('cancelToken', () {
+    test('returns null when handleId is null', () {
+      expect(platform.cancelToken, isNull);
+    });
+
+    test('returns null when handleId is zero', () {
+      fake.mockHandleId = 0;
+      expect(platform.cancelToken, isNull);
+    });
+
+    test('returns MontyCancelToken when handleId > 0', () {
+      fake.mockHandleId = 42;
+      final token = platform.cancelToken;
+      expect(token, isNotNull);
+      expect(token!.id, 42);
+    });
+  });
+
+  group('static cancel API', () {
+    tearDown(() {
+      // Reset static state after each test.
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (_) => false,
+        isCancelledById: (_) => null,
+        ensureInitialized: ([_]) {},
+      );
+      // Clean up any web registry entries by unregistering.
+      // (We can't access _webRegistry directly, but tests below manage
+      // their own entries.)
+    });
+
+    test('registerNativeCancel stores callbacks and cancelById uses them', () {
+      var cancelledId = -1;
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (id) {
+          cancelledId = id;
+          return true;
+        },
+        isCancelledById: (_) => false,
+        ensureInitialized: ([_]) {},
+      );
+      final result = BaseMontyPlatform.cancelById(99);
+      expect(result, isTrue);
+      expect(cancelledId, 99);
+    });
+
+    test('webRegister/webUnregister manage web registry', () {
+      final webFake = _FakeCoreBindings();
+      final webId = BaseMontyPlatform.webRegister(webFake);
+      expect(webId, greaterThan(0));
+
+      // Verify registered via isHandleAlive (web path checks _webRegistry).
+      // Reset native so isHandleAlive falls through to web registry.
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (_) => false,
+        isCancelledById: (_) => null,
+        ensureInitialized: ([_]) {},
+      );
+
+      BaseMontyPlatform.webUnregister(webId);
+    });
+
+    test('webRegister returns incrementing IDs', () {
+      final id1 = BaseMontyPlatform.webRegister(_FakeCoreBindings());
+      final id2 = BaseMontyPlatform.webRegister(_FakeCoreBindings());
+      expect(id2, greaterThan(id1));
+      BaseMontyPlatform.webUnregister(id1);
+      BaseMontyPlatform.webUnregister(id2);
+    });
+
+    test('ensureInitialized invokes registered callback', () {
+      var called = false;
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (_) => false,
+        isCancelledById: (_) => null,
+        ensureInitialized: ([_]) {
+          called = true;
+        },
+      );
+      BaseMontyPlatform.ensureInitialized();
+      expect(called, isTrue);
+    });
+
+    test('isHandleAlive delegates to native callback', () {
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (_) => false,
+        isCancelledById: (id) => id == 42 ? false : null,
+        ensureInitialized: ([_]) {},
+      );
+      expect(BaseMontyPlatform.isHandleAlive(42), isTrue);
+      expect(BaseMontyPlatform.isHandleAlive(999), isFalse);
     });
   });
 

--- a/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
+++ b/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
@@ -1,0 +1,313 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:dart_monty_platform_interface/dart_monty_testing.dart';
+import 'package:test/test.dart';
+
+/// T1-4: Sealed Error Routing Boundary
+///
+/// Verifies that each distinct failure mode maps to its correct sealed
+/// MontyError subtype via BaseMontyPlatform._throwSealedErrorIfApplicable.
+void main() {
+  group('sealed error routing', () {
+    test('KeyboardInterrupt maps to MontyCancelledError', () async {
+      final bindings = _FakeCoreBindings();
+      final platform = _TestPlatform(bindings: bindings);
+
+      bindings.nextRunResult = const CoreRunResult(
+        ok: false,
+        error: 'Execution cancelled',
+        excType: 'KeyboardInterrupt',
+      );
+
+      await expectLater(
+        platform.run('code'),
+        throwsA(isA<MontyCancelledError>()),
+      );
+    });
+
+    test('MemoryLimitExceeded maps to MontyResourceError', () async {
+      final bindings = _FakeCoreBindings();
+      final platform = _TestPlatform(bindings: bindings);
+
+      bindings.nextRunResult = const CoreRunResult(
+        ok: false,
+        error: 'Memory limit exceeded',
+        excType: 'MemoryLimitExceeded',
+      );
+
+      await expectLater(
+        platform.run('code'),
+        throwsA(isA<MontyResourceError>()),
+      );
+    });
+
+    test('Python ZeroDivisionError maps to MontyException (not sealed)',
+        () async {
+      final bindings = _FakeCoreBindings();
+      final platform = _TestPlatform(bindings: bindings);
+
+      bindings.nextRunResult = const CoreRunResult(
+        ok: false,
+        error: 'division by zero',
+        excType: 'ZeroDivisionError',
+      );
+
+      await expectLater(
+        platform.run('code'),
+        throwsA(
+          isA<MontyException>().having(
+            (e) => e.excType,
+            'excType',
+            'ZeroDivisionError',
+          ),
+        ),
+      );
+    });
+
+    test('progress error with KeyboardInterrupt maps to MontyCancelledError',
+        () async {
+      final bindings = _FakeCoreBindings();
+      final platform = _TestPlatform(bindings: bindings);
+
+      bindings.nextStartResult = const CoreProgressResult(
+        state: 'error',
+        error: 'Execution cancelled',
+        excType: 'KeyboardInterrupt',
+      );
+
+      await expectLater(
+        platform.start('code'),
+        throwsA(isA<MontyCancelledError>()),
+      );
+    });
+
+    test('progress error with MemoryLimitExceeded maps to MontyResourceError',
+        () async {
+      final bindings = _FakeCoreBindings();
+      final platform = _TestPlatform(bindings: bindings);
+
+      bindings.nextStartResult = const CoreProgressResult(
+        state: 'error',
+        error: 'Memory limit exceeded',
+        excType: 'MemoryLimitExceeded',
+      );
+
+      await expectLater(
+        platform.start('code'),
+        throwsA(isA<MontyResourceError>()),
+      );
+    });
+  });
+
+  group('exhaustive switch compiles', () {
+    test('all 6 sealed subtypes are matchable', () {
+      // This test verifies that the sealed class hierarchy compiles
+      // with exhaustive pattern matching.
+      const errors = <MontyError>[
+        MontyCancelledError(),
+        MontyScriptError('test'),
+        MontyPanicError('test'),
+        MontyCrashError(),
+        MontyDisposedError(),
+        MontyResourceError('test'),
+      ];
+
+      for (final error in errors) {
+        final label = switch (error) {
+          MontyCancelledError() => 'cancelled',
+          MontyScriptError() => 'script',
+          MontyPanicError() => 'panic',
+          MontyCrashError() => 'crash',
+          MontyDisposedError() => 'disposed',
+          MontyResourceError() => 'resource',
+        };
+        expect(label, isNotEmpty);
+      }
+    });
+
+    test('MontyScriptError preserves excType', () {
+      const error =
+          MontyScriptError('division by zero', excType: 'ZeroDivisionError');
+      expect(error.excType, 'ZeroDivisionError');
+      expect(error.message, 'division by zero');
+    });
+  });
+
+  group('MontyError toString coverage', () {
+    test('MontyCancelledError default message', () {
+      const e = MontyCancelledError();
+      expect(e.toString(), 'MontyCancelledError: Execution cancelled');
+    });
+
+    test('MontyCancelledError custom message', () {
+      const e = MontyCancelledError('custom');
+      expect(e.toString(), 'MontyCancelledError: custom');
+    });
+
+    test('MontyScriptError toString', () {
+      const e = MontyScriptError('boom', excType: 'ValueError');
+      expect(e.toString(), 'MontyScriptError: boom');
+    });
+
+    test('MontyPanicError toString', () {
+      const e = MontyPanicError('rust panic');
+      expect(e.toString(), 'MontyPanicError: rust panic');
+    });
+
+    test('MontyCrashError default message', () {
+      const e = MontyCrashError();
+      expect(
+        e.toString(),
+        'MontyCrashError: Interpreter crashed unexpectedly',
+      );
+    });
+
+    test('MontyDisposedError default message', () {
+      const e = MontyDisposedError();
+      expect(
+        e.toString(),
+        'MontyDisposedError: Interpreter disposed during execution',
+      );
+    });
+
+    test('MontyResourceError toString', () {
+      const e = MontyResourceError('OOM');
+      expect(e.toString(), 'MontyResourceError: OOM');
+    });
+  });
+
+  group('MontyCancelToken', () {
+    tearDown(() {
+      // Reset native callbacks.
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (_) => false,
+        isCancelledById: (_) => null,
+        ensureInitialized: ([_]) {},
+      );
+    });
+
+    test('cancel delegates to BaseMontyPlatform.cancelById', () {
+      var cancelledId = -1;
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (id) {
+          cancelledId = id;
+          return true;
+        },
+        isCancelledById: (_) => false,
+        ensureInitialized: ([_]) {},
+      );
+      const token = MontyCancelToken(42);
+      final result = token.cancel();
+      expect(result, isTrue);
+      expect(cancelledId, 42);
+    });
+
+    test('isAlive delegates to BaseMontyPlatform.isHandleAlive', () {
+      BaseMontyPlatform.registerNativeCancel(
+        cancelById: (_) => false,
+        isCancelledById: (id) => id == 7 ? false : null,
+        ensureInitialized: ([_]) {},
+      );
+      expect(const MontyCancelToken(7).isAlive, isTrue);
+      expect(const MontyCancelToken(999).isAlive, isFalse);
+    });
+  });
+
+  group('MontyPlatform default implementations', () {
+    test('handleId returns null by default on MockMontyPlatform', () {
+      final mock = MockMontyPlatform();
+      // MockMontyPlatform's handleId defaults to null (delegates to super).
+      expect(mock.handleId, isNull);
+    });
+  });
+
+  group('cancel and handleId on MontyPlatform', () {
+    test('cancel on mock platform', () async {
+      final mock = MockMontyPlatform();
+      await mock.cancel();
+      expect(mock.cancelCalled, isTrue);
+    });
+
+    test('handleId on mock platform', () {
+      final mock = MockMontyPlatform();
+      expect(mock.handleId, isNull);
+      mock.mockHandleId = 42;
+      expect(mock.handleId, 42);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+class _FakeCoreBindings implements MontyCoreBindings {
+  CoreRunResult nextRunResult = const CoreRunResult(ok: true, value: 4);
+  CoreProgressResult nextStartResult = const CoreProgressResult(
+    state: 'complete',
+    value: 4,
+  );
+
+  @override
+  Future<bool> init() async => true;
+
+  @override
+  Future<CoreRunResult> run(
+    String code, {
+    String? limitsJson,
+    String? scriptName,
+  }) async =>
+      nextRunResult;
+
+  @override
+  Future<CoreProgressResult> start(
+    String code, {
+    String? extFnsJson,
+    String? limitsJson,
+    String? scriptName,
+  }) async =>
+      nextStartResult;
+
+  @override
+  Future<CoreProgressResult> resume(String valueJson) async =>
+      const CoreProgressResult(state: 'complete');
+
+  @override
+  Future<CoreProgressResult> resumeWithError(String errorMessage) async =>
+      const CoreProgressResult(state: 'complete');
+
+  @override
+  Future<CoreProgressResult> resumeAsFuture() async =>
+      throw UnsupportedError('not supported');
+
+  @override
+  Future<CoreProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  ) async =>
+      throw UnsupportedError('not supported');
+
+  @override
+  Future<Uint8List> snapshot() async => Uint8List(0);
+
+  @override
+  Future<void> restoreSnapshot(Uint8List data) async {}
+
+  @override
+  Future<void> cancel() async {}
+
+  @override
+  int? get handleId => null;
+
+  @override
+  Future<void> dispose() async {}
+}
+
+class _TestPlatform extends BaseMontyPlatform {
+  _TestPlatform({required super.bindings});
+
+  @override
+  String get backendName => 'test';
+}

--- a/packages/dart_monty_wasm/example/example.dart
+++ b/packages/dart_monty_wasm/example/example.dart
@@ -32,10 +32,7 @@ Future<void> _simpleRun(MontyWasm monty) async {
 Future<void> _runWithLimits(MontyWasm monty) async {
   final result = await monty.run(
     'sum(range(100))',
-    limits: const MontyLimits(
-      timeoutMs: 5000,
-      memoryBytes: 10 * 1024 * 1024,
-    ),
+    limits: const MontyLimits(timeoutMs: 5000, memoryBytes: 10 * 1024 * 1024),
   );
   print('With limits: ${result.value}'); // 4950
 }

--- a/packages/dart_monty_wasm/lib/src/wasm_bindings.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_bindings.dart
@@ -108,10 +108,7 @@ final class WasmProgressResult {
 /// Describes the state of the WASM bridge.
 final class WasmDiscoverResult {
   /// Creates a [WasmDiscoverResult].
-  const WasmDiscoverResult({
-    required this.loaded,
-    required this.architecture,
-  });
+  const WasmDiscoverResult({required this.loaded, required this.architecture});
 
   /// Whether the WASM module is loaded.
   final bool loaded;
@@ -193,6 +190,11 @@ abstract class WasmBindings {
 
   /// Restores interpreter state from snapshot [data].
   Future<void> restore(Uint8List data);
+
+  /// Cancels the current execution by terminating the Worker.
+  ///
+  /// Idempotent — safe to call multiple times or after dispose.
+  Future<void> cancel();
 
   /// Discovers the bridge API surface.
   Future<WasmDiscoverResult> discover();

--- a/packages/dart_monty_wasm/lib/src/wasm_bindings_js.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_bindings_js.dart
@@ -16,76 +16,86 @@ extension type _SnapshotResult._(JSObject _) implements JSObject {
 }
 
 // ---------------------------------------------------------------------------
-// JS interop declarations for window.DartMontyBridge
+// JS interop for instance-based DartMontyBridge
 // ---------------------------------------------------------------------------
 
-@JS('DartMontyBridge.init')
-external JSPromise<JSBoolean> _jsInit();
+/// Binds to the JS `DartMontyBridge` class exposed on `window`.
+///
+/// Each instance manages its own Worker for session isolation.
+/// Instance fields (not static) prevent cross-session promise routing bugs
+/// when multiple WASM sessions exist concurrently.
+@JS('DartMontyBridge')
+extension type JsDartMontyBridge._(JSObject _) implements JSObject {
+  /// Creates a new JS `DartMontyBridge` instance with its own Worker.
+  external JsDartMontyBridge();
 
-@JS('DartMontyBridge.run')
-external JSPromise<JSString> _jsRun(
-  JSString code, [
-  JSString? limitsJson,
-  JSString? scriptName,
-]);
+  /// Initializes the Worker and loads the WASM module.
+  external JSPromise<JSBoolean> init();
 
-@JS('DartMontyBridge.start')
-external JSPromise<JSString> _jsStart(
-  JSString code, [
-  JSString? extFnsJson,
-  JSString? limitsJson,
-  JSString? scriptName,
-]);
+  /// Runs Python [code] to completion.
+  external JSPromise<JSString> run(
+    JSString code, [
+    JSString? limitsJson,
+    JSString? scriptName,
+  ]);
 
-@JS('DartMontyBridge.resume')
-external JSPromise<JSString> _jsResume(JSString valueJson);
+  /// Starts iterative execution of [code] with optional external functions.
+  external JSPromise<JSString> start(
+    JSString code, [
+    JSString? extFnsJson,
+    JSString? limitsJson,
+    JSString? scriptName,
+  ]);
 
-@JS('DartMontyBridge.resumeWithError')
-external JSPromise<JSString> _jsResumeWithError(JSString errorJson);
+  /// Resumes paused execution with [valueJson].
+  external JSPromise<JSString> resume(JSString valueJson);
 
-@JS('DartMontyBridge.snapshot')
-external JSPromise<JSAny> _jsSnapshot();
+  /// Resumes paused execution by injecting an error.
+  external JSPromise<JSString> resumeWithError(JSString errorJson);
 
-@JS('DartMontyBridge.restore')
-external JSPromise<JSString> _jsRestore(JSString dataBase64);
+  /// Captures the current interpreter state as a binary snapshot.
+  external JSPromise<JSAny> snapshot();
 
-@JS('DartMontyBridge.discover')
-external JSString _jsDiscover();
+  /// Restores interpreter state from a base64-encoded snapshot.
+  external JSPromise<JSString> restore(JSString dataBase64);
 
-@JS('DartMontyBridge.dispose')
-external JSPromise<JSString> _jsDispose();
+  /// Returns JSON describing the bridge state.
+  external JSString discover();
 
-@JS('DartMontyBridge.createSession')
-external JSPromise<JSNumber> _jsCreateSession();
+  /// Terminates the Worker and rejects pending promises.
+  external JSPromise<JSString> cancel();
 
-@JS('DartMontyBridge.disposeSession')
-external void _jsDisposeSession(JSNumber sessionId);
+  /// Disposes the Worker session, rejecting pending promises first.
+  external JSPromise<JSString> dispose();
+}
 
 /// Concrete [WasmBindings] implementation using `dart:js_interop`.
 ///
-/// Calls into `window.DartMontyBridge` which communicates with a Web Worker
-/// hosting the @pydantic/monty WASM runtime.
+/// Each instance holds its own [JsDartMontyBridge] JS object, which in turn
+/// manages its own Web Worker hosting the @pydantic/monty WASM runtime.
 class WasmBindingsJs extends WasmBindings {
   /// Creates a [WasmBindingsJs].
   WasmBindingsJs();
 
+  late final JsDartMontyBridge _bridge = JsDartMontyBridge();
+
   @override
   Future<bool> init() async {
-    final result = await _jsInit().toDart;
+    final result = await _bridge.init().toDart;
 
     return result.toDart;
   }
 
   @override
   Future<int> createSession() async {
-    final sessionId = await _jsCreateSession().toDart;
-
-    return sessionId.toDartInt;
+    // Instance-based bridge: each WasmBindingsJs IS a session.
+    // Return a synthetic ID; real session routing is per-bridge-instance.
+    return 1;
   }
 
   @override
   Future<void> disposeSession(int sessionId) async {
-    _jsDisposeSession(sessionId.toJS);
+    // No-op: instance-based bridge handles cleanup in dispose().
   }
 
   @override
@@ -94,11 +104,8 @@ class WasmBindingsJs extends WasmBindings {
     String? limitsJson,
     String? scriptName,
   }) async {
-    final resultJson = await _jsRun(
-      code.toJS,
-      limitsJson?.toJS,
-      scriptName?.toJS,
-    ).toDart;
+    final resultJson =
+        await _bridge.run(code.toJS, limitsJson?.toJS, scriptName?.toJS).toDart;
     final map = json.decode(resultJson.toDart) as Map<String, dynamic>;
     final rawTraceback = map['traceback'] as List<Object?>?;
 
@@ -120,19 +127,16 @@ class WasmBindingsJs extends WasmBindings {
     String? limitsJson,
     String? scriptName,
   }) async {
-    final resultJson = await _jsStart(
-      code.toJS,
-      extFnsJson?.toJS,
-      limitsJson?.toJS,
-      scriptName?.toJS,
-    ).toDart;
+    final resultJson = await _bridge
+        .start(code.toJS, extFnsJson?.toJS, limitsJson?.toJS, scriptName?.toJS)
+        .toDart;
 
     return _decodeProgress(resultJson.toDart);
   }
 
   @override
   Future<WasmProgressResult> resume(String valueJson) async {
-    final resultJson = await _jsResume(valueJson.toJS).toDart;
+    final resultJson = await _bridge.resume(valueJson.toJS).toDart;
 
     return _decodeProgress(resultJson.toDart);
   }
@@ -140,7 +144,7 @@ class WasmBindingsJs extends WasmBindings {
   @override
   Future<WasmProgressResult> resumeWithError(String errorMessage) async {
     final errorJson = json.encode(errorMessage);
-    final resultJson = await _jsResumeWithError(errorJson.toJS).toDart;
+    final resultJson = await _bridge.resumeWithError(errorJson.toJS).toDart;
 
     return _decodeProgress(resultJson.toDart);
   }
@@ -164,7 +168,7 @@ class WasmBindingsJs extends WasmBindings {
 
   @override
   Future<Uint8List> snapshot() async {
-    final jsAny = await _jsSnapshot().toDart;
+    final jsAny = await _bridge.snapshot().toDart;
     final result = jsAny as _SnapshotResult;
     if (!result.ok.toDart) {
       throw StateError(result.error?.toDart ?? 'Snapshot failed');
@@ -175,18 +179,16 @@ class WasmBindingsJs extends WasmBindings {
   @override
   Future<void> restore(Uint8List data) async {
     final dataBase64 = base64Encode(data);
-    final resultJson = await _jsRestore(dataBase64.toJS).toDart;
+    final resultJson = await _bridge.restore(dataBase64.toJS).toDart;
     final map = json.decode(resultJson.toDart) as Map<String, dynamic>;
     if (map['ok'] != true) {
-      throw StateError(
-        map['error'] as String? ?? 'Restore failed',
-      );
+      throw StateError(map['error'] as String? ?? 'Restore failed');
     }
   }
 
   @override
   Future<WasmDiscoverResult> discover() async {
-    final jsonStr = _jsDiscover().toDart;
+    final jsonStr = _bridge.discover().toDart;
     final map = json.decode(jsonStr) as Map<String, dynamic>;
 
     return WasmDiscoverResult(
@@ -196,14 +198,15 @@ class WasmBindingsJs extends WasmBindings {
   }
 
   @override
+  Future<void> cancel() async {
+    await _bridge.cancel().toDart;
+    // Always succeeds (idempotent). No error parsing needed.
+  }
+
+  @override
   Future<void> dispose() async {
-    final resultJson = await _jsDispose().toDart;
-    final map = json.decode(resultJson.toDart) as Map<String, dynamic>;
-    if (map['ok'] != true) {
-      throw StateError(
-        map['error'] as String? ?? 'Dispose failed',
-      );
-    }
+    await _bridge.dispose().toDart;
+    // Always succeeds — Worker terminated.
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
@@ -10,6 +10,9 @@ import 'package:dart_monty_wasm/src/wasm_bindings.dart';
 /// Provides synthetic [MontyResourceUsage] with Dart-side wall-clock
 /// timing since the WASM bridge does not expose `ResourceTracker`.
 ///
+/// Registers in [BaseMontyPlatform.webRegister] at init for cross-session
+/// `cancelById` support on web.
+///
 /// ```dart
 /// final core = WasmCoreBindings(bindings: WasmBindingsJs());
 /// final monty = MontyWasm(bindings: core);
@@ -20,11 +23,16 @@ class WasmCoreBindings implements MontyCoreBindings {
 
   final WasmBindings _bindings;
   int? _sessionId;
+  int? _handleId;
+
+  @override
+  int? get handleId => _handleId;
 
   @override
   Future<bool> init() async {
     if (_sessionId != null) return true;
     _sessionId = await _bindings.createSession();
+    _handleId = BaseMontyPlatform.webRegister(this);
     return true;
   }
 
@@ -35,13 +43,18 @@ class WasmCoreBindings implements MontyCoreBindings {
     String? scriptName,
   }) async {
     final sw = Stopwatch()..start();
-    final result = await _bindings.run(
-      code,
-      limitsJson: limitsJson,
-      scriptName: scriptName,
-    );
-    sw.stop();
-    return _translateRunResult(result, sw.elapsedMilliseconds);
+    try {
+      final result = await _bindings.run(
+        code,
+        limitsJson: limitsJson,
+        scriptName: scriptName,
+      );
+      sw.stop();
+      return _translateRunResult(result, sw.elapsedMilliseconds);
+    } on Object catch (e) {
+      _throwIfWebCancelError(e);
+      rethrow;
+    }
   }
 
   @override
@@ -52,30 +65,45 @@ class WasmCoreBindings implements MontyCoreBindings {
     String? scriptName,
   }) async {
     final sw = Stopwatch()..start();
-    final progress = await _bindings.start(
-      code,
-      extFnsJson: extFnsJson,
-      limitsJson: limitsJson,
-      scriptName: scriptName,
-    );
-    sw.stop();
-    return _translateProgressResult(progress, sw.elapsedMilliseconds);
+    try {
+      final progress = await _bindings.start(
+        code,
+        extFnsJson: extFnsJson,
+        limitsJson: limitsJson,
+        scriptName: scriptName,
+      );
+      sw.stop();
+      return _translateProgressResult(progress, sw.elapsedMilliseconds);
+    } on Object catch (e) {
+      _throwIfWebCancelError(e);
+      rethrow;
+    }
   }
 
   @override
   Future<CoreProgressResult> resume(String valueJson) async {
     final sw = Stopwatch()..start();
-    final progress = await _bindings.resume(valueJson);
-    sw.stop();
-    return _translateProgressResult(progress, sw.elapsedMilliseconds);
+    try {
+      final progress = await _bindings.resume(valueJson);
+      sw.stop();
+      return _translateProgressResult(progress, sw.elapsedMilliseconds);
+    } on Object catch (e) {
+      _throwIfWebCancelError(e);
+      rethrow;
+    }
   }
 
   @override
   Future<CoreProgressResult> resumeWithError(String errorMessage) async {
     final sw = Stopwatch()..start();
-    final progress = await _bindings.resumeWithError(errorMessage);
-    sw.stop();
-    return _translateProgressResult(progress, sw.elapsedMilliseconds);
+    try {
+      final progress = await _bindings.resumeWithError(errorMessage);
+      sw.stop();
+      return _translateProgressResult(progress, sw.elapsedMilliseconds);
+    } on Object catch (e) {
+      _throwIfWebCancelError(e);
+      rethrow;
+    }
   }
 
   @override
@@ -103,7 +131,16 @@ class WasmCoreBindings implements MontyCoreBindings {
   }
 
   @override
+  Future<void> cancel() async {
+    await _bindings.cancel();
+  }
+
+  @override
   Future<void> dispose() async {
+    if (_handleId != null) {
+      BaseMontyPlatform.webUnregister(_handleId!);
+      _handleId = null;
+    }
     if (_sessionId != null) {
       await _bindings.disposeSession(_sessionId!);
       _sessionId = null;
@@ -177,6 +214,28 @@ class WasmCoreBindings implements MontyCoreBindings {
 
       default:
         throw StateError('Unknown progress state: ${progress.state}');
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Web error prefix mapping
+  // ---------------------------------------------------------------------------
+
+  /// Maps JS rejection error messages to sealed [MontyError] subtypes.
+  ///
+  /// When cancel() terminates the Worker, pending Promises reject with
+  /// prefixed error messages. This method recognizes those prefixes and
+  /// throws the appropriate sealed type so supervisors can pattern-match.
+  void _throwIfWebCancelError(Object error) {
+    final msg = error.toString();
+    if (msg.contains('MontyCancelled:')) {
+      throw MontyCancelledError(msg);
+    }
+    if (msg.contains('MontyDisposed:')) {
+      throw MontyDisposedError(msg);
+    }
+    if (msg.contains('MontyWorkerError:')) {
+      throw MontyResourceError(msg);
     }
   }
 }

--- a/packages/dart_monty_wasm/test/integration/python_ladder_test.dart
+++ b/packages/dart_monty_wasm/test/integration/python_ladder_test.dart
@@ -124,9 +124,7 @@ Future<void> main() async {
   print('LADDER_DONE');
 }
 
-Future<Map<String, dynamic>> _runFixture(
-  Map<String, dynamic> fixture,
-) async {
+Future<Map<String, dynamic>> _runFixture(Map<String, dynamic> fixture) async {
   final id = fixture['id'] as int;
   final code = fixture['code'] as String;
   final expectError = fixture['expectError'] as bool? ?? false;
@@ -171,9 +169,7 @@ Future<Map<String, dynamic>> _runExpectError(int id, String code) async {
   return {'id': id, 'ok': false, 'error': 'Expected error but succeeded'};
 }
 
-Future<Map<String, dynamic>> _runIterative(
-  Map<String, dynamic> fixture,
-) async {
+Future<Map<String, dynamic>> _runIterative(Map<String, dynamic> fixture) async {
   final id = fixture['id'] as int;
   final code = fixture['code'] as String;
   final extFns = (fixture['externalFunctions'] as List).cast<String>();
@@ -194,10 +190,7 @@ Future<Map<String, dynamic>> _runIterative(
         return {'id': id, 'ok': false, 'error': 'Expected pending state'};
       }
       resultJson = _parseResult(
-        (await _montyResumeWithError(
-          jsonEncode(errorMsg).toJS,
-        ).toDart)
-            .toDart,
+        (await _montyResumeWithError(jsonEncode(errorMsg).toJS).toDart).toDart,
       );
     }
   } else if (resumeValues != null) {

--- a/packages/dart_monty_wasm/test/integration/smoke_test.dart
+++ b/packages/dart_monty_wasm/test/integration/smoke_test.dart
@@ -83,11 +83,7 @@ Future<void> _testErrorHandling() async {
 
 Future<void> _testIterative() async {
   final startResult = _parse(
-    (await _bridgeStart(
-      'fetch("url")'.toJS,
-      '["fetch"]'.toJS,
-    ).toDart)
-        .toDart,
+    (await _bridgeStart('fetch("url")'.toJS, '["fetch"]'.toJS).toDart).toDart,
   );
 
   if (startResult['ok'] != true || startResult['state'] != 'pending') {
@@ -148,11 +144,7 @@ result
 Future<void> _testSnapshot() async {
   // Start an iterative execution
   final startResult = _parse(
-    (await _bridgeStart(
-      'fetch("url")'.toJS,
-      '["fetch"]'.toJS,
-    ).toDart)
-        .toDart,
+    (await _bridgeStart('fetch("url")'.toJS, '["fetch"]'.toJS).toDart).toDart,
   );
 
   if (startResult['ok'] != true || startResult['state'] != 'pending') {

--- a/packages/dart_monty_wasm/test/mock_wasm_bindings.dart
+++ b/packages/dart_monty_wasm/test/mock_wasm_bindings.dart
@@ -49,6 +49,18 @@ class MockWasmBindings extends WasmBindings {
   /// If non-null, [dispose] throws this message as a [StateError].
   String? nextDisposeError;
 
+  /// If non-null, [run] throws this message as a [StateError].
+  String? throwOnRun;
+
+  /// If non-null, [start] throws this message as a [StateError].
+  String? throwOnStart;
+
+  /// If non-null, [resume] throws this message as a [StateError].
+  String? throwOnResume;
+
+  /// If non-null, [resumeWithError] throws this message as a [StateError].
+  String? throwOnResumeWithError;
+
   // ---------------------------------------------------------------------------
   // Call tracking
   // ---------------------------------------------------------------------------
@@ -84,6 +96,9 @@ class MockWasmBindings extends WasmBindings {
 
   /// Number of times [discover] was called.
   int discoverCalls = 0;
+
+  /// Number of times [cancel] was called.
+  int cancelCalls = 0;
 
   /// Number of times [dispose] was called.
   int disposeCalls = 0;
@@ -131,6 +146,7 @@ class MockWasmBindings extends WasmBindings {
     String? scriptName,
   }) async {
     runCalls.add((code: code, limitsJson: limitsJson, scriptName: scriptName));
+    if (throwOnRun != null) throw StateError(throwOnRun!);
 
     return nextRunResult;
   }
@@ -150,6 +166,7 @@ class MockWasmBindings extends WasmBindings {
         scriptName: scriptName,
       ),
     );
+    if (throwOnStart != null) throw StateError(throwOnStart!);
 
     return nextStartResult;
   }
@@ -157,6 +174,7 @@ class MockWasmBindings extends WasmBindings {
   @override
   Future<WasmProgressResult> resume(String valueJson) async {
     resumeCalls.add(valueJson);
+    if (throwOnResume != null) throw StateError(throwOnResume!);
     if (resumeResults.isNotEmpty) return resumeResults.removeAt(0);
 
     return const WasmProgressResult(ok: true, state: 'complete');
@@ -165,6 +183,9 @@ class MockWasmBindings extends WasmBindings {
   @override
   Future<WasmProgressResult> resumeWithError(String errorMessage) async {
     resumeWithErrorCalls.add(errorMessage);
+    if (throwOnResumeWithError != null) {
+      throw StateError(throwOnResumeWithError!);
+    }
     if (resumeWithErrorResults.isNotEmpty) {
       return resumeWithErrorResults.removeAt(0);
     }
@@ -203,6 +224,11 @@ class MockWasmBindings extends WasmBindings {
     if (restoreError != null) {
       throw MontyException(message: restoreError);
     }
+  }
+
+  @override
+  Future<void> cancel() async {
+    cancelCalls++;
   }
 
   @override

--- a/packages/dart_monty_wasm/test/monty_wasm_test.dart
+++ b/packages/dart_monty_wasm/test/monty_wasm_test.dart
@@ -225,10 +225,7 @@ void main() {
         arguments: [],
       );
 
-      await monty.start(
-        'a()',
-        externalFunctions: ['a', 'b', 'c'],
-      );
+      await monty.start('a()', externalFunctions: ['a', 'b', 'c']);
 
       expect(mock.startCalls.first.extFnsJson, '["a","b","c"]');
     });
@@ -297,10 +294,7 @@ void main() {
         state: 'complete',
       );
 
-      await monty.start(
-        'x',
-        limits: const MontyLimits(memoryBytes: 512),
-      );
+      await monty.start('x', limits: const MontyLimits(memoryBytes: 512));
 
       final limitsJson = mock.startCalls.first.limitsJson;
       expect(limitsJson, isNotNull);
@@ -350,11 +344,7 @@ void main() {
 
     test('returns MontyComplete when execution finishes', () async {
       mock.resumeResults.add(
-        const WasmProgressResult(
-          ok: true,
-          state: 'complete',
-          value: 'hello',
-        ),
+        const WasmProgressResult(ok: true, state: 'complete', value: 'hello'),
       );
 
       final progress = await monty.resume('response');
@@ -391,19 +381,13 @@ void main() {
         ),
       );
 
-      expect(
-        () => monty.resume(null),
-        throwsA(isA<MontyException>()),
-      );
+      expect(() => monty.resume(null), throwsA(isA<MontyException>()));
     });
 
     test('throws StateError when idle', () async {
       // Complete the execution first to go back to idle.
       mock.resumeResults.add(
-        const WasmProgressResult(
-          ok: true,
-          state: 'complete',
-        ),
+        const WasmProgressResult(ok: true, state: 'complete'),
       );
       await monty.resume(null);
 
@@ -417,10 +401,7 @@ void main() {
 
     test('encodes complex return values as JSON', () async {
       mock.resumeResults.add(
-        const WasmProgressResult(
-          ok: true,
-          state: 'complete',
-        ),
+        const WasmProgressResult(ok: true, state: 'complete'),
       );
 
       await monty.resume({
@@ -447,10 +428,7 @@ void main() {
 
     test('returns MontyComplete after error injection', () async {
       mock.resumeWithErrorResults.add(
-        const WasmProgressResult(
-          ok: true,
-          state: 'complete',
-        ),
+        const WasmProgressResult(ok: true, state: 'complete'),
       );
 
       final progress = await monty.resumeWithError('network failure');
@@ -479,18 +457,12 @@ void main() {
 
     test('throws StateError when idle', () {
       final freshMonty = MontyWasm(bindings: mock);
-      expect(
-        () => freshMonty.resumeWithError('err'),
-        throwsStateError,
-      );
+      expect(() => freshMonty.resumeWithError('err'), throwsStateError);
     });
 
     test('throws StateError when disposed', () async {
       await monty.dispose();
-      expect(
-        () => monty.resumeWithError('err'),
-        throwsStateError,
-      );
+      expect(() => monty.resumeWithError('err'), throwsStateError);
     });
   });
 
@@ -569,10 +541,7 @@ void main() {
 
     test('throws StateError when disposed', () async {
       await monty.dispose();
-      expect(
-        () => monty.restore(Uint8List.fromList([1])),
-        throwsStateError,
-      );
+      expect(() => monty.restore(Uint8List.fromList([1])), throwsStateError);
     });
 
     test('throws StateError when active', () async {
@@ -584,10 +553,7 @@ void main() {
       );
       await monty.start('x', externalFunctions: ['f']);
 
-      expect(
-        () => monty.restore(Uint8List.fromList([1])),
-        throwsStateError,
-      );
+      expect(() => monty.restore(Uint8List.fromList([1])), throwsStateError);
     });
   });
 
@@ -628,10 +594,7 @@ void main() {
         functionName: 'noop',
       );
 
-      final progress = await monty.start(
-        'noop()',
-        externalFunctions: ['noop'],
-      );
+      final progress = await monty.start('noop()', externalFunctions: ['noop']);
 
       final pending = progress as MontyPending;
       expect(pending.arguments, isEmpty);
@@ -645,10 +608,7 @@ void main() {
         arguments: [],
       );
 
-      final progress = await monty.start(
-        'noop()',
-        externalFunctions: ['noop'],
-      );
+      final progress = await monty.start('noop()', externalFunctions: ['noop']);
 
       final pending = progress as MontyPending;
       expect(pending.arguments, isEmpty);
@@ -660,10 +620,7 @@ void main() {
         state: 'pending',
       );
 
-      final progress = await monty.start(
-        'x()',
-        externalFunctions: ['x'],
-      );
+      final progress = await monty.start('x()', externalFunctions: ['x']);
 
       final pending = progress as MontyPending;
       expect(pending.functionName, '');
@@ -694,10 +651,7 @@ void main() {
     test('partial limits encode only present fields', () async {
       mock.nextRunResult = const WasmRunResult(ok: true, value: 1);
 
-      await monty.run(
-        '1',
-        limits: const MontyLimits(timeoutMs: 300),
-      );
+      await monty.run('1', limits: const MontyLimits(timeoutMs: 300));
 
       final limitsJson = mock.runCalls.first.limitsJson;
       expect(limitsJson, isNotNull);
@@ -740,10 +694,7 @@ void main() {
         methodCall: true,
       );
 
-      final progress = await monty.start(
-        'x',
-        externalFunctions: ['fetch'],
-      );
+      final progress = await monty.start('x', externalFunctions: ['fetch']);
 
       final pending = progress as MontyPending;
       expect(pending.callId, 42);
@@ -757,10 +708,7 @@ void main() {
         functionName: 'f',
       );
 
-      final progress = await monty.start(
-        'x',
-        externalFunctions: ['f'],
-      );
+      final progress = await monty.start('x', externalFunctions: ['f']);
 
       final pending = progress as MontyPending;
       expect(pending.kwargs, isNull);
@@ -828,11 +776,7 @@ void main() {
         errorType: 'NameError',
         excType: 'NameError',
         traceback: [
-          {
-            'filename': 'test.py',
-            'start_line': 5,
-            'start_column': 2,
-          },
+          {'filename': 'test.py', 'start_line': 5, 'start_column': 2},
         ],
       );
 
@@ -882,23 +826,25 @@ void main() {
   // Async/Futures (M13) — forward-compat state handling
   // ===========================================================================
   group('async/futures (M13)', () {
-    test('start() returns MontyResolveFutures for resolve_futures state',
-        () async {
-      mock.nextStartResult = const WasmProgressResult(
-        ok: true,
-        state: 'resolve_futures',
-        pendingCallIds: [0, 1, 2],
-      );
+    test(
+      'start() returns MontyResolveFutures for resolve_futures state',
+      () async {
+        mock.nextStartResult = const WasmProgressResult(
+          ok: true,
+          state: 'resolve_futures',
+          pendingCallIds: [0, 1, 2],
+        );
 
-      final progress = await monty.start(
-        'await asyncio.gather(a(), b(), c())',
-        externalFunctions: ['a', 'b', 'c'],
-      );
+        final progress = await monty.start(
+          'await asyncio.gather(a(), b(), c())',
+          externalFunctions: ['a', 'b', 'c'],
+        );
 
-      expect(progress, isA<MontyResolveFutures>());
-      final rf = progress as MontyResolveFutures;
-      expect(rf.pendingCallIds, [0, 1, 2]);
-    });
+        expect(progress, isA<MontyResolveFutures>());
+        final rf = progress as MontyResolveFutures;
+        expect(rf.pendingCallIds, [0, 1, 2]);
+      },
+    );
 
     test('resolve_futures state defaults to empty pendingCallIds', () async {
       mock.nextStartResult = const WasmProgressResult(

--- a/packages/dart_monty_wasm/test/wasm_core_bindings_test.dart
+++ b/packages/dart_monty_wasm/test/wasm_core_bindings_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
 import 'package:dart_monty_wasm/src/wasm_bindings.dart';
 import 'package:dart_monty_wasm/src/wasm_core_bindings.dart';
 import 'package:test/test.dart';
@@ -176,10 +177,7 @@ void main() {
         methodCall: true,
       );
 
-      final result = await bindings.start(
-        'x',
-        extFnsJson: '["fetch"]',
-      );
+      final result = await bindings.start('x', extFnsJson: '["fetch"]');
 
       expect(result.state, 'pending');
       expect(result.functionName, 'fetch');
@@ -268,11 +266,7 @@ void main() {
   group('resume()', () {
     test('delegates valueJson and translates result', () async {
       mock.resumeResults.add(
-        const WasmProgressResult(
-          ok: true,
-          state: 'complete',
-          value: 'done',
-        ),
+        const WasmProgressResult(ok: true, state: 'complete', value: 'done'),
       );
 
       final result = await bindings.resume('"hello"');
@@ -284,10 +278,7 @@ void main() {
 
     test('error translates to error state', () async {
       mock.resumeResults.add(
-        const WasmProgressResult(
-          ok: false,
-          error: 'runtime error',
-        ),
+        const WasmProgressResult(ok: false, error: 'runtime error'),
       );
 
       final result = await bindings.resume('null');
@@ -303,10 +294,7 @@ void main() {
   group('resumeWithError()', () {
     test('delegates errorMessage and translates result', () async {
       mock.resumeWithErrorResults.add(
-        const WasmProgressResult(
-          ok: true,
-          state: 'complete',
-        ),
+        const WasmProgressResult(ok: true, state: 'complete'),
       );
 
       final result = await bindings.resumeWithError('network failure');
@@ -325,10 +313,7 @@ void main() {
     });
 
     test('resolveFutures throws UnsupportedError', () {
-      expect(
-        () => bindings.resolveFutures('{}', '{}'),
-        throwsUnsupportedError,
-      );
+      expect(() => bindings.resolveFutures('{}', '{}'), throwsUnsupportedError);
     });
   });
 
@@ -354,6 +339,102 @@ void main() {
 
       expect(mock.restoreCalls, hasLength(1));
       expect(mock.restoreCalls.first, data);
+    });
+  });
+
+  // ===========================================================================
+  // cancel()
+  // ===========================================================================
+  group('cancel()', () {
+    test('delegates to bindings', () async {
+      await bindings.cancel();
+      expect(mock.cancelCalls, 1);
+    });
+  });
+
+  // ===========================================================================
+  // handleId
+  // ===========================================================================
+  group('handleId', () {
+    test('is null before init', () {
+      expect(bindings.handleId, isNull);
+    });
+
+    test('is set after init via webRegister', () async {
+      await bindings.init();
+      expect(bindings.handleId, isNotNull);
+      expect(bindings.handleId, greaterThan(0));
+    });
+  });
+
+  // ===========================================================================
+  // web cancel error mapping
+  // ===========================================================================
+  group('_throwIfWebCancelError', () {
+    test('run: MontyCancelled prefix throws MontyCancelledError', () async {
+      mock
+        ..nextRunResult = const WasmRunResult(ok: true, value: 1)
+        ..throwOnRun = 'MontyCancelled: Worker terminated';
+
+      await expectLater(
+        () => bindings.run('x'),
+        throwsA(isA<MontyCancelledError>()),
+      );
+    });
+
+    test('run: MontyDisposed prefix throws MontyDisposedError', () async {
+      mock.throwOnRun = 'MontyDisposed: Session disposed';
+
+      await expectLater(
+        () => bindings.run('x'),
+        throwsA(isA<MontyDisposedError>()),
+      );
+    });
+
+    test('run: MontyWorkerError prefix throws MontyResourceError', () async {
+      mock.throwOnRun = 'MontyWorkerError: WASM OOM';
+
+      await expectLater(
+        () => bindings.run('x'),
+        throwsA(isA<MontyResourceError>()),
+      );
+    });
+
+    test('run: unrecognized error rethrows as-is', () async {
+      mock.throwOnRun = 'SomeOtherError';
+
+      await expectLater(
+        () => bindings.run('x'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('start: MontyCancelled prefix throws MontyCancelledError', () async {
+      mock.throwOnStart = 'MontyCancelled: Worker terminated';
+
+      await expectLater(
+        () => bindings.start('x'),
+        throwsA(isA<MontyCancelledError>()),
+      );
+    });
+
+    test('resume: MontyCancelled prefix throws MontyCancelledError', () async {
+      mock.throwOnResume = 'MontyCancelled: Worker terminated';
+
+      await expectLater(
+        () => bindings.resume('"x"'),
+        throwsA(isA<MontyCancelledError>()),
+      );
+    });
+
+    test('resumeWithError: MontyCancelled prefix throws MontyCancelledError',
+        () async {
+      mock.throwOnResumeWithError = 'MontyCancelled: Worker terminated';
+
+      await expectLater(
+        () => bindings.resumeWithError('err'),
+        throwsA(isA<MontyCancelledError>()),
+      );
     });
   });
 

--- a/spike/web_test/web/monty_glue.js
+++ b/spike/web_test/web/monty_glue.js
@@ -2,150 +2,197 @@
  * monty_glue.js — Bridge between @pydantic/monty WASM Worker and Dart JS interop.
  *
  * Monty WASM runs inside a Web Worker (monty_worker.js) to bypass Chrome's
- * 8MB synchronous WASM compile limit. This glue exposes window.montyBridge
- * with methods Dart can call via dart:js_interop.
+ * 8MB synchronous WASM compile limit. Each DartMontyBridge instance manages
+ * its own Worker — instance fields (not static) prevent cross-session
+ * promise routing bugs when multiple WASM sessions exist concurrently.
  */
 
-let worker = null;
-let nextId = 1;
-const pending = new Map(); // id -> { resolve, reject }
+class DartMontyBridge {
+  constructor() {
+    this._worker = null;
+    this._nextId = 1;
+    this._pending = new Map(); // id -> { resolve, reject }
+  }
 
-/**
- * Initialize the Monty Worker.
- *
- * @returns {Promise<boolean>} true if Worker loaded WASM successfully.
- */
-async function init() {
-  if (worker) return true;
-  return new Promise((resolve) => {
-    try {
-      worker = new Worker(
-        new URL('./monty_worker.js', window.location.href),
-        { type: 'module' },
-      );
-
-      worker.onmessage = (e) => {
-        const msg = e.data;
-
-        if (msg.type === 'ready') {
-          console.log('[monty_glue] Worker ready, exports:', msg.exports.join(', '));
-          resolve(true);
-          return;
-        }
-
-        if (msg.type === 'error' && !msg.id) {
-          console.error('[monty_glue] Worker init error:', msg.message);
-          resolve(false);
-          return;
-        }
-
-        // Route responses to pending promises
-        if (msg.id && pending.has(msg.id)) {
-          const { resolve: res } = pending.get(msg.id);
-          pending.delete(msg.id);
-          res(msg);
-        }
-      };
-
-      worker.onerror = (err) => {
-        console.error('[monty_glue] Worker error:', err.message || err);
-        resolve(false);
-      };
-    } catch (e) {
-      console.error('[monty_glue] Failed to create Worker:', e.message);
-      resolve(false);
+  /**
+   * Reject all pending promises. Shared by cancel(), dispose(), and onerror.
+   * Idempotent — safe to call multiple times.
+   *
+   * @param {string} reason  Error message forwarded to Dart as the rejection value.
+   */
+  _rejectPending(reason) {
+    const error = new Error(reason);
+    for (const [, { reject }] of this._pending) {
+      reject(error);
     }
-  });
-}
-
-/**
- * Send a message to the Worker and wait for a response.
- */
-function callWorker(msg) {
-  return new Promise((resolve, reject) => {
-    const id = nextId++;
-    pending.set(id, { resolve, reject });
-    worker.postMessage({ ...msg, id });
-  });
-}
-
-/**
- * Run Python code to completion.
- *
- * @param {string} code  Python source code.
- * @returns {string} JSON result.
- */
-async function run(code) {
-  if (!worker) {
-    return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+    this._pending.clear();
   }
-  const result = await callWorker({ type: 'run', code });
-  return JSON.stringify(result);
-}
 
-/**
- * Start iterative execution.
- *
- * @param {string} code        Python source code.
- * @param {string} extFnsJson  JSON array of external function names.
- * @returns {string} JSON result.
- */
-async function start(code, extFnsJson) {
-  if (!worker) {
-    return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+  /**
+   * Initialize the Monty Worker.
+   *
+   * @returns {Promise<boolean>} true if Worker loaded WASM successfully.
+   */
+  async init() {
+    if (this._worker) return true;
+    return new Promise((resolve) => {
+      try {
+        this._worker = new Worker(
+          new URL('./monty_worker.js', window.location.href),
+          { type: 'module' },
+        );
+
+        this._worker.onmessage = (e) => {
+          const msg = e.data;
+
+          if (msg.type === 'ready') {
+            console.log('[monty_glue] Worker ready, exports:', msg.exports.join(', '));
+            resolve(true);
+            return;
+          }
+
+          if (msg.type === 'error' && !msg.id) {
+            console.error('[monty_glue] Worker init error:', msg.message);
+            resolve(false);
+            return;
+          }
+
+          // Route responses to pending promises
+          if (msg.id && this._pending.has(msg.id)) {
+            const { resolve: res } = this._pending.get(msg.id);
+            this._pending.delete(msg.id);
+            res(msg);
+          }
+        };
+
+        this._worker.onerror = (event) => {
+          this._rejectPending(`MontyWorkerError: ${event.message}`);
+          this._worker = null; // Dead after trap
+        };
+      } catch (e) {
+        console.error('[monty_glue] Failed to create Worker:', e.message);
+        resolve(false);
+      }
+    });
   }
-  const extFns = JSON.parse(extFnsJson || '[]');
-  const result = await callWorker({ type: 'start', code, extFns });
-  return JSON.stringify(result);
-}
 
-/**
- * Resume a paused execution.
- *
- * @param {string} valueJson  JSON value to return to Python.
- * @returns {string} JSON result.
- */
-async function resume(valueJson) {
-  if (!worker) {
-    return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+  /**
+   * Send a message to the Worker and wait for a response.
+   */
+  _callWorker(msg) {
+    return new Promise((resolve, reject) => {
+      const id = this._nextId++;
+      this._pending.set(id, { resolve, reject });
+      this._worker.postMessage({ ...msg, id });
+    });
   }
-  const value = JSON.parse(valueJson);
-  const result = await callWorker({ type: 'resume', value });
-  return JSON.stringify(result);
-}
 
-/**
- * Discover available API surface.
- *
- * @returns {string} JSON describing state.
- */
-function discover() {
-  return JSON.stringify({ loaded: worker !== null, architecture: 'worker' });
-}
-
-/**
- * Resume a paused execution with an error.
- *
- * @param {string} errorJson  JSON error message to propagate to Python.
- * @returns {string} JSON result.
- */
-async function resumeWithError(errorJson) {
-  if (!worker) {
-    return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+  /**
+   * Run Python code to completion.
+   *
+   * @param {string} code  Python source code.
+   * @returns {string} JSON result.
+   */
+  async run(code) {
+    if (!this._worker) {
+      return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+    }
+    const result = await this._callWorker({ type: 'run', code });
+    return JSON.stringify(result);
   }
-  const errorMessage = JSON.parse(errorJson);
-  const result = await callWorker({ type: 'resumeWithError', errorMessage });
-  return JSON.stringify(result);
+
+  /**
+   * Start iterative execution.
+   *
+   * @param {string} code        Python source code.
+   * @param {string} extFnsJson  JSON array of external function names.
+   * @returns {string} JSON result.
+   */
+  async start(code, extFnsJson) {
+    if (!this._worker) {
+      return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+    }
+    const extFns = JSON.parse(extFnsJson || '[]');
+    const result = await this._callWorker({ type: 'start', code, extFns });
+    return JSON.stringify(result);
+  }
+
+  /**
+   * Resume a paused execution.
+   *
+   * @param {string} valueJson  JSON value to return to Python.
+   * @returns {string} JSON result.
+   */
+  async resume(valueJson) {
+    if (!this._worker) {
+      return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+    }
+    const value = JSON.parse(valueJson);
+    const result = await this._callWorker({ type: 'resume', value });
+    return JSON.stringify(result);
+  }
+
+  /**
+   * Resume a paused execution with an error.
+   *
+   * @param {string} errorJson  JSON error message to propagate to Python.
+   * @returns {string} JSON result.
+   */
+  async resumeWithError(errorJson) {
+    if (!this._worker) {
+      return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+    }
+    const errorMessage = JSON.parse(errorJson);
+    const result = await this._callWorker({ type: 'resumeWithError', errorMessage });
+    return JSON.stringify(result);
+  }
+
+  /**
+   * Discover available API surface.
+   *
+   * @returns {string} JSON describing state.
+   */
+  discover() {
+    return JSON.stringify({ loaded: this._worker !== null, architecture: 'worker' });
+  }
+
+  /**
+   * Hard-kill the Worker. Idempotent — safe to call multiple times.
+   * Rejects any pending execution promise so Dart's blocked Future completes.
+   *
+   * @returns {string} JSON { ok: true } — always succeeds (matches native semantics).
+   */
+  async cancel() {
+    this._rejectPending('MontyCancelled: Worker terminated via cancel()');
+
+    if (this._worker) {
+      this._worker.terminate();
+      this._worker = null;
+    }
+
+    return JSON.stringify({ ok: true });
+  }
+
+  /**
+   * Dispose the worker. Also rejects pending promises so Dart Futures
+   * don't hang if dispose() is called before cancel().
+   *
+   * @returns {string} JSON { ok: true }.
+   */
+  async dispose() {
+    this._rejectPending('MontyDisposed: Worker disposed before completion');
+
+    if (this._worker) {
+      this._worker.terminate();
+      this._worker = null;
+    }
+
+    return JSON.stringify({ ok: true });
+  }
 }
 
-// Expose bridge on window for Dart JS interop
-window.montyBridge = {
-  init,
-  run,
-  start,
-  resume,
-  resumeWithError,
-  discover,
-};
+// Expose the class on window for Dart @JS('DartMontyBridge') interop.
+// Dart calls `new DartMontyBridge()` to create per-session instances.
+window.DartMontyBridge = DartMontyBridge;
 
-console.log('[monty_glue] montyBridge registered on window (Worker architecture)');
+console.log('[monty_glue] DartMontyBridge class registered on window (Worker architecture)');


### PR DESCRIPTION
## Summary
- Wire cross-isolate cancellation from Rust C-ABI through FFI, platform interface, and web
- Sealed `MontyError` hierarchy (6 subtypes) with exhaustive Dart `switch`
- `MontyCancelToken` extension type for type-safe cross-isolate cancel
- Instance-based JS `DartMontyBridge` with `_rejectPending` pattern for web parity

## Changes
- **Rust/native**: `cancel_by_id`, `is_cancelled_by_id`, `free_by_id`, `get_handle_id` C exports
- **dart_monty_ffi**: `NativeBindingsFfi` cancel methods, `FfiCoreBindings` handleId/onHandleCreated callback, `_MontyErrorResponse` for sealed error forwarding, `_DisposeRequest` in terminate()
- **dart_monty_platform_interface**: Sealed `MontyError` (6 subtypes), `MontyCancelToken`, `BaseMontyPlatform` static cancel API + exception mapping, web registry
- **dart_monty_wasm**: Instance-based `JsDartMontyBridge`, `WasmCoreBindings.cancel()`, error prefix mapping
- **spike/web_test**: Rewritten `monty_glue.js` as `DartMontyBridge` class

## Test plan
- [x] T1-1: end-to-end cancel (5 trials), double/triple idempotency, cancel after completion
- [x] T1-2: cross-isolate MontyCancelToken routing (5 trials), isAlive, auto-init
- [x] T1-3: terminate resource release (5 trials), Rust registry freed, zombie count
- [x] T1-4: sealed error routing, exhaustive switch (6 subtypes), MockMontyPlatform
- [x] FFI unit tests: 167/167 (no regressions)
- [x] Platform interface: 9/9
- [x] Integration: 21/21 (3 consecutive runs, zero flakes)
- [x] `dart analyze --fatal-infos`: zero issues across all packages
- [x] Gemini review: 7/8 PASS, 1 INCONCLUSIVE (expected)