### PR TITLE
fix(bridge): add MontyCancelledError and MontyError catch blocks

### DIFF
--- a/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
@@ -183,6 +183,15 @@ class DefaultMontyBridge implements MontyBridge {
             return;
         }
       }
+    } on MontyCancelledError {
+      controller.add(const BridgeRunError(message: 'Execution cancelled'));
+    } on MontyError catch (e) {
+      log.warning('Monty error', attributes: {'error': e.message});
+      _flushPrintBuffer(printBuffer, controller);
+      final output = printBuffer.isNotEmpty ? printBuffer.toString() : null;
+      controller.add(
+        BridgeRunError(message: e.message, printOutput: output),
+      );
     } on MontyException catch (e) {
       log.warning('Python error', attributes: {'error': e.message});
       _flushPrintBuffer(printBuffer, controller);


### PR DESCRIPTION
## Summary
- Add explicit catch blocks for `MontyCancelledError` and `MontyError` in `DefaultMontyBridge._run()`
- Without these, cancellation errors fell through to `on Object` catch, logging clean cancels as infrastructure errors

## Changes
- **default_monty_bridge.dart**: Two new catches before existing `MontyException` catch:
  - `on MontyCancelledError` → `BridgeRunError(message: 'Execution cancelled')` (no print flush)
  - `on MontyError` → `BridgeRunError(message: e.message, printOutput: ...)` with warning log

## Test plan
- [x] dart_monty_bridge: 89/89 tests pass
- [x] dart analyze --fatal-infos: 0 issues
- [x] dart format: no changes