### PR TITLE
fix(web): repair web ladder runner with Dart-side bridge construction

### DIFF
--- a/spike/web_test/bin/ladder_runner.dart
+++ b/spike/web_test/bin/ladder_runner.dart
@@ -9,25 +9,22 @@ library;
 
 import 'dart:convert';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 
 // ---------------------------------------------------------------------------
-// JS interop bindings for window.montyBridge
+// JS interop bindings — Dart-side instance construction (Option B)
 // ---------------------------------------------------------------------------
 
-@JS('montyBridge.init')
-external JSPromise<JSBoolean> _montyInit();
-
-@JS('montyBridge.run')
-external JSPromise<JSString> _montyRun(JSString code);
-
-@JS('montyBridge.start')
-external JSPromise<JSString> _montyStart(JSString code, JSString extFnsJson);
-
-@JS('montyBridge.resume')
-external JSPromise<JSString> _montyResume(JSString valueJson);
-
-@JS('montyBridge.resumeWithError')
-external JSPromise<JSString> _montyResumeWithError(JSString errorJson);
+@JS('DartMontyBridge')
+extension type DartMontyBridge._(JSObject _) implements JSObject {
+  external DartMontyBridge();
+  external JSPromise<JSBoolean> init();
+  external JSPromise<JSString> run(JSString code);
+  external JSPromise<JSString> start(JSString code, JSString extFnsJson);
+  external JSPromise<JSString> resume(JSString valueJson);
+  external JSPromise<JSString> resumeWithError(JSString errorJson);
+  external JSPromise dispose();
+}
 
 // ---------------------------------------------------------------------------
 // JS fetch interop
@@ -82,8 +79,20 @@ void _output(Map<String, dynamic> result) {
 Future<void> main() async {
   print('=== Web Python Ladder Runner ===');
 
-  // Initialize Monty Worker
-  final ok = (await _montyInit().toDart).toDart;
+  // Wait for the JS module to attach DartMontyBridge to the window.
+  var retries = 0;
+  while (!globalContext.has('DartMontyBridge')) {
+    if (retries++ > 50) {
+      print('LADDER_ERROR:DartMontyBridge class never loaded on window');
+      print('LADDER_DONE');
+      return;
+    }
+    await Future.delayed(const Duration(milliseconds: 50));
+  }
+
+  final bridge = DartMontyBridge();
+
+  final ok = (await bridge.init().toDart).toDart;
   if (!ok) {
     print('LADDER_ERROR:Monty Worker init failed');
     print('LADDER_DONE');
@@ -107,7 +116,7 @@ Future<void> main() async {
           continue;
         }
 
-        final result = await _runFixture(fixture);
+        final result = await _runFixture(bridge, fixture);
         _output(result);
       }
     } catch (e) {
@@ -115,10 +124,12 @@ Future<void> main() async {
     }
   }
 
+  await bridge.dispose().toDart;
   print('LADDER_DONE');
 }
 
 Future<Map<String, dynamic>> _runFixture(
+  DartMontyBridge bridge,
   Map<String, dynamic> fixture,
 ) async {
   final id = fixture['id'] as int;
@@ -129,11 +140,11 @@ Future<Map<String, dynamic>> _runFixture(
   Map<String, dynamic> result;
   try {
     if (fixture['externalFunctions'] != null) {
-      result = await _runIterative(fixture);
+      result = await _runIterative(bridge, fixture);
     } else if (expectError) {
-      result = await _runExpectError(id, code);
+      result = await _runExpectError(bridge, id, code);
     } else {
-      result = await _runSimple(id, code);
+      result = await _runSimple(bridge, id, code);
     }
   } catch (e) {
     result = {'id': id, 'ok': false, 'error': '$e'};
@@ -149,16 +160,24 @@ Future<Map<String, dynamic>> _runFixture(
   return result;
 }
 
-Future<Map<String, dynamic>> _runSimple(int id, String code) async {
-  final result = _parseResult((await _montyRun(code.toJS).toDart).toDart);
+Future<Map<String, dynamic>> _runSimple(
+  DartMontyBridge bridge,
+  int id,
+  String code,
+) async {
+  final result = _parseResult((await bridge.run(code.toJS).toDart).toDart);
   if (result['ok'] == true) {
     return {'id': id, 'ok': true, 'value': result['value']};
   }
   return {'id': id, 'ok': false, 'error': result['error']};
 }
 
-Future<Map<String, dynamic>> _runExpectError(int id, String code) async {
-  final result = _parseResult((await _montyRun(code.toJS).toDart).toDart);
+Future<Map<String, dynamic>> _runExpectError(
+  DartMontyBridge bridge,
+  int id,
+  String code,
+) async {
+  final result = _parseResult((await bridge.run(code.toJS).toDart).toDart);
   if (result['ok'] == false) {
     // Expected an error — report success with the error message
     return {'id': id, 'ok': true, 'error': result['error']};
@@ -167,6 +186,7 @@ Future<Map<String, dynamic>> _runExpectError(int id, String code) async {
 }
 
 Future<Map<String, dynamic>> _runIterative(
+  DartMontyBridge bridge,
   Map<String, dynamic> fixture,
 ) async {
   final id = fixture['id'] as int;
@@ -177,7 +197,7 @@ Future<Map<String, dynamic>> _runIterative(
 
   // Start iterative execution
   var resultJson = _parseResult(
-    (await _montyStart(code.toJS, jsonEncode(extFns).toJS).toDart).toDart,
+    (await bridge.start(code.toJS, jsonEncode(extFns).toJS).toDart).toDart,
   );
 
   if (resultJson['ok'] != true) {
@@ -190,9 +210,11 @@ Future<Map<String, dynamic>> _runIterative(
         return {'id': id, 'ok': false, 'error': 'Expected pending state'};
       }
       resultJson = _parseResult(
-        (await _montyResumeWithError(
-          jsonEncode(errorMsg).toJS,
-        ).toDart)
+        (await bridge
+                .resumeWithError(
+                  jsonEncode(errorMsg).toJS,
+                )
+                .toDart)
             .toDart,
       );
     }
@@ -202,7 +224,7 @@ Future<Map<String, dynamic>> _runIterative(
         return {'id': id, 'ok': false, 'error': 'Expected pending state'};
       }
       resultJson = _parseResult(
-        (await _montyResume(jsonEncode(value).toJS).toDart).toDart,
+        (await bridge.resume(jsonEncode(value).toJS).toDart).toDart,
       );
     }
   }

--- a/tool/test_python_ladder.sh
+++ b/tool/test_python_ladder.sh
@@ -155,6 +155,7 @@ sed -i.bak 's|new URL("@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs"|new 
   web/monty_worker.js && rm -f web/monty_worker.js.bak
 
 cp node_modules/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs web/ 2>/dev/null || true
+cp node_modules/@pydantic/monty-wasm32-wasi/monty.wasm32-wasi.wasm web/ 2>/dev/null || true
 
 echo "  esbuild: bundle glue"
 npx esbuild web/monty_glue.js \


### PR DESCRIPTION
## Summary
- Replace global `@JS('montyBridge.*')` bindings with `extension type DartMontyBridge` that constructs the JS class from Dart (Option B)
- Add missing `cp` for `monty.wasm32-wasi.wasm` to `web/` in `tool/test_python_ladder.sh`
- Add `globalContext.has('DartMontyBridge')` polling guard for module-vs-defer race condition

## Changes
- **spike/web_test/bin/ladder_runner.dart**: Rewrite JS interop to Dart-side instance construction, thread `bridge` through all helpers
- **tool/test_python_ladder.sh**: Copy WASM binary alongside `wasi-worker-browser.mjs`

## Context
The web ladder runner was completely broken — `window.montyBridge` was never defined (only the CLASS at `window.DartMontyBridge`), and the WASM binary wasn't being copied to the served directory. After this fix, all 100+ tier fixtures pass in headless Chrome.

## Known follow-ups
- #TBD: `LADDER_DONE` signal not captured (Chrome exits before async completion)
- #TBD: `check_ladder_results` schema mismatch (`"tier"/"test"` vs `"id"/"ok"`)

## Test plan
- [x] `dart analyze --fatal-infos` clean
- [x] `dart format` clean
- [x] `bash tool/test_python_ladder.sh` — all 100+ web fixtures pass