### PR TITLE
chore(format): apply dart format tall style

### DIFF
--- a/example/desktop/lib/main.dart
+++ b/example/desktop/lib/main.dart
@@ -62,22 +62,13 @@ class _MontyPageState extends State<MontyPage> {
         onTap: (i) => setState(() => _tabIndex = i),
         type: BottomNavigationBarType.fixed,
         items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.code),
-            label: 'Examples',
-          ),
+          BottomNavigationBarItem(icon: Icon(Icons.code), label: 'Examples'),
           BottomNavigationBarItem(
             icon: Icon(Icons.bar_chart),
             label: 'Sorting',
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.route),
-            label: 'TSP',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.checklist),
-            label: 'Ladder',
-          ),
+          BottomNavigationBarItem(icon: Icon(Icons.route), label: 'TSP'),
+          BottomNavigationBarItem(icon: Icon(Icons.checklist), label: 'Ladder'),
         ],
       ),
     );
@@ -217,8 +208,9 @@ class _ExamplesPageState extends State<_ExamplesPage> {
                     min: 10,
                     max: 10000,
                     divisions: 100,
-                    onChanged:
-                        _running ? null : (v) => setState(() => _timeoutMs = v),
+                    onChanged: _running
+                        ? null
+                        : (v) => setState(() => _timeoutMs = v),
                   ),
                 ),
               ],
@@ -235,8 +227,9 @@ class _ExamplesPageState extends State<_ExamplesPage> {
                     min: 1,
                     max: 64,
                     divisions: 63,
-                    onChanged:
-                        _running ? null : (v) => setState(() => _memoryMb = v),
+                    onChanged: _running
+                        ? null
+                        : (v) => setState(() => _memoryMb = v),
                   ),
                 ),
               ],
@@ -328,7 +321,7 @@ enum _Algorithm {
   tim,
   shell,
   cocktail,
-  sleep
+  sleep,
 }
 
 /// Speed presets mapping labels to delay in milliseconds.
@@ -450,7 +443,8 @@ class _VisualizerPageState extends State<_VisualizerPage> {
             _highlightI = -1;
             _highlightJ = -1;
             _currentAction = _BarAction.sorted;
-            _status = 'Done in ${_elapsed()} — $_steps steps '
+            _status =
+                'Done in ${_elapsed()} — $_steps steps '
                 '($_comparisons cmp, $_swaps swaps)';
             _sorting = false;
           });
@@ -464,8 +458,9 @@ class _VisualizerPageState extends State<_VisualizerPage> {
             _bars = stepArr;
             _highlightI = i;
             _highlightJ = j;
-            _currentAction =
-                action == 'swap' ? _BarAction.swapped : _BarAction.comparing;
+            _currentAction = action == 'swap'
+                ? _BarAction.swapped
+                : _BarAction.comparing;
             if (delayMs == 0) {
               _status = 'Sorting... ${_elapsed()} — $_steps steps';
             }
@@ -563,8 +558,9 @@ class _VisualizerPageState extends State<_VisualizerPage> {
               ButtonSegment(value: _Algorithm.sleep, label: Text('Sleep')),
             ],
             selected: {_algorithm},
-            onSelectionChanged:
-                _sorting ? null : (v) => setState(() => _algorithm = v.first),
+            onSelectionChanged: _sorting
+                ? null
+                : (v) => setState(() => _algorithm = v.first),
           ),
           const SizedBox(height: 12),
 
@@ -624,17 +620,20 @@ class _VisualizerPageState extends State<_VisualizerPage> {
                 ? const Center(child: Text('Press Start to begin'))
                 : LayoutBuilder(
                     builder: (context, constraints) {
-                      final maxVal =
-                          _bars.reduce((a, b) => a > b ? a : b).toDouble();
+                      final maxVal = _bars
+                          .reduce((a, b) => a > b ? a : b)
+                          .toDouble();
                       return Row(
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: List.generate(_bars.length, (i) {
-                          final height =
-                              maxVal > 0 ? (_bars[i] / maxVal) * 270 : 0.0;
+                          final height = maxVal > 0
+                              ? (_bars[i] / maxVal) * 270
+                              : 0.0;
                           return Expanded(
                             child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 0.5),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 0.5,
+                              ),
                               child: Container(
                                 height: height,
                                 decoration: BoxDecoration(
@@ -724,8 +723,9 @@ class _TspPageState extends State<_TspPage> {
       _cityCount.toInt(),
       (_) => [rng.nextInt(100), rng.nextInt(100)],
     );
-    return _tspTemplateFor(_algorithm)
-        .replaceAll('INPUT_CITIES', cities.toString());
+    return _tspTemplateFor(
+      _algorithm,
+    ).replaceAll('INPUT_CITIES', cities.toString());
   }
 
   void _startTsp() {
@@ -845,14 +845,12 @@ class _TspPageState extends State<_TspPage> {
                 value: _TspAlgorithm.nearestNeighbor,
                 label: Text('Nearest Neighbor'),
               ),
-              ButtonSegment(
-                value: _TspAlgorithm.twoOpt,
-                label: Text('2-opt'),
-              ),
+              ButtonSegment(value: _TspAlgorithm.twoOpt, label: Text('2-opt')),
             ],
             selected: {_algorithm},
-            onSelectionChanged:
-                _running ? null : (v) => setState(() => _algorithm = v.first),
+            onSelectionChanged: _running
+                ? null
+                : (v) => setState(() => _algorithm = v.first),
           ),
           const SizedBox(height: 12),
           Row(
@@ -865,14 +863,12 @@ class _TspPageState extends State<_TspPage> {
                   max: 40,
                   divisions: 7,
                   label: _cityCount.toInt().toString(),
-                  onChanged:
-                      _running ? null : (v) => setState(() => _cityCount = v),
+                  onChanged: _running
+                      ? null
+                      : (v) => setState(() => _cityCount = v),
                 ),
               ),
-              SizedBox(
-                width: 32,
-                child: Text(_cityCount.toInt().toString()),
-              ),
+              SizedBox(width: 32, child: Text(_cityCount.toInt().toString())),
             ],
           ),
           Row(
@@ -948,11 +944,7 @@ class _TspPageState extends State<_TspPage> {
 }
 
 class _TspPainter extends CustomPainter {
-  _TspPainter({
-    required this.cities,
-    required this.route,
-    required this.done,
-  });
+  _TspPainter({required this.cities, required this.route, required this.done});
 
   final List<List<int>> cities;
   final List<int> route;
@@ -1161,8 +1153,8 @@ class _LadderPageState extends State<_LadderPage> {
     final expected = fixture['expected'];
     final expectedContains = fixture['expectedContains'] as String?;
     final expectError = fixture['expectError'] as bool? ?? false;
-    final externalFunctions =
-        (fixture['externalFunctions'] as List?)?.cast<String>();
+    final externalFunctions = (fixture['externalFunctions'] as List?)
+        ?.cast<String>();
     final resumeValues = fixture['resumeValues'] as List?;
     final resumeErrors = fixture['resumeErrors'] as List?;
 
@@ -1255,7 +1247,8 @@ class _LadderPageState extends State<_LadderPage> {
       if (errorContains != null && !e.message.contains(errorContains)) {
         result
           ..status = _TestStatus.fail
-          ..detail = 'expected error containing "$errorContains", '
+          ..detail =
+              'expected error containing "$errorContains", '
               'got: ${e.message}';
         _fail++;
       } else {
@@ -1319,7 +1312,8 @@ class _LadderPageState extends State<_LadderPage> {
           if (errorContains != null && !e.message.contains(errorContains)) {
             result
               ..status = _TestStatus.fail
-              ..detail = 'expected error containing "$errorContains", '
+              ..detail =
+                  'expected error containing "$errorContains", '
                   'got: ${e.message}';
             _fail++;
           } else {
@@ -1341,7 +1335,8 @@ class _LadderPageState extends State<_LadderPage> {
           if (errorContains != null && !errMsg.contains(errorContains)) {
             result
               ..status = _TestStatus.fail
-              ..detail = 'expected error containing "$errorContains", '
+              ..detail =
+                  'expected error containing "$errorContains", '
                   'got: $errMsg';
             _fail++;
           } else {
@@ -1362,8 +1357,9 @@ class _LadderPageState extends State<_LadderPage> {
       var resumeIdx = 0;
       while (progress is MontyPending) {
         if (resumeErrors != null && resumeIdx < resumeErrors.length) {
-          progress =
-              await monty.resumeWithError(resumeErrors[resumeIdx].toString());
+          progress = await monty.resumeWithError(
+            resumeErrors[resumeIdx].toString(),
+          );
         } else if (resumeValues != null && resumeIdx < resumeValues.length) {
           progress = await monty.resume(resumeValues[resumeIdx]);
         } else {
@@ -1487,8 +1483,9 @@ class _LadderPageState extends State<_LadderPage> {
   Widget _tierHeader(int tier) {
     final expanded = _expandedTiers.contains(tier);
     final tierResults = _results.where((r) => r.tier == tier);
-    final tierPass =
-        tierResults.where((r) => r.status == _TestStatus.pass).length;
+    final tierPass = tierResults
+        .where((r) => r.status == _TestStatus.pass)
+        .length;
     final tierTotal = tierResults.length;
 
     return InkWell(
@@ -1509,10 +1506,7 @@ class _LadderPageState extends State<_LadderPage> {
             const SizedBox(width: 8),
             Text(
               'Tier $tier',
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
-              ),
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
             const Spacer(),
             Text(
@@ -1643,7 +1637,8 @@ class _LadderPageState extends State<_LadderPage> {
 
 String _templateFor(_Algorithm algo) {
   return switch (algo) {
-    _Algorithm.bubble => '''
+    _Algorithm.bubble =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 i = 0
@@ -1660,7 +1655,8 @@ while i < n:
     i = i + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.selection => '''
+    _Algorithm.selection =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 i = 0
@@ -1680,7 +1676,8 @@ while i < n:
     i = i + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.insertion => '''
+    _Algorithm.insertion =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 i = 1
@@ -1701,7 +1698,8 @@ while i < n:
     i = i + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.quick => '''
+    _Algorithm.quick =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 stack = [[0, n - 1]]
@@ -1733,7 +1731,8 @@ while len(stack) > 0:
         stack.append([p + 1, high])
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.tim => '''
+    _Algorithm.tim =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 RUN = 8
@@ -1800,7 +1799,8 @@ while size < n:
     size = size * 2
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.shell => '''
+    _Algorithm.shell =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 gap = n // 2
@@ -1824,7 +1824,8 @@ while gap > 0:
     gap = gap // 2
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.cocktail => '''
+    _Algorithm.cocktail =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 swapped = True
@@ -1859,7 +1860,8 @@ while swapped:
     start = start + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.sleep => '''
+    _Algorithm.sleep =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 result = []
@@ -1894,7 +1896,8 @@ arr''',
 
 String _tspTemplateFor(_TspAlgorithm algo) {
   return switch (algo) {
-    _TspAlgorithm.nearestNeighbor => '''
+    _TspAlgorithm.nearestNeighbor =>
+      '''
 cities = INPUT_CITIES
 n = len(cities)
 visited = []
@@ -1932,7 +1935,8 @@ dy = cities[route[n - 1]][1] - cities[route[0]][1]
 total = total + (dx * dx + dy * dy) ** 0.5
 yield_state(route, total, step, "done")
 route''',
-    _TspAlgorithm.twoOpt => '''
+    _TspAlgorithm.twoOpt =>
+      '''
 cities = INPUT_CITIES
 n = len(cities)
 route = []
@@ -2018,7 +2022,8 @@ class _Example {
     String code,
     MontyLimits? limits,
     void Function(String text, {bool isError}) log,
-  ) runner;
+  )
+  runner;
 }
 
 /// Performs a real HTTP GET, returning the response body or injecting an error
@@ -2053,19 +2058,20 @@ Future<MontyProgress> _httpFetch(
 
 final _examples = <_Example>[
   // 1. Expressions & resource usage
-  _Example(
-    '1. Expressions',
-    'sum(range(100_000))',
-    (monty, code, limits, log) async {
-      final result = await monty.run(code, limits: limits);
-      log('Result: ${result.value}');
-      log(
-        'Memory: ${result.usage.memoryBytesUsed} bytes  '
-        'Time: ${result.usage.timeElapsedMs} ms  '
-        'Stack: ${result.usage.stackDepthUsed}',
-      );
-    },
-  ),
+  _Example('1. Expressions', 'sum(range(100_000))', (
+    monty,
+    code,
+    limits,
+    log,
+  ) async {
+    final result = await monty.run(code, limits: limits);
+    log('Result: ${result.value}');
+    log(
+      'Memory: ${result.usage.memoryBytesUsed} bytes  '
+      'Time: ${result.usage.timeElapsedMs} ms  '
+      'Stack: ${result.usage.stackDepthUsed}',
+    );
+  }),
 
   // 2. Multi-line code (Fibonacci)
   _Example(
@@ -2191,7 +2197,9 @@ final _examples = <_Example>[
       final futureValues = <int, Object?>{};
       while (progress is! MontyComplete) {
         if (progress is MontyPending) {
-          log('Python awaits ${progress.functionName}() — converting to future');
+          log(
+            'Python awaits ${progress.functionName}() — converting to future',
+          );
           progress = await futurePlatform.resumeAsFuture();
         } else if (progress is MontyResolveFutures) {
           log('Resolving ${progress.pendingCallIds.length} futures...');

--- a/example/desktop/test/widget_test.dart
+++ b/example/desktop/test/widget_test.dart
@@ -3,8 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('app renders with bottom navigation and Examples tab',
-      (tester) async {
+  testWidgets('app renders with bottom navigation and Examples tab', (
+    tester,
+  ) async {
     await tester.pumpWidget(const MontyDesktopApp());
 
     expect(find.text('Monty Desktop Example'), findsOneWidget);

--- a/example/flutter_web/lib/main.dart
+++ b/example/flutter_web/lib/main.dart
@@ -82,9 +82,7 @@ class _MontyPageState extends State<MontyPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Monty Flutter Web Example'),
-      ),
+      appBar: AppBar(title: const Text('Monty Flutter Web Example')),
       body: IndexedStack(
         index: _tabIndex,
         children: const [
@@ -99,22 +97,13 @@ class _MontyPageState extends State<MontyPage> {
         onTap: (i) => setState(() => _tabIndex = i),
         type: BottomNavigationBarType.fixed,
         items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.code),
-            label: 'Examples',
-          ),
+          BottomNavigationBarItem(icon: Icon(Icons.code), label: 'Examples'),
           BottomNavigationBarItem(
             icon: Icon(Icons.bar_chart),
             label: 'Sorting',
           ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.route),
-            label: 'TSP',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.checklist),
-            label: 'Ladder',
-          ),
+          BottomNavigationBarItem(icon: Icon(Icons.route), label: 'TSP'),
+          BottomNavigationBarItem(icon: Icon(Icons.checklist), label: 'Ladder'),
         ],
       ),
     );
@@ -254,8 +243,9 @@ class _ExamplesPageState extends State<_ExamplesPage> {
                     min: 10,
                     max: 10000,
                     divisions: 100,
-                    onChanged:
-                        _running ? null : (v) => setState(() => _timeoutMs = v),
+                    onChanged: _running
+                        ? null
+                        : (v) => setState(() => _timeoutMs = v),
                   ),
                 ),
               ],
@@ -272,8 +262,9 @@ class _ExamplesPageState extends State<_ExamplesPage> {
                     min: 1,
                     max: 64,
                     divisions: 63,
-                    onChanged:
-                        _running ? null : (v) => setState(() => _memoryMb = v),
+                    onChanged: _running
+                        ? null
+                        : (v) => setState(() => _memoryMb = v),
                   ),
                 ),
               ],
@@ -365,7 +356,7 @@ enum _Algorithm {
   tim,
   shell,
   cocktail,
-  sleep
+  sleep,
 }
 
 /// Speed presets mapping labels to delay in milliseconds.
@@ -480,8 +471,9 @@ class _VisualizerPageState extends State<_VisualizerPage> {
           _bars = stepArr;
           _highlightI = i;
           _highlightJ = j;
-          _currentAction =
-              action == 'swap' ? _BarAction.swapped : _BarAction.comparing;
+          _currentAction = action == 'swap'
+              ? _BarAction.swapped
+              : _BarAction.comparing;
         });
 
         await Future<void>.delayed(
@@ -567,8 +559,9 @@ class _VisualizerPageState extends State<_VisualizerPage> {
               ButtonSegment(value: _Algorithm.sleep, label: Text('Sleep')),
             ],
             selected: {_algorithm},
-            onSelectionChanged:
-                _sorting ? null : (v) => setState(() => _algorithm = v.first),
+            onSelectionChanged: _sorting
+                ? null
+                : (v) => setState(() => _algorithm = v.first),
           ),
           const SizedBox(height: 12),
 
@@ -614,8 +607,9 @@ class _VisualizerPageState extends State<_VisualizerPage> {
           ElevatedButton(
             onPressed: _sorting ? _stopSort : _startSort,
             style: ElevatedButton.styleFrom(
-              backgroundColor:
-                  _sorting ? Colors.red.shade700 : Colors.green.shade700,
+              backgroundColor: _sorting
+                  ? Colors.red.shade700
+                  : Colors.green.shade700,
               foregroundColor: _kText,
             ),
             child: Text(_sorting ? 'Stop' : 'Start'),
@@ -629,17 +623,20 @@ class _VisualizerPageState extends State<_VisualizerPage> {
                 ? const Center(child: Text('Press Start to begin'))
                 : LayoutBuilder(
                     builder: (context, constraints) {
-                      final maxVal =
-                          _bars.reduce((a, b) => a > b ? a : b).toDouble();
+                      final maxVal = _bars
+                          .reduce((a, b) => a > b ? a : b)
+                          .toDouble();
                       return Row(
                         crossAxisAlignment: CrossAxisAlignment.end,
                         children: List.generate(_bars.length, (i) {
-                          final height =
-                              maxVal > 0 ? (_bars[i] / maxVal) * 270 : 0.0;
+                          final height = maxVal > 0
+                              ? (_bars[i] / maxVal) * 270
+                              : 0.0;
                           return Expanded(
                             child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 0.5),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 0.5,
+                              ),
                               child: Container(
                                 height: height,
                                 decoration: BoxDecoration(
@@ -727,8 +724,9 @@ class _TspPageState extends State<_TspPage> {
       _cityCount.toInt(),
       (_) => [rng.nextInt(100), rng.nextInt(100)],
     );
-    return _tspTemplateFor(_algorithm)
-        .replaceAll('INPUT_CITIES', cities.toString());
+    return _tspTemplateFor(
+      _algorithm,
+    ).replaceAll('INPUT_CITIES', cities.toString());
   }
 
   void _startTsp() {
@@ -848,14 +846,12 @@ class _TspPageState extends State<_TspPage> {
                 value: _TspAlgorithm.nearestNeighbor,
                 label: Text('Nearest Neighbor'),
               ),
-              ButtonSegment(
-                value: _TspAlgorithm.twoOpt,
-                label: Text('2-opt'),
-              ),
+              ButtonSegment(value: _TspAlgorithm.twoOpt, label: Text('2-opt')),
             ],
             selected: {_algorithm},
-            onSelectionChanged:
-                _running ? null : (v) => setState(() => _algorithm = v.first),
+            onSelectionChanged: _running
+                ? null
+                : (v) => setState(() => _algorithm = v.first),
           ),
           const SizedBox(height: 12),
           Row(
@@ -868,14 +864,12 @@ class _TspPageState extends State<_TspPage> {
                   max: 40,
                   divisions: 7,
                   label: _cityCount.toInt().toString(),
-                  onChanged:
-                      _running ? null : (v) => setState(() => _cityCount = v),
+                  onChanged: _running
+                      ? null
+                      : (v) => setState(() => _cityCount = v),
                 ),
               ),
-              SizedBox(
-                width: 32,
-                child: Text(_cityCount.toInt().toString()),
-              ),
+              SizedBox(width: 32, child: Text(_cityCount.toInt().toString())),
             ],
           ),
           Row(
@@ -899,8 +893,9 @@ class _TspPageState extends State<_TspPage> {
           ElevatedButton(
             onPressed: _running ? _stopTsp : _startTsp,
             style: ElevatedButton.styleFrom(
-              backgroundColor:
-                  _running ? Colors.red.shade700 : Colors.green.shade700,
+              backgroundColor: _running
+                  ? Colors.red.shade700
+                  : Colors.green.shade700,
               foregroundColor: _kText,
             ),
             child: Text(_running ? 'Stop' : 'Start'),
@@ -952,11 +947,7 @@ class _TspPageState extends State<_TspPage> {
 }
 
 class _TspPainter extends CustomPainter {
-  _TspPainter({
-    required this.cities,
-    required this.route,
-    required this.done,
-  });
+  _TspPainter({required this.cities, required this.route, required this.done});
 
   final List<List<int>> cities;
   final List<int> route;
@@ -1164,8 +1155,8 @@ class _LadderPageState extends State<_LadderPage> {
     final expected = fixture['expected'];
     final expectedContains = fixture['expectedContains'] as String?;
     final expectError = fixture['expectError'] as bool? ?? false;
-    final externalFunctions =
-        (fixture['externalFunctions'] as List?)?.cast<String>();
+    final externalFunctions = (fixture['externalFunctions'] as List?)
+        ?.cast<String>();
     final resumeValues = fixture['resumeValues'] as List?;
     final resumeErrors = fixture['resumeErrors'] as List?;
 
@@ -1246,7 +1237,8 @@ class _LadderPageState extends State<_LadderPage> {
       if (errorContains != null && !e.message.contains(errorContains)) {
         result
           ..status = _TestStatus.fail
-          ..detail = 'expected error containing "$errorContains", '
+          ..detail =
+              'expected error containing "$errorContains", '
               'got: ${e.message}';
         _fail++;
       } else {
@@ -1276,8 +1268,9 @@ class _LadderPageState extends State<_LadderPage> {
     var resumeIdx = 0;
     while (progress is MontyPending) {
       if (resumeErrors != null && resumeIdx < resumeErrors.length) {
-        progress =
-            await monty.resumeWithError(resumeErrors[resumeIdx].toString());
+        progress = await monty.resumeWithError(
+          resumeErrors[resumeIdx].toString(),
+        );
       } else if (resumeValues != null && resumeIdx < resumeValues.length) {
         progress = await monty.resume(resumeValues[resumeIdx]);
       } else {
@@ -1400,8 +1393,9 @@ class _LadderPageState extends State<_LadderPage> {
   Widget _tierHeader(int tier) {
     final expanded = _expandedTiers.contains(tier);
     final tierResults = _results.where((r) => r.tier == tier);
-    final tierPass =
-        tierResults.where((r) => r.status == _TestStatus.pass).length;
+    final tierPass = tierResults
+        .where((r) => r.status == _TestStatus.pass)
+        .length;
     final tierTotal = tierResults.length;
 
     return InkWell(
@@ -1422,10 +1416,7 @@ class _LadderPageState extends State<_LadderPage> {
             const SizedBox(width: 8),
             Text(
               'Tier $tier',
-              style: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
-              ),
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
             ),
             const Spacer(),
             Text(
@@ -1529,7 +1520,8 @@ class _LadderPageState extends State<_LadderPage> {
 
 String _templateFor(_Algorithm algo) {
   return switch (algo) {
-    _Algorithm.bubble => '''
+    _Algorithm.bubble =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 i = 0
@@ -1546,7 +1538,8 @@ while i < n:
     i = i + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.selection => '''
+    _Algorithm.selection =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 i = 0
@@ -1566,7 +1559,8 @@ while i < n:
     i = i + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.insertion => '''
+    _Algorithm.insertion =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 i = 1
@@ -1587,7 +1581,8 @@ while i < n:
     i = i + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.quick => '''
+    _Algorithm.quick =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 stack = [[0, n - 1]]
@@ -1619,7 +1614,8 @@ while len(stack) > 0:
         stack.append([p + 1, high])
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.tim => '''
+    _Algorithm.tim =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 RUN = 8
@@ -1686,7 +1682,8 @@ while size < n:
     size = size * 2
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.shell => '''
+    _Algorithm.shell =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 gap = n // 2
@@ -1710,7 +1707,8 @@ while gap > 0:
     gap = gap // 2
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.cocktail => '''
+    _Algorithm.cocktail =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 swapped = True
@@ -1745,7 +1743,8 @@ while swapped:
     start = start + 1
 yield_state(arr, -1, -1, "done")
 arr''',
-    _Algorithm.sleep => '''
+    _Algorithm.sleep =>
+      '''
 arr = INPUT_ARRAY[:]
 n = len(arr)
 result = []
@@ -1780,7 +1779,8 @@ arr''',
 
 String _tspTemplateFor(_TspAlgorithm algo) {
   return switch (algo) {
-    _TspAlgorithm.nearestNeighbor => '''
+    _TspAlgorithm.nearestNeighbor =>
+      '''
 cities = INPUT_CITIES
 n = len(cities)
 visited = []
@@ -1818,7 +1818,8 @@ dy = cities[route[n - 1]][1] - cities[route[0]][1]
 total = total + (dx * dx + dy * dy) ** 0.5
 yield_state(route, total, step, "done")
 route''',
-    _TspAlgorithm.twoOpt => '''
+    _TspAlgorithm.twoOpt =>
+      '''
 cities = INPUT_CITIES
 n = len(cities)
 route = []
@@ -1904,7 +1905,8 @@ class _Example {
     String code,
     MontyLimits? limits,
     void Function(String text, {bool isError}) log,
-  ) runner;
+  )
+  runner;
 }
 
 /// Performs an HTTP GET using package:http, returning the response body or
@@ -1937,19 +1939,15 @@ Future<MontyProgress> _httpFetch(
 
 final _examples = <_Example>[
   // 1. Expressions & resource usage
-  _Example(
-    '1. Expressions',
-    '2 ** 8',
-    (monty, code, limits, log) async {
-      final result = await monty.run(code, limits: limits);
-      log('Result: ${result.value}');
-      log(
-        'Memory: ${result.usage.memoryBytesUsed} bytes  '
-        'Time: ${result.usage.timeElapsedMs} ms  '
-        'Stack: ${result.usage.stackDepthUsed}',
-      );
-    },
-  ),
+  _Example('1. Expressions', '2 ** 8', (monty, code, limits, log) async {
+    final result = await monty.run(code, limits: limits);
+    log('Result: ${result.value}');
+    log(
+      'Memory: ${result.usage.memoryBytesUsed} bytes  '
+      'Time: ${result.usage.timeElapsedMs} ms  '
+      'Stack: ${result.usage.stackDepthUsed}',
+    );
+  }),
 
   // 2. Multi-line code (Fibonacci)
   _Example(

--- a/example/web-showcase/bin/showcase.dart
+++ b/example/web-showcase/bin/showcase.dart
@@ -250,9 +250,7 @@ Future<Object?> _dispatch(String fnName, List<dynamic> args) async {
       return DateTime.now().toIso8601String();
 
     case 'interpreter_snapshot':
-      final result = _parse(
-        (await _bridgeSnapshot().toDart).toDart,
-      );
+      final result = _parse((await _bridgeSnapshot().toDart).toDart);
       if (result['ok'] == true) {
         return result['data'] as String;
       }
@@ -260,9 +258,7 @@ Future<Object?> _dispatch(String fnName, List<dynamic> args) async {
 
     case 'interpreter_restore':
       final data = args[0] as String;
-      final result = _parse(
-        (await _bridgeRestore(data.toJS).toDart).toDart,
-      );
+      final result = _parse((await _bridgeRestore(data.toJS).toDart).toDart);
       if (result['ok'] == true) return 'restored';
       return 'Error: ${result['error']}';
 
@@ -354,8 +350,9 @@ Future<Map<String, dynamic>> _runWithHostFunctions(String code) async {
       );
     } on Exception catch (e) {
       result = _parse(
-        (await _bridgeResumeWithError(jsonEncode(e.toString()).toJS).toDart)
-            .toDart,
+        (await _bridgeResumeWithError(
+          jsonEncode(e.toString()).toJS,
+        ).toDart).toDart,
       );
     }
   }
@@ -1234,7 +1231,9 @@ Future<void> main() async {
   _populateDemoSelector();
 
   // Run button
-  document.getElementById('run-btn')!.addEventListener(
+  document
+      .getElementById('run-btn')!
+      .addEventListener(
         'click',
         (Event e) {
           _runCode();
@@ -1242,7 +1241,9 @@ Future<void> main() async {
       );
 
   // Clear button
-  document.getElementById('clear-btn')!.addEventListener(
+  document
+      .getElementById('clear-btn')!
+      .addEventListener(
         'click',
         (Event e) {
           _clearOutput();
@@ -1254,7 +1255,9 @@ Future<void> main() async {
       );
 
   // Ctrl+Enter to run
-  document.getElementById('editor')!.addEventListener(
+  document
+      .getElementById('editor')!
+      .addEventListener(
         'keydown',
         (KeyboardEvent e) {
           if (e.key == 'Enter' && (e.ctrlKey || e.metaKey)) {

--- a/example/web/bin/ladder_showcase.dart
+++ b/example/web/bin/ladder_showcase.dart
@@ -24,10 +24,7 @@ external JSPromise<JSBoolean> _montyInit();
 external JSPromise<JSString> _montyRun(JSString code);
 
 @JS('DartMontyBridge.start')
-external JSPromise<JSString> _montyStart(
-  JSString code, [
-  JSString? extFnsJson,
-]);
+external JSPromise<JSString> _montyStart(JSString code, [JSString? extFnsJson]);
 
 @JS('DartMontyBridge.resume')
 external JSPromise<JSString> _montyResume(JSString valueJson);
@@ -246,9 +243,7 @@ Future<void> main() async {
 // Fixture execution
 // ---------------------------------------------------------------------------
 
-Future<Map<String, dynamic>> _runFixture(
-  Map<String, dynamic> fixture,
-) async {
+Future<Map<String, dynamic>> _runFixture(Map<String, dynamic> fixture) async {
   final expectError = fixture['expectError'] as bool? ?? false;
   final xfail = fixture['xfail'] as String?;
 
@@ -276,24 +271,19 @@ Future<Map<String, dynamic>> _runFixture(
     }
     return {
       'status': 'xpass',
-      'detail': 'xpass: expected failure did not occur'
+      'detail': 'xpass: expected failure did not occur',
     };
   }
 
   return result;
 }
 
-Future<Map<String, dynamic>> _runSimple(
-  Map<String, dynamic> fixture,
-) async {
+Future<Map<String, dynamic>> _runSimple(Map<String, dynamic> fixture) async {
   final code = fixture['code'] as String;
   final result = _parse((await _montyRun(code.toJS).toDart).toDart);
 
   if (result['ok'] != true) {
-    return {
-      'status': 'fail',
-      'detail': 'Bridge error: ${result['error']}',
-    };
+    return {'status': 'fail', 'detail': 'Bridge error: ${result['error']}'};
   }
 
   final actual = result['value'];
@@ -313,14 +303,13 @@ Future<Map<String, dynamic>> _runExpectError(
 
   return {
     'status': 'warn',
-    'detail': 'Expected error but got value: ${result['value']}'
+    'detail':
+        'Expected error but got value: ${result['value']}'
         ' — WASM Monty may handle this differently than CPython',
   };
 }
 
-Future<Map<String, dynamic>> _runIterative(
-  Map<String, dynamic> fixture,
-) async {
+Future<Map<String, dynamic>> _runIterative(Map<String, dynamic> fixture) async {
   final code = fixture['code'] as String;
   final expectError = fixture['expectError'] as bool? ?? false;
   final extFns = (fixture['externalFunctions'] as List).cast<String>();
@@ -398,7 +387,8 @@ Map<String, dynamic> _compareResult(
 
     return {
       'status': 'warn',
-      'detail': 'Value: $str'
+      'detail':
+          'Value: $str'
           ' — expected to contain "$expectedContains"'
           ' (WASM Monty behavioral difference)',
     };
@@ -413,7 +403,8 @@ Map<String, dynamic> _compareResult(
 
     return {
       'status': 'warn',
-      'detail': 'Value: $actual'
+      'detail':
+          'Value: $actual'
           ' — expected (sorted): $expected'
           ' (WASM Monty behavioral difference)',
     };
@@ -425,7 +416,8 @@ Map<String, dynamic> _compareResult(
 
   return {
     'status': 'warn',
-    'detail': 'Value: $actual'
+    'detail':
+        'Value: $actual'
         ' — expected: $expected'
         ' (WASM Monty behavioral difference)',
   };

--- a/example/web/bin/main.dart
+++ b/example/web/bin/main.dart
@@ -55,7 +55,9 @@ Future<void> main() async {
   // ── 2. Multi-line code ────────────────────────────────────────────────
   print('');
   print('── Multi-line code ──');
-  r = _parse((await _bridgeRun('''
+  r = _parse(
+    (await _bridgeRun(
+      '''
 def fib(n):
     a, b = 0, 1
     for _ in range(n):
@@ -63,9 +65,9 @@ def fib(n):
     return a
 fib(10)
 '''
-              .toJS)
-          .toDart)
-      .toDart);
+          .toJS,
+    ).toDart).toDart,
+  );
   print('  fib(10) = ${r['value']}');
 
   // ── 3. String result ──────────────────────────────────────────────────
@@ -87,15 +89,14 @@ fib(10)
     (await _bridgeStart(
       'fetch("https://example.com")'.toJS,
       '["fetch"]'.toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
   print('  start() → state=${r['state']}, fn=${r['functionName']}');
 
   r = _parse(
-    (await _bridgeResume(jsonEncode('<html>Hello from Dart!</html>').toJS)
-            .toDart)
-        .toDart,
+    (await _bridgeResume(
+      jsonEncode('<html>Hello from Dart!</html>').toJS,
+    ).toDart).toDart,
   );
   print('  resume() → state=${r['state']}, value=${r['value']}');
 
@@ -113,14 +114,14 @@ result
 '''
           .toJS,
       '["fetch"]'.toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
   print('  start() → state=${r['state']}');
 
   r = _parse(
-    (await _bridgeResumeWithError(jsonEncode('network timeout').toJS).toDart)
-        .toDart,
+    (await _bridgeResumeWithError(
+      jsonEncode('network timeout').toJS,
+    ).toDart).toDart,
   );
   print('  resumeWithError() → value=${r['value']}');
 

--- a/packages/dart_monty_ffi/bin/cancel_benchmark.dart
+++ b/packages/dart_monty_ffi/bin/cancel_benchmark.dart
@@ -79,7 +79,8 @@ Future<Map<String, dynamic>> runT1_1({
   }
   stderr.writeln();
 
-  final pass = cancelledCount == cancelN &&
+  final pass =
+      cancelledCount == cancelN &&
       wrongTypeCount == 0 &&
       doubleThrowCount == 0 &&
       postCompleteThrowCount == 0;
@@ -148,7 +149,8 @@ Future<Map<String, dynamic>> runT1_2({
     'cross_cancel_success': crossCancelSuccess,
     'state_error': stateErrorCount,
     'alive_post_terminate': isAlivePostTerminate,
-    'pass': crossCancelSuccess == n &&
+    'pass':
+        crossCancelSuccess == n &&
         stateErrorCount == 0 &&
         isAlivePostTerminate == 0,
   };
@@ -437,8 +439,9 @@ Future<Map<String, dynamic>> runT2_3({
     'cycles': totalCycles,
     'delta_mb': deltaMb,
     'slope_mb_per_cycle': slope,
-    'rss_checkpoints': rssAt
-        .map((k, v) => MapEntry(k, (v / (1024 * 1024)).toStringAsFixed(1))),
+    'rss_checkpoints': rssAt.map(
+      (k, v) => MapEntry(k, (v / (1024 * 1024)).toStringAsFixed(1)),
+    ),
     'pass': deltaMb.abs() < 5.0 && slope.abs() < 0.005,
   };
 }
@@ -645,8 +648,9 @@ Map<String, dynamic> _computeStats(
   final ciLow = bootstrapMedians[(10000 * 0.025).floor()];
   final ciHigh = bootstrapMedians[(10000 * 0.975).floor()];
 
-  final pass =
-      name == 'T3-1' ? (p95 < 5.0 && maxVal < 20.0) : (p95 < 20.0); // T3-2
+  final pass = name == 'T3-1'
+      ? (p95 < 5.0 && maxVal < 20.0)
+      : (p95 < 20.0); // T3-2
 
   return {
     'experiment': name,
@@ -723,15 +727,9 @@ void _printResult(Map<String, dynamic> r) {
         '[95% CI: ${(r['ci_low_ms'] as double).toStringAsFixed(3)} '
         '- ${(r['ci_high_ms'] as double).toStringAsFixed(3)}]',
       );
-      stdout.writeln(
-        '  P95: ${(r['p95_ms'] as double).toStringAsFixed(3)} ms',
-      );
-      stdout.writeln(
-        '  P99: ${(r['p99_ms'] as double).toStringAsFixed(3)} ms',
-      );
-      stdout.writeln(
-        '  Max: ${(r['max_ms'] as double).toStringAsFixed(3)} ms',
-      );
+      stdout.writeln('  P95: ${(r['p95_ms'] as double).toStringAsFixed(3)} ms');
+      stdout.writeln('  P99: ${(r['p99_ms'] as double).toStringAsFixed(3)} ms');
+      stdout.writeln('  Max: ${(r['max_ms'] as double).toStringAsFixed(3)} ms');
   }
   stdout.writeln('  VERDICT: ${r['pass'] == true ? "PASS" : "FAIL"}');
   stdout.writeln();
@@ -742,7 +740,8 @@ void _printResult(Map<String, dynamic> r) {
 // ---------------------------------------------------------------------------
 Future<void> main(List<String> args) async {
   final libPath = _resolveLibraryPath();
-  final isAot = const bool.fromEnvironment('dart.vm.product') ||
+  final isAot =
+      const bool.fromEnvironment('dart.vm.product') ||
       !Platform.resolvedExecutable.endsWith('dart');
   final mode = isAot ? 'AOT' : 'JIT';
 

--- a/packages/dart_monty_ffi/example/example.dart
+++ b/packages/dart_monty_ffi/example/example.dart
@@ -87,10 +87,7 @@ Future<void> _printCapture(MontyFfi monty) async {
 /// Snapshots capture state mid-execution (during a start/resume loop).
 Future<void> _snapshotRestore(MontyFfi monty) async {
   // Start execution that pauses on an external function call.
-  await monty.start(
-    'x = 42\nget_value()',
-    externalFunctions: ['get_value'],
-  );
+  await monty.start('x = 42\nget_value()', externalFunctions: ['get_value']);
   // Interpreter is now paused — snapshot the in-progress state.
   final bytes = await monty.snapshot();
   print('Snapshot size: ${bytes.length} bytes');

--- a/packages/dart_monty_ffi/lib/src/ffi_core_bindings.dart
+++ b/packages/dart_monty_ffi/lib/src/ffi_core_bindings.dart
@@ -24,10 +24,8 @@ class FfiCoreBindings implements MontyCoreBindings {
   /// handle is created (in [run] and [start]) with the monotonic handle ID.
   /// Used by the isolate worker to send the handle ID to the supervisor
   /// before entering a potentially blocking FFI call.
-  FfiCoreBindings({
-    required NativeBindings bindings,
-    this.onHandleCreated,
-  }) : _bindings = bindings;
+  FfiCoreBindings({required NativeBindings bindings, this.onHandleCreated})
+    : _bindings = bindings;
 
   final NativeBindings _bindings;
   int? _handle;
@@ -236,8 +234,9 @@ class FfiCoreBindings implements MontyCoreBindings {
         return CoreProgressResult(
           state: 'complete',
           value: jsonMap['value'] as Object?,
-          usage:
-              usageMap != null ? MontyResourceUsage.fromJson(usageMap) : null,
+          usage: usageMap != null
+              ? MontyResourceUsage.fromJson(usageMap)
+              : null,
           printOutput: jsonMap['print_output'] as String?,
           error: errorMap?['message'] as String?,
           excType: errorMap?['exc_type'] as String?,
@@ -248,9 +247,7 @@ class FfiCoreBindings implements MontyCoreBindings {
         _handle = handle;
         final argsJson = progress.argumentsJson;
         final args = argsJson != null
-            ? List<Object?>.from(
-                json.decode(argsJson) as List<Object?>,
-              )
+            ? List<Object?>.from(json.decode(argsJson) as List<Object?>)
             : const <Object?>[];
 
         final kwargsJson = progress.kwargsJson;
@@ -306,9 +303,7 @@ class FfiCoreBindings implements MontyCoreBindings {
         if (idsJson == null) {
           throw StateError('Future call IDs JSON is null');
         }
-        final ids = List<int>.from(
-          json.decode(idsJson) as List<Object?>,
-        );
+        final ids = List<int>.from(json.decode(idsJson) as List<Object?>);
 
         return CoreProgressResult(
           state: 'resolve_futures',
@@ -360,9 +355,7 @@ class FfiCoreBindings implements MontyCoreBindings {
   /// expected by [NativeBindings.create].
   String? _parseExtFns(String? extFnsJson) {
     if (extFnsJson == null) return null;
-    final list = List<String>.from(
-      json.decode(extFnsJson) as List<Object?>,
-    );
+    final list = List<String>.from(json.decode(extFnsJson) as List<Object?>);
 
     return list.isNotEmpty ? list.join(',') : null;
   }

--- a/packages/dart_monty_ffi/lib/src/generated/dart_monty_bindings.dart
+++ b/packages/dart_monty_ffi/lib/src/generated/dart_monty_bindings.dart
@@ -11,17 +11,16 @@ import 'dart:ffi' as ffi;
 class DartMontyBindings {
   /// Holds the symbol lookup function.
   final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-      _lookup;
+  _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
   DartMontyBindings(ffi.DynamicLibrary dynamicLibrary)
-      : _lookup = dynamicLibrary.lookup;
+    : _lookup = dynamicLibrary.lookup;
 
   /// The symbols are looked up with [lookup].
   DartMontyBindings.fromLookup(
-      ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-          lookup)
-      : _lookup = lookup;
+    ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup,
+  ) : _lookup = lookup;
 
   /// Create a new handle from Python source code.
   ///
@@ -38,42 +37,41 @@ class DartMontyBindings {
     ffi.Pointer<ffi.Char> script_name,
     ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
   ) {
-    return _monty_create(
-      code,
-      ext_fns,
-      script_name,
-      out_error,
-    );
+    return _monty_create(code, ext_fns, script_name, out_error);
   }
 
-  late final _monty_createPtr = _lookup<
-      ffi.NativeFunction<
+  late final _monty_createPtr =
+      _lookup<
+        ffi.NativeFunction<
           ffi.Pointer<MontyHandle> Function(
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_create');
-  late final _monty_create = _monty_createPtr.asFunction<
-      ffi.Pointer<MontyHandle> Function(
+            ffi.Pointer<ffi.Char>,
+            ffi.Pointer<ffi.Char>,
+            ffi.Pointer<ffi.Char>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_create');
+  late final _monty_create = _monty_createPtr
+      .asFunction<
+        ffi.Pointer<MontyHandle> Function(
           ffi.Pointer<ffi.Char>,
           ffi.Pointer<ffi.Char>,
           ffi.Pointer<ffi.Char>,
-          ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Free a handle. Safe to call with NULL.
-  void monty_free(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_free(
-      handle,
-    );
+  void monty_free(ffi.Pointer<MontyHandle> handle) {
+    return _monty_free(handle);
   }
 
   late final _monty_freePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MontyHandle>)>>(
-          'monty_free');
-  late final _monty_free =
-      _monty_freePtr.asFunction<void Function(ffi.Pointer<MontyHandle>)>();
+        'monty_free',
+      );
+  late final _monty_free = _monty_freePtr
+      .asFunction<void Function(ffi.Pointer<MontyHandle>)>();
 
   /// Run Python code to completion.
   ///
@@ -88,22 +86,27 @@ class DartMontyBindings {
     ffi.Pointer<ffi.Pointer<ffi.Char>> result_json,
     ffi.Pointer<ffi.Pointer<ffi.Char>> error_msg,
   ) {
-    return MontyResultTag.fromValue(_monty_run(
-      handle,
-      result_json,
-      error_msg,
-    ));
+    return MontyResultTag.fromValue(_monty_run(handle, result_json, error_msg));
   }
 
-  late final _monty_runPtr = _lookup<
-      ffi.NativeFunction<
+  late final _monty_runPtr =
+      _lookup<
+        ffi.NativeFunction<
           ffi.UnsignedInt Function(
-              ffi.Pointer<MontyHandle>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_run');
-  late final _monty_run = _monty_runPtr.asFunction<
-      int Function(ffi.Pointer<MontyHandle>, ffi.Pointer<ffi.Pointer<ffi.Char>>,
-          ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+            ffi.Pointer<MontyHandle>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_run');
+  late final _monty_run = _monty_runPtr
+      .asFunction<
+        int Function(
+          ffi.Pointer<MontyHandle>,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Start iterative execution. Pauses at external function calls.
   ///
@@ -114,19 +117,25 @@ class DartMontyBindings {
     ffi.Pointer<MontyHandle> handle,
     ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
   ) {
-    return MontyProgressTag.fromValue(_monty_start(
-      handle,
-      out_error,
-    ));
+    return MontyProgressTag.fromValue(_monty_start(handle, out_error));
   }
 
-  late final _monty_startPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.UnsignedInt Function(ffi.Pointer<MontyHandle>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_start');
-  late final _monty_start = _monty_startPtr.asFunction<
-      int Function(
-          ffi.Pointer<MontyHandle>, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+  late final _monty_startPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.UnsignedInt Function(
+            ffi.Pointer<MontyHandle>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_start');
+  late final _monty_start = _monty_startPtr
+      .asFunction<
+        int Function(
+          ffi.Pointer<MontyHandle>,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Resume execution with a return value.
   ///
@@ -139,22 +148,29 @@ class DartMontyBindings {
     ffi.Pointer<ffi.Char> value_json,
     ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
   ) {
-    return MontyProgressTag.fromValue(_monty_resume(
-      handle,
-      value_json,
-      out_error,
-    ));
+    return MontyProgressTag.fromValue(
+      _monty_resume(handle, value_json, out_error),
+    );
   }
 
-  late final _monty_resumePtr = _lookup<
-      ffi.NativeFunction<
+  late final _monty_resumePtr =
+      _lookup<
+        ffi.NativeFunction<
           ffi.UnsignedInt Function(
-              ffi.Pointer<MontyHandle>,
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_resume');
-  late final _monty_resume = _monty_resumePtr.asFunction<
-      int Function(ffi.Pointer<MontyHandle>, ffi.Pointer<ffi.Char>,
-          ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+            ffi.Pointer<MontyHandle>,
+            ffi.Pointer<ffi.Char>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_resume');
+  late final _monty_resume = _monty_resumePtr
+      .asFunction<
+        int Function(
+          ffi.Pointer<MontyHandle>,
+          ffi.Pointer<ffi.Char>,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Resume execution with an error (raises RuntimeError in Python).
   ///
@@ -167,22 +183,29 @@ class DartMontyBindings {
     ffi.Pointer<ffi.Char> error_message,
     ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
   ) {
-    return MontyProgressTag.fromValue(_monty_resume_with_error(
-      handle,
-      error_message,
-      out_error,
-    ));
+    return MontyProgressTag.fromValue(
+      _monty_resume_with_error(handle, error_message, out_error),
+    );
   }
 
-  late final _monty_resume_with_errorPtr = _lookup<
-      ffi.NativeFunction<
+  late final _monty_resume_with_errorPtr =
+      _lookup<
+        ffi.NativeFunction<
           ffi.UnsignedInt Function(
-              ffi.Pointer<MontyHandle>,
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_resume_with_error');
-  late final _monty_resume_with_error = _monty_resume_with_errorPtr.asFunction<
-      int Function(ffi.Pointer<MontyHandle>, ffi.Pointer<ffi.Char>,
-          ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+            ffi.Pointer<MontyHandle>,
+            ffi.Pointer<ffi.Char>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_resume_with_error');
+  late final _monty_resume_with_error = _monty_resume_with_errorPtr
+      .asFunction<
+        int Function(
+          ffi.Pointer<MontyHandle>,
+          ffi.Pointer<ffi.Char>,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Resume by creating a future (tells the VM this call returns a future).
   /// Only valid when handle is in PENDING state.
@@ -195,19 +218,27 @@ class DartMontyBindings {
     ffi.Pointer<MontyHandle> handle,
     ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
   ) {
-    return MontyProgressTag.fromValue(_monty_resume_as_future(
-      handle,
-      out_error,
-    ));
+    return MontyProgressTag.fromValue(
+      _monty_resume_as_future(handle, out_error),
+    );
   }
 
-  late final _monty_resume_as_futurePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.UnsignedInt Function(ffi.Pointer<MontyHandle>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_resume_as_future');
-  late final _monty_resume_as_future = _monty_resume_as_futurePtr.asFunction<
-      int Function(
-          ffi.Pointer<MontyHandle>, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+  late final _monty_resume_as_futurePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.UnsignedInt Function(
+            ffi.Pointer<MontyHandle>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_resume_as_future');
+  late final _monty_resume_as_future = _monty_resume_as_futurePtr
+      .asFunction<
+        int Function(
+          ffi.Pointer<MontyHandle>,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Get the pending future call IDs as a JSON array.
   /// Only valid after progress returned MONTY_PROGRESS_RESOLVE_FUTURES.
@@ -217,15 +248,15 @@ class DartMontyBindings {
   ffi.Pointer<ffi.Char> monty_pending_future_call_ids(
     ffi.Pointer<MontyHandle> handle,
   ) {
-    return _monty_pending_future_call_ids(
-      handle,
-    );
+    return _monty_pending_future_call_ids(handle);
   }
 
-  late final _monty_pending_future_call_idsPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ffi.Char> Function(
-              ffi.Pointer<MontyHandle>)>>('monty_pending_future_call_ids');
+  late final _monty_pending_future_call_idsPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)
+        >
+      >('monty_pending_future_call_ids');
   late final _monty_pending_future_call_ids = _monty_pending_future_call_idsPtr
       .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)>();
 
@@ -246,41 +277,46 @@ class DartMontyBindings {
     ffi.Pointer<ffi.Char> errors_json,
     ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
   ) {
-    return MontyProgressTag.fromValue(_monty_resume_futures(
-      handle,
-      results_json,
-      errors_json,
-      out_error,
-    ));
+    return MontyProgressTag.fromValue(
+      _monty_resume_futures(handle, results_json, errors_json, out_error),
+    );
   }
 
-  late final _monty_resume_futuresPtr = _lookup<
-      ffi.NativeFunction<
+  late final _monty_resume_futuresPtr =
+      _lookup<
+        ffi.NativeFunction<
           ffi.UnsignedInt Function(
-              ffi.Pointer<MontyHandle>,
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Char>,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_resume_futures');
-  late final _monty_resume_futures = _monty_resume_futuresPtr.asFunction<
-      int Function(ffi.Pointer<MontyHandle>, ffi.Pointer<ffi.Char>,
-          ffi.Pointer<ffi.Char>, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+            ffi.Pointer<MontyHandle>,
+            ffi.Pointer<ffi.Char>,
+            ffi.Pointer<ffi.Char>,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_resume_futures');
+  late final _monty_resume_futures = _monty_resume_futuresPtr
+      .asFunction<
+        int Function(
+          ffi.Pointer<MontyHandle>,
+          ffi.Pointer<ffi.Char>,
+          ffi.Pointer<ffi.Char>,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Get the pending external function name.
   /// Only valid after monty_start/monty_resume returned MONTY_PROGRESS_PENDING.
   ///
   /// @return  Heap-allocated string, or NULL. Caller frees with monty_string_free().
-  ffi.Pointer<ffi.Char> monty_pending_fn_name(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_pending_fn_name(
-      handle,
-    );
+  ffi.Pointer<ffi.Char> monty_pending_fn_name(ffi.Pointer<MontyHandle> handle) {
+    return _monty_pending_fn_name(handle);
   }
 
-  late final _monty_pending_fn_namePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ffi.Char> Function(
-              ffi.Pointer<MontyHandle>)>>('monty_pending_fn_name');
+  late final _monty_pending_fn_namePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)
+        >
+      >('monty_pending_fn_name');
   late final _monty_pending_fn_name = _monty_pending_fn_namePtr
       .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)>();
 
@@ -291,15 +327,15 @@ class DartMontyBindings {
   ffi.Pointer<ffi.Char> monty_pending_fn_args_json(
     ffi.Pointer<MontyHandle> handle,
   ) {
-    return _monty_pending_fn_args_json(
-      handle,
-    );
+    return _monty_pending_fn_args_json(handle);
   }
 
-  late final _monty_pending_fn_args_jsonPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ffi.Char> Function(
-              ffi.Pointer<MontyHandle>)>>('monty_pending_fn_args_json');
+  late final _monty_pending_fn_args_jsonPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)
+        >
+      >('monty_pending_fn_args_json');
   late final _monty_pending_fn_args_json = _monty_pending_fn_args_jsonPtr
       .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)>();
 
@@ -311,15 +347,15 @@ class DartMontyBindings {
   ffi.Pointer<ffi.Char> monty_pending_fn_kwargs_json(
     ffi.Pointer<MontyHandle> handle,
   ) {
-    return _monty_pending_fn_kwargs_json(
-      handle,
-    );
+    return _monty_pending_fn_kwargs_json(handle);
   }
 
-  late final _monty_pending_fn_kwargs_jsonPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ffi.Char> Function(
-              ffi.Pointer<MontyHandle>)>>('monty_pending_fn_kwargs_json');
+  late final _monty_pending_fn_kwargs_jsonPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)
+        >
+      >('monty_pending_fn_kwargs_json');
   late final _monty_pending_fn_kwargs_json = _monty_pending_fn_kwargs_jsonPtr
       .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)>();
 
@@ -327,17 +363,14 @@ class DartMontyBindings {
   /// Only valid after monty_start/monty_resume returned MONTY_PROGRESS_PENDING.
   ///
   /// @return  Call ID, or UINT32_MAX if not in Paused state.
-  int monty_pending_call_id(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_pending_call_id(
-      handle,
-    );
+  int monty_pending_call_id(ffi.Pointer<MontyHandle> handle) {
+    return _monty_pending_call_id(handle);
   }
 
-  late final _monty_pending_call_idPtr = _lookup<
-          ffi.NativeFunction<ffi.Uint32 Function(ffi.Pointer<MontyHandle>)>>(
-      'monty_pending_call_id');
+  late final _monty_pending_call_idPtr =
+      _lookup<
+        ffi.NativeFunction<ffi.Uint32 Function(ffi.Pointer<MontyHandle>)>
+      >('monty_pending_call_id');
   late final _monty_pending_call_id = _monty_pending_call_idPtr
       .asFunction<int Function(ffi.Pointer<MontyHandle>)>();
 
@@ -345,17 +378,14 @@ class DartMontyBindings {
   /// Only valid after monty_start/monty_resume returned MONTY_PROGRESS_PENDING.
   ///
   /// @return  1 for method call, 0 for function call, -1 if not in Paused state.
-  int monty_pending_method_call(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_pending_method_call(
-      handle,
-    );
+  int monty_pending_method_call(ffi.Pointer<MontyHandle> handle) {
+    return _monty_pending_method_call(handle);
   }
 
   late final _monty_pending_method_callPtr =
       _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Pointer<MontyHandle>)>>(
-          'monty_pending_method_call');
+        'monty_pending_method_call',
+      );
   late final _monty_pending_method_call = _monty_pending_method_callPtr
       .asFunction<int Function(ffi.Pointer<MontyHandle>)>();
 
@@ -366,32 +396,29 @@ class DartMontyBindings {
   ffi.Pointer<ffi.Char> monty_complete_result_json(
     ffi.Pointer<MontyHandle> handle,
   ) {
-    return _monty_complete_result_json(
-      handle,
-    );
+    return _monty_complete_result_json(handle);
   }
 
-  late final _monty_complete_result_jsonPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ffi.Char> Function(
-              ffi.Pointer<MontyHandle>)>>('monty_complete_result_json');
+  late final _monty_complete_result_jsonPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)
+        >
+      >('monty_complete_result_json');
   late final _monty_complete_result_json = _monty_complete_result_jsonPtr
       .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<MontyHandle>)>();
 
   /// Check whether the completed result is an error.
   ///
   /// @return  1 = error, 0 = success, -1 = not in Complete state.
-  int monty_complete_is_error(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_complete_is_error(
-      handle,
-    );
+  int monty_complete_is_error(ffi.Pointer<MontyHandle> handle) {
+    return _monty_complete_is_error(handle);
   }
 
   late final _monty_complete_is_errorPtr =
       _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Pointer<MontyHandle>)>>(
-          'monty_complete_is_error');
+        'monty_complete_is_error',
+      );
   late final _monty_complete_is_error = _monty_complete_is_errorPtr
       .asFunction<int Function(ffi.Pointer<MontyHandle>)>();
 
@@ -405,19 +432,25 @@ class DartMontyBindings {
     ffi.Pointer<MontyHandle> handle,
     ffi.Pointer<ffi.Size> out_len,
   ) {
-    return _monty_snapshot(
-      handle,
-      out_len,
-    );
+    return _monty_snapshot(handle, out_len);
   }
 
-  late final _monty_snapshotPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<ffi.Uint8> Function(ffi.Pointer<MontyHandle>,
-              ffi.Pointer<ffi.Size>)>>('monty_snapshot');
-  late final _monty_snapshot = _monty_snapshotPtr.asFunction<
-      ffi.Pointer<ffi.Uint8> Function(
-          ffi.Pointer<MontyHandle>, ffi.Pointer<ffi.Size>)>();
+  late final _monty_snapshotPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Uint8> Function(
+            ffi.Pointer<MontyHandle>,
+            ffi.Pointer<ffi.Size>,
+          )
+        >
+      >('monty_snapshot');
+  late final _monty_snapshot = _monty_snapshotPtr
+      .asFunction<
+        ffi.Pointer<ffi.Uint8> Function(
+          ffi.Pointer<MontyHandle>,
+          ffi.Pointer<ffi.Size>,
+        )
+      >();
 
   /// Restore a handle from a snapshot byte buffer.
   ///
@@ -430,72 +463,67 @@ class DartMontyBindings {
     int len,
     ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
   ) {
-    return _monty_restore(
-      data,
-      len,
-      out_error,
-    );
+    return _monty_restore(data, len, out_error);
   }
 
-  late final _monty_restorePtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<MontyHandle> Function(ffi.Pointer<ffi.Uint8>, ffi.Size,
-              ffi.Pointer<ffi.Pointer<ffi.Char>>)>>('monty_restore');
-  late final _monty_restore = _monty_restorePtr.asFunction<
-      ffi.Pointer<MontyHandle> Function(
-          ffi.Pointer<ffi.Uint8>, int, ffi.Pointer<ffi.Pointer<ffi.Char>>)>();
+  late final _monty_restorePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<MontyHandle> Function(
+            ffi.Pointer<ffi.Uint8>,
+            ffi.Size,
+            ffi.Pointer<ffi.Pointer<ffi.Char>>,
+          )
+        >
+      >('monty_restore');
+  late final _monty_restore = _monty_restorePtr
+      .asFunction<
+        ffi.Pointer<MontyHandle> Function(
+          ffi.Pointer<ffi.Uint8>,
+          int,
+          ffi.Pointer<ffi.Pointer<ffi.Char>>,
+        )
+      >();
 
   /// Set memory limit in bytes. Call before monty_run/monty_start.
-  void monty_set_memory_limit(
-    ffi.Pointer<MontyHandle> handle,
-    int bytes,
-  ) {
-    return _monty_set_memory_limit(
-      handle,
-      bytes,
-    );
+  void monty_set_memory_limit(ffi.Pointer<MontyHandle> handle, int bytes) {
+    return _monty_set_memory_limit(handle, bytes);
   }
 
-  late final _monty_set_memory_limitPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<MontyHandle>, ffi.Size)>>('monty_set_memory_limit');
+  late final _monty_set_memory_limitPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<MontyHandle>, ffi.Size)
+        >
+      >('monty_set_memory_limit');
   late final _monty_set_memory_limit = _monty_set_memory_limitPtr
       .asFunction<void Function(ffi.Pointer<MontyHandle>, int)>();
 
   /// Set execution time limit in milliseconds.
-  void monty_set_time_limit_ms(
-    ffi.Pointer<MontyHandle> handle,
-    int ms,
-  ) {
-    return _monty_set_time_limit_ms(
-      handle,
-      ms,
-    );
+  void monty_set_time_limit_ms(ffi.Pointer<MontyHandle> handle, int ms) {
+    return _monty_set_time_limit_ms(handle, ms);
   }
 
-  late final _monty_set_time_limit_msPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(ffi.Pointer<MontyHandle>,
-              ffi.Uint64)>>('monty_set_time_limit_ms');
+  late final _monty_set_time_limit_msPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<MontyHandle>, ffi.Uint64)
+        >
+      >('monty_set_time_limit_ms');
   late final _monty_set_time_limit_ms = _monty_set_time_limit_msPtr
       .asFunction<void Function(ffi.Pointer<MontyHandle>, int)>();
 
   /// Set stack depth limit.
-  void monty_set_stack_limit(
-    ffi.Pointer<MontyHandle> handle,
-    int depth,
-  ) {
-    return _monty_set_stack_limit(
-      handle,
-      depth,
-    );
+  void monty_set_stack_limit(ffi.Pointer<MontyHandle> handle, int depth) {
+    return _monty_set_stack_limit(handle, depth);
   }
 
-  late final _monty_set_stack_limitPtr = _lookup<
-      ffi.NativeFunction<
-          ffi.Void Function(
-              ffi.Pointer<MontyHandle>, ffi.Size)>>('monty_set_stack_limit');
+  late final _monty_set_stack_limitPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Pointer<MontyHandle>, ffi.Size)
+        >
+      >('monty_set_stack_limit');
   late final _monty_set_stack_limit = _monty_set_stack_limitPtr
       .asFunction<void Function(ffi.Pointer<MontyHandle>, int)>();
 
@@ -503,148 +531,118 @@ class DartMontyBindings {
   /// The next bytecode boundary check raises KeyboardInterrupt.
   /// Idempotent — safe to call multiple times. Thread-safe.
   /// No-op if handle is NULL.
-  void monty_cancel(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_cancel(
-      handle,
-    );
+  void monty_cancel(ffi.Pointer<MontyHandle> handle) {
+    return _monty_cancel(handle);
   }
 
   late final _monty_cancelPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MontyHandle>)>>(
-          'monty_cancel');
-  late final _monty_cancel =
-      _monty_cancelPtr.asFunction<void Function(ffi.Pointer<MontyHandle>)>();
+        'monty_cancel',
+      );
+  late final _monty_cancel = _monty_cancelPtr
+      .asFunction<void Function(ffi.Pointer<MontyHandle>)>();
 
   /// Check whether the cancel flag is set.
   /// Returns 1 if cancelled, 0 if not, -1 if handle is NULL.
-  int monty_is_cancelled(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_is_cancelled(
-      handle,
-    );
+  int monty_is_cancelled(ffi.Pointer<MontyHandle> handle) {
+    return _monty_is_cancelled(handle);
   }
 
   late final _monty_is_cancelledPtr =
       _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Pointer<MontyHandle>)>>(
-          'monty_is_cancelled');
+        'monty_is_cancelled',
+      );
   late final _monty_is_cancelled = _monty_is_cancelledPtr
       .asFunction<int Function(ffi.Pointer<MontyHandle>)>();
 
   /// Reset the cancel flag. Call before reusing a handle after cancel.
   /// No-op if handle is NULL.
-  void monty_reset_cancel(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_reset_cancel(
-      handle,
-    );
+  void monty_reset_cancel(ffi.Pointer<MontyHandle> handle) {
+    return _monty_reset_cancel(handle);
   }
 
   late final _monty_reset_cancelPtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<MontyHandle>)>>(
-          'monty_reset_cancel');
+        'monty_reset_cancel',
+      );
   late final _monty_reset_cancel = _monty_reset_cancelPtr
       .asFunction<void Function(ffi.Pointer<MontyHandle>)>();
 
   /// Get the monotonic handle ID for cross-isolate cancel.
   /// Returns 0 if handle is NULL or not registered.
-  int monty_get_handle_id(
-    ffi.Pointer<MontyHandle> handle,
-  ) {
-    return _monty_get_handle_id(
-      handle,
-    );
+  int monty_get_handle_id(ffi.Pointer<MontyHandle> handle) {
+    return _monty_get_handle_id(handle);
   }
 
-  late final _monty_get_handle_idPtr = _lookup<
-          ffi.NativeFunction<ffi.Uint64 Function(ffi.Pointer<MontyHandle>)>>(
-      'monty_get_handle_id');
+  late final _monty_get_handle_idPtr =
+      _lookup<
+        ffi.NativeFunction<ffi.Uint64 Function(ffi.Pointer<MontyHandle>)>
+      >('monty_get_handle_id');
   late final _monty_get_handle_id = _monty_get_handle_idPtr
       .asFunction<int Function(ffi.Pointer<MontyHandle>)>();
 
   /// Cancel a handle by its registry ID. Works from any thread/isolate.
   /// Returns 0 on success, -1 if not found, -2 if cancel flag was dropped.
-  int monty_cancel_by_id(
-    int handle_id,
-  ) {
-    return _monty_cancel_by_id(
-      handle_id,
-    );
+  int monty_cancel_by_id(int handle_id) {
+    return _monty_cancel_by_id(handle_id);
   }
 
   late final _monty_cancel_by_idPtr =
       _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Uint64)>>(
-          'monty_cancel_by_id');
-  late final _monty_cancel_by_id =
-      _monty_cancel_by_idPtr.asFunction<int Function(int)>();
+        'monty_cancel_by_id',
+      );
+  late final _monty_cancel_by_id = _monty_cancel_by_idPtr
+      .asFunction<int Function(int)>();
 
   /// Check whether a handle is cancelled by registry ID.
   /// Returns 1 if cancelled, 0 if not cancelled, -1 if not found.
-  int monty_is_cancelled_by_id(
-    int handle_id,
-  ) {
-    return _monty_is_cancelled_by_id(
-      handle_id,
-    );
+  int monty_is_cancelled_by_id(int handle_id) {
+    return _monty_is_cancelled_by_id(handle_id);
   }
 
   late final _monty_is_cancelled_by_idPtr =
       _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Uint64)>>(
-          'monty_is_cancelled_by_id');
-  late final _monty_is_cancelled_by_id =
-      _monty_is_cancelled_by_idPtr.asFunction<int Function(int)>();
+        'monty_is_cancelled_by_id',
+      );
+  late final _monty_is_cancelled_by_id = _monty_is_cancelled_by_idPtr
+      .asFunction<int Function(int)>();
 
   /// Free a MontyHandle by its registry ID. Safe from any thread.
   /// Returns 1 if the handle was found and freed, 0 if not found.
   /// Used by supervisor to clean up after crash-only disposal when the
   /// worker isolate was killed before it could call monty_free().
-  int monty_free_by_id(
-    int handle_id,
-  ) {
-    return _monty_free_by_id(
-      handle_id,
-    );
+  int monty_free_by_id(int handle_id) {
+    return _monty_free_by_id(handle_id);
   }
 
   late final _monty_free_by_idPtr =
       _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Uint64)>>(
-          'monty_free_by_id');
-  late final _monty_free_by_id =
-      _monty_free_by_idPtr.asFunction<int Function(int)>();
+        'monty_free_by_id',
+      );
+  late final _monty_free_by_id = _monty_free_by_idPtr
+      .asFunction<int Function(int)>();
 
   /// Free a string returned by any monty_* function. Safe with NULL.
-  void monty_string_free(
-    ffi.Pointer<ffi.Char> ptr,
-  ) {
-    return _monty_string_free(
-      ptr,
-    );
+  void monty_string_free(ffi.Pointer<ffi.Char> ptr) {
+    return _monty_string_free(ptr);
   }
 
   late final _monty_string_freePtr =
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Char>)>>(
-          'monty_string_free');
-  late final _monty_string_free =
-      _monty_string_freePtr.asFunction<void Function(ffi.Pointer<ffi.Char>)>();
+        'monty_string_free',
+      );
+  late final _monty_string_free = _monty_string_freePtr
+      .asFunction<void Function(ffi.Pointer<ffi.Char>)>();
 
   /// Free a byte buffer returned by monty_snapshot(). Safe with NULL.
-  void monty_bytes_free(
-    ffi.Pointer<ffi.Uint8> ptr,
-    int len,
-  ) {
-    return _monty_bytes_free(
-      ptr,
-      len,
-    );
+  void monty_bytes_free(ffi.Pointer<ffi.Uint8> ptr, int len) {
+    return _monty_bytes_free(ptr, len);
   }
 
-  late final _monty_bytes_freePtr = _lookup<
-          ffi
-          .NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>>(
-      'monty_bytes_free');
+  late final _monty_bytes_freePtr =
+      _lookup<
+        ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Uint8>, ffi.Size)>
+      >('monty_bytes_free');
   late final _monty_bytes_free = _monty_bytes_freePtr
       .asFunction<void Function(ffi.Pointer<ffi.Uint8>, int)>();
 }
@@ -660,10 +658,10 @@ enum MontyResultTag {
   const MontyResultTag(this.value);
 
   static MontyResultTag fromValue(int value) => switch (value) {
-        0 => MONTY_RESULT_OK,
-        1 => MONTY_RESULT_ERROR,
-        _ => throw ArgumentError('Unknown value for MontyResultTag: $value'),
-      };
+    0 => MONTY_RESULT_OK,
+    1 => MONTY_RESULT_ERROR,
+    _ => throw ArgumentError('Unknown value for MontyResultTag: $value'),
+  };
 }
 
 /// Progress tag for monty_start() / monty_resume().
@@ -677,10 +675,10 @@ enum MontyProgressTag {
   const MontyProgressTag(this.value);
 
   static MontyProgressTag fromValue(int value) => switch (value) {
-        0 => MONTY_PROGRESS_COMPLETE,
-        1 => MONTY_PROGRESS_PENDING,
-        2 => MONTY_PROGRESS_ERROR,
-        3 => MONTY_PROGRESS_RESOLVE_FUTURES,
-        _ => throw ArgumentError('Unknown value for MontyProgressTag: $value'),
-      };
+    0 => MONTY_PROGRESS_COMPLETE,
+    1 => MONTY_PROGRESS_PENDING,
+    2 => MONTY_PROGRESS_ERROR,
+    3 => MONTY_PROGRESS_RESOLVE_FUTURES,
+    _ => throw ArgumentError('Unknown value for MontyProgressTag: $value'),
+  };
 }

--- a/packages/dart_monty_ffi/lib/src/monty_ffi.dart
+++ b/packages/dart_monty_ffi/lib/src/monty_ffi.dart
@@ -32,14 +32,14 @@ class MontyFfi extends BaseMontyPlatform
   MontyFfi.withCore({
     required FfiCoreBindings coreBindings,
     required NativeBindings nativeBindings,
-  })  : _nativeBindings = nativeBindings,
-        super(bindings: coreBindings);
+  }) : _nativeBindings = nativeBindings,
+       super(bindings: coreBindings);
 
   MontyFfi._({
     required FfiCoreBindings coreBindings,
     required NativeBindings nativeBindings,
-  })  : _nativeBindings = nativeBindings,
-        super(bindings: coreBindings);
+  }) : _nativeBindings = nativeBindings,
+       super(bindings: coreBindings);
 
   final NativeBindings _nativeBindings;
 
@@ -65,14 +65,9 @@ class MontyFfi extends BaseMontyPlatform
       results.map((k, v) => MapEntry(k.toString(), v)),
     );
     final errorsJson = errors != null
-        ? json.encode(
-            errors.map((k, v) => MapEntry(k.toString(), v)),
-          )
+        ? json.encode(errors.map((k, v) => MapEntry(k.toString(), v)))
         : '{}';
-    final progress = await coreBindings.resolveFutures(
-      resultsJson,
-      errorsJson,
-    );
+    final progress = await coreBindings.resolveFutures(resultsJson, errorsJson);
     return translateProgress(progress);
   }
 

--- a/packages/dart_monty_ffi/lib/src/monty_native.dart
+++ b/packages/dart_monty_ffi/lib/src/monty_native.dart
@@ -55,11 +55,7 @@ class MontyNative extends MontyPlatform
     try {
       await _ensureInitialized();
 
-      return await _bindings.run(
-        code,
-        limits: limits,
-        scriptName: scriptName,
-      );
+      return await _bindings.run(code, limits: limits, scriptName: scriptName);
     } finally {
       markIdle();
     }

--- a/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
+++ b/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
@@ -19,13 +19,13 @@ class NativeBindingsFfi extends NativeBindings {
   /// On iOS, symbols are statically linked into the main executable, so
   /// [DynamicLibrary.process] is used instead of [DynamicLibrary.open].
   NativeBindingsFfi({String? libraryPath})
-      : _lib = DartMontyBindings(
-          Platform.isIOS
-              ? DynamicLibrary.process()
-              : DynamicLibrary.open(
-                  NativeLibraryLoader.resolve(overridePath: libraryPath),
-                ),
-        ) {
+    : _lib = DartMontyBindings(
+        Platform.isIOS
+            ? DynamicLibrary.process()
+            : DynamicLibrary.open(
+                NativeLibraryLoader.resolve(overridePath: libraryPath),
+              ),
+      ) {
     _instance ??= this;
     BaseMontyPlatform.registerNativeCancel(
       cancelById: (id) => instanceOrNull?.cancelById(id) ?? false,
@@ -53,18 +53,15 @@ class NativeBindingsFfi extends NativeBindings {
   }
 
   @override
-  int create(
-    String code, {
-    String? externalFunctions,
-    String? scriptName,
-  }) {
+  int create(String code, {String? externalFunctions, String? scriptName}) {
     final cCode = code.toNativeUtf8().cast<Char>();
     final nullChar = nullptr.cast<Char>();
     final cExtFns = externalFunctions != null
         ? externalFunctions.toNativeUtf8().cast<Char>()
         : nullChar;
-    final cScriptName =
-        scriptName != null ? scriptName.toNativeUtf8().cast<Char>() : nullChar;
+    final cScriptName = scriptName != null
+        ? scriptName.toNativeUtf8().cast<Char>()
+        : nullChar;
     final outError = calloc<Pointer<Char>>();
 
     try {
@@ -207,18 +204,12 @@ class NativeBindingsFfi extends NativeBindings {
 
   @override
   void setTimeLimitMs(int handle, int ms) {
-    _lib.monty_set_time_limit_ms(
-      Pointer<MontyHandle>.fromAddress(handle),
-      ms,
-    );
+    _lib.monty_set_time_limit_ms(Pointer<MontyHandle>.fromAddress(handle), ms);
   }
 
   @override
   void setStackLimit(int handle, int depth) {
-    _lib.monty_set_stack_limit(
-      Pointer<MontyHandle>.fromAddress(handle),
-      depth,
-    );
+    _lib.monty_set_stack_limit(Pointer<MontyHandle>.fromAddress(handle), depth);
   }
 
   @override
@@ -292,9 +283,7 @@ class NativeBindingsFfi extends NativeBindings {
   @override
   int getHandleId(int handle) {
     if (handle == 0) return 0;
-    return _lib.monty_get_handle_id(
-      Pointer<MontyHandle>.fromAddress(handle),
-    );
+    return _lib.monty_get_handle_id(Pointer<MontyHandle>.fromAddress(handle));
   }
 
   @override
@@ -331,11 +320,7 @@ class NativeBindingsFfi extends NativeBindings {
         final resultJson = _readAndFreeString(resultJsonPtr);
         final isError = _lib.monty_complete_is_error(ptr);
 
-        return ProgressResult(
-          tag: 0,
-          resultJson: resultJson,
-          isError: isError,
-        );
+        return ProgressResult(tag: 0, resultJson: resultJson, isError: isError);
 
       case MontyProgressTag.MONTY_PROGRESS_PENDING:
         final fnNamePtr = _lib.monty_pending_fn_name(ptr);

--- a/packages/dart_monty_ffi/lib/src/native_isolate_bindings_impl.dart
+++ b/packages/dart_monty_ffi/lib/src/native_isolate_bindings_impl.dart
@@ -167,11 +167,11 @@ Future<void> _isolateMain(_InitMessage init) async {
     try {
       switch (message) {
         case _RunRequest(
-            :final id,
-            :final code,
-            :final limits,
-            :final scriptName,
-          ):
+          :final id,
+          :final code,
+          :final limits,
+          :final scriptName,
+        ):
           final result = await monty.run(
             code,
             limits: limits,
@@ -180,12 +180,12 @@ Future<void> _isolateMain(_InitMessage init) async {
           init.mainSendPort.send(_RunResponse(id, result));
 
         case _StartRequest(
-            :final id,
-            :final code,
-            :final externalFunctions,
-            :final limits,
-            :final scriptName,
-          ):
+          :final id,
+          :final code,
+          :final externalFunctions,
+          :final limits,
+          :final scriptName,
+        ):
           final progress = await monty.start(
             code,
             externalFunctions: externalFunctions,

--- a/packages/dart_monty_ffi/lib/src/native_library_loader.dart
+++ b/packages/dart_monty_ffi/lib/src/native_library_loader.dart
@@ -37,8 +37,6 @@ abstract final class NativeLibraryLoader {
     if (Platform.isWindows) {
       return '$_baseName.dll';
     }
-    throw UnsupportedError(
-      'Unsupported platform: ${Platform.operatingSystem}',
-    );
+    throw UnsupportedError('Unsupported platform: ${Platform.operatingSystem}');
   }
 }

--- a/packages/dart_monty_ffi/test/cancel_t1_1_end_to_end_test.dart
+++ b/packages/dart_monty_ffi/test/cancel_t1_1_end_to_end_test.dart
@@ -24,28 +24,27 @@ void main() {
 
   group('cancel during execution', () {
     for (var trial = 1; trial <= 5; trial++) {
-      test('trial $trial: cancel halts infinite loop with MontyCancelledError',
-          () async {
-        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
-        await isolate.init();
+      test(
+        'trial $trial: cancel halts infinite loop with MontyCancelledError',
+        () async {
+          final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+          await isolate.init();
 
-        final startFuture = isolate.start(
-          infiniteLoop,
-          externalFunctions: ['__never_called__'],
-        );
+          final startFuture = isolate.start(
+            infiniteLoop,
+            externalFunctions: ['__never_called__'],
+          );
 
-        // Give the interpreter time to enter the infinite loop.
-        await Future<void>.delayed(const Duration(milliseconds: 100));
+          // Give the interpreter time to enter the infinite loop.
+          await Future<void>.delayed(const Duration(milliseconds: 100));
 
-        await isolate.cancel();
+          await isolate.cancel();
 
-        await expectLater(
-          startFuture,
-          throwsA(isA<MontyCancelledError>()),
-        );
+          await expectLater(startFuture, throwsA(isA<MontyCancelledError>()));
 
-        await isolate.terminate();
-      });
+          await isolate.terminate();
+        },
+      );
     }
   });
 

--- a/packages/dart_monty_ffi/test/cancel_t1_2_cross_boundary_test.dart
+++ b/packages/dart_monty_ffi/test/cancel_t1_2_cross_boundary_test.dart
@@ -47,10 +47,7 @@ void main() {
         final cancelled = token.cancel();
         expect(cancelled, isTrue, reason: 'cancel should find the handle');
 
-        await expectLater(
-          startFuture,
-          throwsA(isA<MontyCancelledError>()),
-        );
+        await expectLater(startFuture, throwsA(isA<MontyCancelledError>()));
 
         await isolate.terminate();
       });

--- a/packages/dart_monty_ffi/test/cancel_t1_3_terminate_release_test.dart
+++ b/packages/dart_monty_ffi/test/cancel_t1_3_terminate_release_test.dart
@@ -39,8 +39,9 @@ void main() {
         expect(hid, greaterThan(0));
 
         // Before terminate: handle exists in Rust registry.
-        final preState =
-            NativeBindingsFfi.instanceOrNull?.isCancelledById(hid!);
+        final preState = NativeBindingsFfi.instanceOrNull?.isCancelledById(
+          hid!,
+        );
         expect(preState, isNotNull, reason: 'handle should be in registry');
 
         // Guard startFuture so its error does not escape the test zone
@@ -66,8 +67,9 @@ void main() {
         expect(isolate.handleId, isNull);
 
         // After terminate: Rust registry should not contain the handle.
-        final postState =
-            NativeBindingsFfi.instanceOrNull?.isCancelledById(hid!);
+        final postState = NativeBindingsFfi.instanceOrNull?.isCancelledById(
+          hid!,
+        );
         expect(
           postState,
           isNull,

--- a/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_1_test.dart
+++ b/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_1_test.dart
@@ -114,8 +114,10 @@ void main() {
       'Post-completion throw count: $postCompleteThrowCount / $postCompleteN',
     );
     print('');
-    print('VERDICT: '
-        '${cancelledCount == cancelN && wrongTypeCount == 0 && doubleThrowCount == 0 && tripleThrowCount == 0 && postCompleteThrowCount == 0 ? "PASS" : "FAIL"}');
+    print(
+      'VERDICT: '
+      '${cancelledCount == cancelN && wrongTypeCount == 0 && doubleThrowCount == 0 && tripleThrowCount == 0 && postCompleteThrowCount == 0 ? "PASS" : "FAIL"}',
+    );
     print('=== END T1-1 ===\n');
   });
 }

--- a/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_2_test.dart
+++ b/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_2_test.dart
@@ -87,8 +87,10 @@ void main() {
     print('isAlive==true post-terminate: $isAlivePostTerminate / $n');
     print('Auto-init success: $autoInitSuccess / $n');
     print('');
-    print('VERDICT: '
-        '${crossCancelSuccess == n && stateErrorCount == 0 && isAlivePostTerminate == 0 ? "PASS" : "FAIL"}');
+    print(
+      'VERDICT: '
+      '${crossCancelSuccess == n && stateErrorCount == 0 && isAlivePostTerminate == 0 ? "PASS" : "FAIL"}',
+    );
     print('=== END T1-2 ===\n');
   });
 }

--- a/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_3_test.dart
+++ b/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_3_test.dart
@@ -48,8 +48,9 @@ void main() {
         expect(hid, isNotNull);
 
         // Verify handle exists pre-terminate.
-        final preState =
-            NativeBindingsFfi.instanceOrNull?.isCancelledById(hid!);
+        final preState = NativeBindingsFfi.instanceOrNull?.isCancelledById(
+          hid!,
+        );
         expect(preState, isNotNull, reason: 'handle should be in registry');
 
         // Guard startFuture.
@@ -78,8 +79,9 @@ void main() {
         }
 
         // Check Rust registry cleanup.
-        final postState =
-            NativeBindingsFfi.instanceOrNull?.isCancelledById(hid!);
+        final postState = NativeBindingsFfi.instanceOrNull?.isCancelledById(
+          hid!,
+        );
         if (postState == null) {
           registryFreedCount++;
         } else {
@@ -97,8 +99,10 @@ void main() {
     print('handleId nulled: $handleIdNulledCount / $n');
     print('handleId NOT nulled: $handleIdNotNulledCount');
     print('');
-    print('VERDICT: '
-        '${registryFreedCount == n && handleIdNulledCount == n ? "PASS" : "FAIL"}');
+    print(
+      'VERDICT: '
+      '${registryFreedCount == n && handleIdNulledCount == n ? "PASS" : "FAIL"}',
+    );
     print('=== END T1-3 ===\n');
   });
 }

--- a/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_4_test.dart
+++ b/packages/dart_monty_ffi/test/experiments/cancel_exp_t1_4_test.dart
@@ -86,49 +86,45 @@ void main() {
 
   group('T1-4D: Dispose during run → error resolution (N=$n)', () {
     for (var trial = 1; trial <= n; trial++) {
-      test(
-        'trial $trial',
-        () async {
-          final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
-          await isolate.init();
+      test('trial $trial', () async {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
 
-          final startFuture = isolate.start(
-            'while True: pass',
-            externalFunctions: ['__never_called__'],
+        final startFuture = isolate.start(
+          'while True: pass',
+          externalFunctions: ['__never_called__'],
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        // dispose() without cancel — should still resolve the Future.
+        // Use terminate() which has a built-in 5s timeout for stuck isolates.
+        Object? caughtError;
+        unawaited(
+          startFuture.then<void>(
+            (_) {},
+            onError: (Object e) {
+              caughtError = e;
+            },
+          ),
+        );
+
+        await isolate.terminate();
+
+        // Give async error propagation a moment.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        if (caughtError is MontyDisposedError ||
+            caughtError is MontyCancelledError ||
+            caughtError is MontyCrashError) {
+          subDCorrect++;
+        } else {
+          subDWrongTypes.add(
+            caughtError?.runtimeType.toString() ??
+                'null (Future still pending)',
           );
-
-          await Future<void>.delayed(const Duration(milliseconds: 100));
-
-          // dispose() without cancel — should still resolve the Future.
-          // Use terminate() which has a built-in 5s timeout for stuck isolates.
-          Object? caughtError;
-          unawaited(
-            startFuture.then<void>(
-              (_) {},
-              onError: (Object e) {
-                caughtError = e;
-              },
-            ),
-          );
-
-          await isolate.terminate();
-
-          // Give async error propagation a moment.
-          await Future<void>.delayed(const Duration(milliseconds: 100));
-
-          if (caughtError is MontyDisposedError ||
-              caughtError is MontyCancelledError ||
-              caughtError is MontyCrashError) {
-            subDCorrect++;
-          } else {
-            subDWrongTypes.add(
-              caughtError?.runtimeType.toString() ??
-                  'null (Future still pending)',
-            );
-          }
-        },
-        timeout: const Timeout(Duration(seconds: 10)),
-      );
+        }
+      }, timeout: const Timeout(Duration(seconds: 10)));
     }
   });
 
@@ -143,8 +139,10 @@ void main() {
     print('Sub-B (OOM): SKIPPED (needs MontyLimits.memoryBytes integration)');
     print('Sub-E (Rust panic): SKIPPED (needs test-only FFI path)');
     print('');
-    print('VERDICT: '
-        '${subACorrect == n && subCCorrect == n && subDCorrect == n ? "PASS" : "FAIL (with caveats for skipped sub-experiments)"}');
+    print(
+      'VERDICT: '
+      '${subACorrect == n && subCCorrect == n && subDCorrect == n ? "PASS" : "FAIL (with caveats for skipped sub-experiments)"}',
+    );
     print('=== END T1-4 ===\n');
   });
 }

--- a/packages/dart_monty_ffi/test/experiments/cancel_exp_t2_2_test.dart
+++ b/packages/dart_monty_ffi/test/experiments/cancel_exp_t2_2_test.dart
@@ -51,69 +51,65 @@ void main() {
   // =========================================================================
   group('T2-2-C1: dispose() during run (N=$nC1)', () {
     for (var trial = 1; trial <= nC1; trial++) {
-      test(
-        'trial $trial',
-        () async {
-          final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
-          await isolate.init();
+      test('trial $trial', () async {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
 
-          final startFuture = isolate.start(
-            'while True: pass',
-            externalFunctions: ['__never_called__'],
+        final startFuture = isolate.start(
+          'while True: pass',
+          externalFunctions: ['__never_called__'],
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final sw = Stopwatch()..start();
+
+        // Track whether startFuture resolves.
+        final futureCompleter = Completer<String>();
+        unawaited(
+          startFuture.then<void>(
+            (_) {
+              sw.stop();
+              futureCompleter.complete('completed_normally');
+            },
+            onError: (Object e) {
+              sw.stop();
+              futureCompleter.complete(e.runtimeType.toString());
+            },
+          ),
+        );
+
+        // Try dispose() with a timeout — it may hang because worker
+        // is stuck in FFI and can't process the _DisposeRequest.
+        var disposeHung = false;
+        try {
+          await isolate.dispose().timeout(
+            const Duration(milliseconds: disposeTimeoutMs),
           );
+        } on TimeoutException {
+          disposeHung = true;
+          c1DisposeHangCount++;
+        }
 
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+        // Check if startFuture resolved (give it a short window).
+        final result = await futureCompleter.future.timeout(
+          const Duration(milliseconds: futureHangTimeoutMs),
+          onTimeout: () => 'HANGING',
+        );
 
-          final sw = Stopwatch()..start();
+        if (result == 'HANGING') {
+          c1HangingCount++;
+        } else {
+          c1ResolvedCount++;
+          c1ResolutionTimesMs.add(sw.elapsedMicroseconds / 1000.0);
+          c1ResolvedTypes[result] = (c1ResolvedTypes[result] ?? 0) + 1;
+        }
 
-          // Track whether startFuture resolves.
-          final futureCompleter = Completer<String>();
-          unawaited(
-            startFuture.then<void>(
-              (_) {
-                sw.stop();
-                futureCompleter.complete('completed_normally');
-              },
-              onError: (Object e) {
-                sw.stop();
-                futureCompleter.complete(e.runtimeType.toString());
-              },
-            ),
-          );
-
-          // Try dispose() with a timeout — it may hang because worker
-          // is stuck in FFI and can't process the _DisposeRequest.
-          var disposeHung = false;
-          try {
-            await isolate.dispose().timeout(
-                  const Duration(milliseconds: disposeTimeoutMs),
-                );
-          } on TimeoutException {
-            disposeHung = true;
-            c1DisposeHangCount++;
-          }
-
-          // Check if startFuture resolved (give it a short window).
-          final result = await futureCompleter.future.timeout(
-            const Duration(milliseconds: futureHangTimeoutMs),
-            onTimeout: () => 'HANGING',
-          );
-
-          if (result == 'HANGING') {
-            c1HangingCount++;
-          } else {
-            c1ResolvedCount++;
-            c1ResolutionTimesMs.add(sw.elapsedMicroseconds / 1000.0);
-            c1ResolvedTypes[result] = (c1ResolvedTypes[result] ?? 0) + 1;
-          }
-
-          // Force-clean with terminate() so we don't leak zombies between trials.
-          if (disposeHung) {
-            await isolate.terminate();
-          }
-        },
-        timeout: const Timeout(Duration(seconds: 30)),
-      );
+        // Force-clean with terminate() so we don't leak zombies between trials.
+        if (disposeHung) {
+          await isolate.terminate();
+        }
+      }, timeout: const Timeout(Duration(seconds: 30)));
     }
   });
 
@@ -122,52 +118,48 @@ void main() {
   // =========================================================================
   group('T2-2-C2: terminate() during run (N=$nC2)', () {
     for (var trial = 1; trial <= nC2; trial++) {
-      test(
-        'trial $trial',
-        () async {
-          final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
-          await isolate.init();
+      test('trial $trial', () async {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
 
-          final startFuture = isolate.start(
-            'while True: pass',
-            externalFunctions: ['__never_called__'],
-          );
+        final startFuture = isolate.start(
+          'while True: pass',
+          externalFunctions: ['__never_called__'],
+        );
 
-          await Future<void>.delayed(const Duration(milliseconds: 100));
+        await Future<void>.delayed(const Duration(milliseconds: 100));
 
-          final sw = Stopwatch()..start();
+        final sw = Stopwatch()..start();
 
-          final futureCompleter = Completer<String>();
-          unawaited(
-            startFuture.then<void>(
-              (_) {
-                sw.stop();
-                futureCompleter.complete('completed_normally');
-              },
-              onError: (Object e) {
-                sw.stop();
-                futureCompleter.complete(e.runtimeType.toString());
-              },
-            ),
-          );
+        final futureCompleter = Completer<String>();
+        unawaited(
+          startFuture.then<void>(
+            (_) {
+              sw.stop();
+              futureCompleter.complete('completed_normally');
+            },
+            onError: (Object e) {
+              sw.stop();
+              futureCompleter.complete(e.runtimeType.toString());
+            },
+          ),
+        );
 
-          await isolate.terminate();
+        await isolate.terminate();
 
-          final result = await futureCompleter.future.timeout(
-            const Duration(milliseconds: futureHangTimeoutMs),
-            onTimeout: () => 'HANGING',
-          );
+        final result = await futureCompleter.future.timeout(
+          const Duration(milliseconds: futureHangTimeoutMs),
+          onTimeout: () => 'HANGING',
+        );
 
-          if (result == 'HANGING') {
-            c2HangingCount++;
-          } else {
-            c2ResolvedCount++;
-            c2ResolutionTimesMs.add(sw.elapsedMicroseconds / 1000.0);
-            c2ResolvedTypes[result] = (c2ResolvedTypes[result] ?? 0) + 1;
-          }
-        },
-        timeout: const Timeout(Duration(seconds: 30)),
-      );
+        if (result == 'HANGING') {
+          c2HangingCount++;
+        } else {
+          c2ResolvedCount++;
+          c2ResolutionTimesMs.add(sw.elapsedMicroseconds / 1000.0);
+          c2ResolvedTypes[result] = (c2ResolvedTypes[result] ?? 0) + 1;
+        }
+      }, timeout: const Timeout(Duration(seconds: 30)));
     }
   });
 
@@ -204,10 +196,14 @@ void main() {
 
     final c1Pass = c1HangingCount == 0;
     final c2Pass = c2HangingCount == 0;
-    print('VERDICT C1 (dispose): ${c1Pass ? "PASS" : "FAIL"}'
-        '${!c1Pass ? " — $c1HangingCount/$nC1 futures hung, $c1DisposeHangCount/$nC1 dispose() calls hung" : ""}');
-    print('VERDICT C2 (terminate): ${c2Pass ? "PASS" : "FAIL"}'
-        '${!c2Pass ? " — $c2HangingCount/$nC2 futures hung" : ""}');
+    print(
+      'VERDICT C1 (dispose): ${c1Pass ? "PASS" : "FAIL"}'
+      '${!c1Pass ? " — $c1HangingCount/$nC1 futures hung, $c1DisposeHangCount/$nC1 dispose() calls hung" : ""}',
+    );
+    print(
+      'VERDICT C2 (terminate): ${c2Pass ? "PASS" : "FAIL"}'
+      '${!c2Pass ? " — $c2HangingCount/$nC2 futures hung" : ""}',
+    );
     print('');
     print('OVERALL: ${c1Pass && c2Pass ? "PASS" : "FAIL"}');
     print('=== END T2-2 ===\n');

--- a/packages/dart_monty_ffi/test/experiments/cancel_exp_t2_3_test.dart
+++ b/packages/dart_monty_ffi/test/experiments/cancel_exp_t2_3_test.dart
@@ -27,32 +27,28 @@ void main() {
   final rssAtCheckpoint = <int, int>{};
 
   group('T2-3: memory leak soak ($totalCycles cycles)', () {
-    test(
-      'soak run',
-      () async {
-        // Warm-up: 5 cycles.
-        for (var i = 0; i < 5; i++) {
-          final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
-          await isolate.init();
-          await isolate.run('2 + 2');
-          await isolate.dispose();
+    test('soak run', () async {
+      // Warm-up: 5 cycles.
+      for (var i = 0; i < 5; i++) {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
+        await isolate.run('2 + 2');
+        await isolate.dispose();
+      }
+
+      rssAtCheckpoint[0] = ProcessInfo.currentRss;
+
+      for (var cycle = 1; cycle <= totalCycles; cycle++) {
+        final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
+        await isolate.init();
+        await isolate.run('2 + 2');
+        await isolate.dispose();
+
+        if (checkpoints.contains(cycle)) {
+          rssAtCheckpoint[cycle] = ProcessInfo.currentRss;
         }
-
-        rssAtCheckpoint[0] = ProcessInfo.currentRss;
-
-        for (var cycle = 1; cycle <= totalCycles; cycle++) {
-          final isolate = NativeIsolateBindingsImpl(libraryPath: libPath);
-          await isolate.init();
-          await isolate.run('2 + 2');
-          await isolate.dispose();
-
-          if (checkpoints.contains(cycle)) {
-            rssAtCheckpoint[cycle] = ProcessInfo.currentRss;
-          }
-        }
-      },
-      timeout: const Timeout(Duration(minutes: 10)),
-    );
+      }
+    }, timeout: const Timeout(Duration(minutes: 10)));
   });
 
   tearDownAll(() {
@@ -66,8 +62,9 @@ void main() {
     var r2 = 0.0;
     if (entries.length >= 2) {
       final xs = entries.map((e) => e.key.toDouble()).toList();
-      final ys =
-          entries.map((e) => (e.value - baseRss) / (1024 * 1024)).toList();
+      final ys = entries
+          .map((e) => (e.value - baseRss) / (1024 * 1024))
+          .toList();
       final n = xs.length;
       final mx = xs.reduce((a, b) => a + b) / n;
       final my = ys.reduce((a, b) => a + b) / n;

--- a/packages/dart_monty_ffi/test/experiments/cancel_exp_t3_2_test.dart
+++ b/packages/dart_monty_ffi/test/experiments/cancel_exp_t3_2_test.dart
@@ -56,9 +56,7 @@ void main() {
         await Future<void>.delayed(const Duration(milliseconds: 100));
 
         // Guard the Future so its error doesn't escape the zone.
-        unawaited(
-          startFuture.then<void>((_) {}, onError: (_) {}),
-        );
+        unawaited(startFuture.then<void>((_) {}, onError: (_) {}));
 
         final sw = Stopwatch()..start();
         await isolate.terminate();

--- a/packages/dart_monty_ffi/test/ffi_core_bindings_test.dart
+++ b/packages/dart_monty_ffi/test/ffi_core_bindings_test.dart
@@ -26,7 +26,8 @@ void main() {
     test('success translates to CoreRunResult(ok: true)', () async {
       mock.nextRunResult = const RunResult(
         tag: 0,
-        resultJson: '{"value": 42, "usage": {"memory_bytes_used": 100, '
+        resultJson:
+            '{"value": 42, "usage": {"memory_bytes_used": 100, '
             '"time_elapsed_ms": 5, "stack_depth_used": 3}}',
       );
 
@@ -52,7 +53,8 @@ void main() {
     test('success with print_output preserves it', () async {
       mock.nextRunResult = const RunResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}, '
             r'"print_output": "hello\n"}',
       );
@@ -65,7 +67,8 @@ void main() {
     test('success with embedded error preserves error fields', () async {
       mock.nextRunResult = const RunResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}, '
             '"error": {"message": "NameError", "exc_type": "NameError"}}',
       );
@@ -80,7 +83,8 @@ void main() {
     test('error with result JSON extracts error details', () async {
       mock.nextRunResult = const RunResult(
         tag: 1,
-        resultJson: '{"error": {"message": "division by zero", '
+        resultJson:
+            '{"error": {"message": "division by zero", '
             '"exc_type": "ZeroDivisionError", '
             '"traceback": [{"filename": "<test>", "start_line": 1}]}}',
       );
@@ -94,10 +98,7 @@ void main() {
     });
 
     test('error falls back to errorMessage', () async {
-      mock.nextRunResult = const RunResult(
-        tag: 1,
-        errorMessage: 'C API error',
-      );
+      mock.nextRunResult = const RunResult(tag: 1, errorMessage: 'C API error');
 
       final result = await bindings.run('bad');
 
@@ -117,7 +118,8 @@ void main() {
     test('passes scriptName to create()', () async {
       mock.nextRunResult = const RunResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
       );
 
@@ -129,13 +131,15 @@ void main() {
     test('applies limits from JSON', () async {
       mock.nextRunResult = const RunResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
       );
 
       await bindings.run(
         'code',
-        limitsJson: '{"memory_bytes": 1024, "timeout_ms": 5000, '
+        limitsJson:
+            '{"memory_bytes": 1024, "timeout_ms": 5000, '
             '"stack_depth": 100}',
       );
 
@@ -150,7 +154,8 @@ void main() {
     test('null limits skips limit calls', () async {
       mock.nextRunResult = const RunResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
       );
 
@@ -162,10 +167,7 @@ void main() {
     });
 
     test('frees handle even on error', () async {
-      mock.nextRunResult = const RunResult(
-        tag: 1,
-        errorMessage: 'error',
-      );
+      mock.nextRunResult = const RunResult(tag: 1, errorMessage: 'error');
 
       await bindings.run('bad');
 
@@ -175,10 +177,7 @@ void main() {
     test('null result JSON on tag 0 throws StateError', () async {
       mock.nextRunResult = const RunResult(tag: 0);
 
-      await expectLater(
-        () => bindings.run('code'),
-        throwsA(isA<StateError>()),
-      );
+      await expectLater(() => bindings.run('code'), throwsA(isA<StateError>()));
     });
   });
 
@@ -186,7 +185,8 @@ void main() {
     test('complete translates to CoreProgressResult', () async {
       mock.nextStartResult = const ProgressResult(
         tag: 0,
-        resultJson: '{"value": 99, "usage": {"memory_bytes_used": 50, '
+        resultJson:
+            '{"value": 99, "usage": {"memory_bytes_used": 50, '
             '"time_elapsed_ms": 2, "stack_depth_used": 1}}',
       );
 
@@ -208,7 +208,8 @@ void main() {
     test('complete with embedded error preserves error', () async {
       mock.nextStartResult = const ProgressResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}, '
             '"error": {"message": "caught", "exc_type": "RuntimeError"}}',
       );
@@ -230,10 +231,7 @@ void main() {
         methodCall: true,
       );
 
-      final result = await bindings.start(
-        'code',
-        extFnsJson: '["get_data"]',
-      );
+      final result = await bindings.start('code', extFnsJson: '["get_data"]');
 
       expect(result.state, 'pending');
       expect(result.functionName, 'get_data');
@@ -252,24 +250,15 @@ void main() {
         kwargsJson: '{}',
       );
 
-      final result = await bindings.start(
-        'code',
-        extFnsJson: '["fn"]',
-      );
+      final result = await bindings.start('code', extFnsJson: '["fn"]');
 
       expect(result.kwargs, isNull);
     });
 
     test('pending with null args defaults to empty list', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
 
-      final result = await bindings.start(
-        'code',
-        extFnsJson: '["fn"]',
-      );
+      final result = await bindings.start('code', extFnsJson: '["fn"]');
 
       expect(result.arguments, isEmpty);
     });
@@ -277,7 +266,8 @@ void main() {
     test('error with result JSON extracts details', () async {
       mock.nextStartResult = const ProgressResult(
         tag: 2,
-        resultJson: '{"error": {"message": "not defined", '
+        resultJson:
+            '{"error": {"message": "not defined", '
             '"exc_type": "NameError"}}',
       );
 
@@ -306,10 +296,7 @@ void main() {
         futureCallIdsJson: '[1, 2, 3]',
       );
 
-      final result = await bindings.start(
-        'code',
-        extFnsJson: '["fn"]',
-      );
+      final result = await bindings.start('code', extFnsJson: '["fn"]');
 
       expect(result.state, 'resolve_futures');
       expect(result.pendingCallIds, [1, 2, 3]);
@@ -321,11 +308,7 @@ void main() {
       await expectLater(
         () => bindings.start('code'),
         throwsA(
-          isA<StateError>().having(
-            (e) => e.message,
-            'message',
-            contains('99'),
-          ),
+          isA<StateError>().having((e) => e.message, 'message', contains('99')),
         ),
       );
     });
@@ -333,14 +316,12 @@ void main() {
     test('external functions joined as comma-separated', () async {
       mock.nextStartResult = const ProgressResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
       );
 
-      await bindings.start(
-        'code',
-        extFnsJson: '["fn_a", "fn_b"]',
-      );
+      await bindings.start('code', extFnsJson: '["fn_a", "fn_b"]');
 
       expect(mock.createCalls.first.externalFunctions, 'fn_a,fn_b');
     });
@@ -348,7 +329,8 @@ void main() {
     test('null extFnsJson passes null to create', () async {
       mock.nextStartResult = const ProgressResult(
         tag: 0,
-        resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": null, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
       );
 
@@ -361,17 +343,15 @@ void main() {
   group('resume()', () {
     test('delegates valueJson and translates result', () async {
       // Enter active state via start → pending.
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
       await bindings.start('code', extFnsJson: '["fn"]');
 
       // Now resume.
       mock.resumeResults.add(
         const ProgressResult(
           tag: 0,
-          resultJson: '{"value": "done", "usage": {"memory_bytes_used": 0, '
+          resultJson:
+              '{"value": "done", "usage": {"memory_bytes_used": 0, '
               '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
         ),
       );
@@ -400,16 +380,14 @@ void main() {
 
   group('resumeWithError()', () {
     test('delegates errorMessage and translates result', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
       await bindings.start('code', extFnsJson: '["fn"]');
 
       mock.resumeWithErrorResults.add(
         const ProgressResult(
           tag: 0,
-          resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+          resultJson:
+              '{"value": null, "usage": {"memory_bytes_used": 0, '
               '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
         ),
       );
@@ -431,17 +409,11 @@ void main() {
 
   group('resumeAsFuture()', () {
     test('delegates and translates result', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
       await bindings.start('code', extFnsJson: '["fn"]');
 
       mock.resumeAsFutureResults.add(
-        const ProgressResult(
-          tag: 3,
-          futureCallIdsJson: '[0]',
-        ),
+        const ProgressResult(tag: 3, futureCallIdsJson: '[0]'),
       );
 
       final result = await bindings.resumeAsFuture();
@@ -470,16 +442,14 @@ void main() {
       mock.resolveFuturesResults.add(
         const ProgressResult(
           tag: 0,
-          resultJson: '{"value": "resolved", "usage": '
+          resultJson:
+              '{"value": "resolved", "usage": '
               '{"memory_bytes_used": 0, "time_elapsed_ms": 0, '
               '"stack_depth_used": 0}}',
         ),
       );
 
-      final result = await bindings.resolveFutures(
-        '{"1": "value"}',
-        '{}',
-      );
+      final result = await bindings.resolveFutures('{"1": "value"}', '{}');
 
       expect(mock.resolveFuturesCalls, hasLength(1));
       expect(result.state, 'complete');
@@ -496,10 +466,7 @@ void main() {
 
   group('snapshot()', () {
     test('delegates to bindings', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
       await bindings.start('code', extFnsJson: '["fn"]');
 
       mock.nextSnapshotData = Uint8List.fromList([10, 20, 30]);
@@ -510,10 +477,7 @@ void main() {
     });
 
     test('throws StateError when no handle', () async {
-      await expectLater(
-        () => bindings.snapshot(),
-        throwsA(isA<StateError>()),
-      );
+      await expectLater(() => bindings.snapshot(), throwsA(isA<StateError>()));
     });
   });
 
@@ -534,10 +498,7 @@ void main() {
 
   group('dispose()', () {
     test('frees active handle', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
       await bindings.start('code', extFnsJson: '["fn"]');
 
       await bindings.dispose();
@@ -552,10 +513,7 @@ void main() {
     });
 
     test('second dispose is no-op', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
       await bindings.start('code', extFnsJson: '["fn"]');
 
       await bindings.dispose();
@@ -570,7 +528,8 @@ void main() {
     test('run creates and frees handle each call', () async {
       mock.nextRunResult = const RunResult(
         tag: 0,
-        resultJson: '{"value": 1, "usage": {"memory_bytes_used": 0, '
+        resultJson:
+            '{"value": 1, "usage": {"memory_bytes_used": 0, '
             '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
       );
 
@@ -582,10 +541,7 @@ void main() {
     });
 
     test('start stores handle on pending, frees on complete', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'fn',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'fn');
       await bindings.start('code', extFnsJson: '["fn"]');
 
       // Handle stored, not freed yet.
@@ -595,7 +551,8 @@ void main() {
       mock.resumeResults.add(
         const ProgressResult(
           tag: 0,
-          resultJson: '{"value": null, "usage": {"memory_bytes_used": 0, '
+          resultJson:
+              '{"value": null, "usage": {"memory_bytes_used": 0, '
               '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
         ),
       );

--- a/packages/dart_monty_ffi/test/integration/python_ladder_runner.dart
+++ b/packages/dart_monty_ffi/test/integration/python_ladder_runner.dart
@@ -20,14 +20,13 @@ import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart
 Future<void> main() async {
   final bindings = NativeBindingsFfi();
   final fixtureDir = Directory('../../test/fixtures/python_ladder');
-  final tierFiles = fixtureDir
-      .listSync()
-      .whereType<File>()
-      .where(
-        (f) => f.path.endsWith('.json'),
-      )
-      .toList()
-    ..sort((a, b) => a.path.compareTo(b.path));
+  final tierFiles =
+      fixtureDir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.json'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
 
   for (final file in tierFiles) {
     final fixtures = (jsonDecode(file.readAsStringSync()) as List)

--- a/packages/dart_monty_ffi/test/integration/readme_doctest.dart
+++ b/packages/dart_monty_ffi/test/integration/readme_doctest.dart
@@ -39,10 +39,8 @@ List<String> _extractDartBlocks(String markdown) =>
 // Registry: (relative path from repo root) -> handler per block index
 // ---------------------------------------------------------------------------
 
-typedef BlockHandler = Future<void> Function(
-  String block,
-  NativeBindingsFfi bindings,
-);
+typedef BlockHandler =
+    Future<void> Function(String block, NativeBindingsFfi bindings);
 
 /// Hand-written handlers keyed by `(readmePath, blockIndex)`.
 final Map<(String, int), BlockHandler> _handlers = {
@@ -76,10 +74,7 @@ final Map<(String, int), BlockHandler> _handlers = {
 ///
 /// The README calls `fib(30)` but Monty has no built-in fib.
 /// We validate the *pattern* — `run()` works with and without limits.
-Future<void> _handleRootBlock0(
-  String block,
-  NativeBindingsFfi bindings,
-) async {
+Future<void> _handleRootBlock0(String block, NativeBindingsFfi bindings) async {
   // Verify the block looks like what we expect.
   expect(block, contains("run('2 + 2')"));
   expect(block, contains('MontyLimits'));
@@ -105,10 +100,7 @@ Future<void> _handleRootBlock0(
 }
 
 /// README.md block 1: external function dispatch loop.
-Future<void> _handleRootBlock1(
-  String block,
-  NativeBindingsFfi bindings,
-) async {
+Future<void> _handleRootBlock1(String block, NativeBindingsFfi bindings) async {
   expect(block, contains('externalFunctions'));
   expect(block, contains('MontyPending'));
 
@@ -135,10 +127,7 @@ Future<void> _handleRootBlock1(
 }
 
 /// README.md block 2: stateful sessions.
-Future<void> _handleRootBlock2(
-  String block,
-  NativeBindingsFfi bindings,
-) async {
+Future<void> _handleRootBlock2(String block, NativeBindingsFfi bindings) async {
   expect(block, contains('MontySession'));
   expect(block, contains('x = 42'));
 
@@ -187,10 +176,7 @@ Future<void> _handlePlatformInterfaceBlock0(
 // ---------------------------------------------------------------------------
 
 /// ffi/README.md block 0: MontyFfi run + external function dispatch.
-Future<void> _handleFfiBlock0(
-  String block,
-  NativeBindingsFfi bindings,
-) async {
+Future<void> _handleFfiBlock0(String block, NativeBindingsFfi bindings) async {
   expect(block, contains('MontyFfi'));
   expect(block, contains('NativeBindingsFfi'));
   expect(block, contains("run('2 + 2')"));
@@ -286,9 +272,10 @@ void main() {
               !d.path.contains('spike'),
         )
         .map((d) {
-      final name = d.uri.pathSegments.where((s) => s.isNotEmpty).last;
-      return 'packages/$name/README.md';
-    }).where((p) => File('$repoRoot/$p').existsSync()),
+          final name = d.uri.pathSegments.where((s) => s.isNotEmpty).last;
+          return 'packages/$name/README.md';
+        })
+        .where((p) => File('$repoRoot/$p').existsSync()),
   ];
 
   for (final readmePath in readmePaths) {
@@ -301,7 +288,8 @@ void main() {
         expect(
           _handlers.containsKey((readmePath, i)),
           isTrue,
-          reason: '$readmePath block $i has no handler — add one to '
+          reason:
+              '$readmePath block $i has no handler — add one to '
               'readme_doctest.dart',
         );
       }
@@ -391,112 +379,114 @@ void main() {
     });
 
     // -- platform_interface: construct all types, verify fields --
-    test('platform_interface/example/example.dart: type construction',
-        () async {
-      final source = _readExample(
-        repoRoot,
-        'packages/dart_monty_platform_interface/example/example.dart',
-      );
-      expect(source, contains('MontyResult.fromJson'));
-      expect(source, contains('MontyException'));
-      expect(source, contains('MontyStackFrame'));
-      expect(source, contains('MontyResourceUsage'));
-      expect(source, contains('MontyLimits'));
-      expect(source, contains('MontyPending'));
-      expect(source, contains('MontyComplete'));
-      expect(source, contains('MontyResolveFutures'));
+    test(
+      'platform_interface/example/example.dart: type construction',
+      () async {
+        final source = _readExample(
+          repoRoot,
+          'packages/dart_monty_platform_interface/example/example.dart',
+        );
+        expect(source, contains('MontyResult.fromJson'));
+        expect(source, contains('MontyException'));
+        expect(source, contains('MontyStackFrame'));
+        expect(source, contains('MontyResourceUsage'));
+        expect(source, contains('MontyLimits'));
+        expect(source, contains('MontyPending'));
+        expect(source, contains('MontyComplete'));
+        expect(source, contains('MontyResolveFutures'));
 
-      // Exercise the same type constructions.
-      final result = MontyResult.fromJson(const {
-        'value': 42,
-        'usage': {
-          'memory_bytes_used': 1024,
-          'time_elapsed_ms': 5,
-          'stack_depth_used': 2,
-        },
-      });
-      expect(result.value, 42);
-      expect(result.isError, isFalse);
+        // Exercise the same type constructions.
+        final result = MontyResult.fromJson(const {
+          'value': 42,
+          'usage': {
+            'memory_bytes_used': 1024,
+            'time_elapsed_ms': 5,
+            'stack_depth_used': 2,
+          },
+        });
+        expect(result.value, 42);
+        expect(result.isError, isFalse);
 
-      final errorResult = MontyResult.fromJson(const {
-        'error': {
-          'message': 'division by zero',
-          'exc_type': 'ZeroDivisionError',
-          'filename': '<expr>',
-          'line_number': 1,
-          'column_number': 2,
-        },
-        'usage': {
-          'memory_bytes_used': 512,
-          'time_elapsed_ms': 1,
-          'stack_depth_used': 1,
-        },
-      });
-      expect(errorResult.isError, isTrue);
-      expect(errorResult.error!.excType, 'ZeroDivisionError');
+        final errorResult = MontyResult.fromJson(const {
+          'error': {
+            'message': 'division by zero',
+            'exc_type': 'ZeroDivisionError',
+            'filename': '<expr>',
+            'line_number': 1,
+            'column_number': 2,
+          },
+          'usage': {
+            'memory_bytes_used': 512,
+            'time_elapsed_ms': 1,
+            'stack_depth_used': 1,
+          },
+        });
+        expect(errorResult.isError, isTrue);
+        expect(errorResult.error!.excType, 'ZeroDivisionError');
 
-      const frame = MontyStackFrame(
-        filename: 'script.py',
-        startLine: 5,
-        startColumn: 10,
-        frameName: '<module>',
-        previewLine: '    return x + 1',
-      );
-      expect(frame.filename, 'script.py');
-      expect(frame.startLine, 5);
-      expect(frame.frameName, '<module>');
+        const frame = MontyStackFrame(
+          filename: 'script.py',
+          startLine: 5,
+          startColumn: 10,
+          frameName: '<module>',
+          previewLine: '    return x + 1',
+        );
+        expect(frame.filename, 'script.py');
+        expect(frame.startLine, 5);
+        expect(frame.frameName, '<module>');
 
-      const usage = MontyResourceUsage(
-        memoryBytesUsed: 2048,
-        timeElapsedMs: 10,
-        stackDepthUsed: 3,
-      );
-      expect(usage.memoryBytesUsed, 2048);
+        const usage = MontyResourceUsage(
+          memoryBytesUsed: 2048,
+          timeElapsedMs: 10,
+          stackDepthUsed: 3,
+        );
+        expect(usage.memoryBytesUsed, 2048);
 
-      const limits = MontyLimits(
-        timeoutMs: 5000,
-        memoryBytes: 10 * 1024 * 1024,
-        stackDepth: 100,
-      );
-      expect(limits.timeoutMs, 5000);
+        const limits = MontyLimits(
+          timeoutMs: 5000,
+          memoryBytes: 10 * 1024 * 1024,
+          stackDepth: 100,
+        );
+        expect(limits.timeoutMs, 5000);
 
-      // Pattern matching on sealed type.
-      const pending = MontyPending(
-        functionName: 'fetch',
-        arguments: ['https://api.example.com/data'],
-        kwargs: {'timeout': 30},
-        callId: 1,
-      );
-      expect(pending.functionName, 'fetch');
-      expect(pending.kwargs, {'timeout': 30});
+        // Pattern matching on sealed type.
+        const pending = MontyPending(
+          functionName: 'fetch',
+          arguments: ['https://api.example.com/data'],
+          kwargs: {'timeout': 30},
+          callId: 1,
+        );
+        expect(pending.functionName, 'fetch');
+        expect(pending.kwargs, {'timeout': 30});
 
-      const complete = MontyComplete(
-        result: MontyResult(
-          value: 42,
-          usage: MontyResourceUsage(
-            memoryBytesUsed: 1024,
-            timeElapsedMs: 5,
-            stackDepthUsed: 2,
+        const complete = MontyComplete(
+          result: MontyResult(
+            value: 42,
+            usage: MontyResourceUsage(
+              memoryBytesUsed: 1024,
+              timeElapsedMs: 5,
+              stackDepthUsed: 2,
+            ),
           ),
-        ),
-      );
-      expect(complete.result.value, 42);
+        );
+        expect(complete.result.value, 42);
 
-      const futures = MontyResolveFutures(pendingCallIds: [1, 2, 3]);
-      expect(futures.pendingCallIds, [1, 2, 3]);
+        const futures = MontyResolveFutures(pendingCallIds: [1, 2, 3]);
+        expect(futures.pendingCallIds, [1, 2, 3]);
 
-      // Exhaustive switch (compile-time guarantee).
-      for (final progress in [pending, complete, futures]) {
-        switch (progress) {
-          case MontyPending(:final functionName):
-            expect(functionName, 'fetch');
-          case MontyComplete(:final result):
-            expect(result.value, 42);
-          case MontyResolveFutures(:final pendingCallIds):
-            expect(pendingCallIds, hasLength(3));
+        // Exhaustive switch (compile-time guarantee).
+        for (final progress in [pending, complete, futures]) {
+          switch (progress) {
+            case MontyPending(:final functionName):
+              expect(functionName, 'fetch');
+            case MontyComplete(:final result):
+              expect(result.value, 42);
+            case MontyResolveFutures(:final pendingCallIds):
+              expect(pendingCallIds, hasLength(3));
+          }
         }
-      }
-    });
+      },
+    );
 
     // -- WASM: structure-only --
     test('wasm/example/example.dart: structure', () {

--- a/packages/dart_monty_ffi/test/mock_native_bindings.dart
+++ b/packages/dart_monty_ffi/test/mock_native_bindings.dart
@@ -26,7 +26,8 @@ class MockNativeBindings extends NativeBindings {
   /// Result returned by [run].
   RunResult nextRunResult = const RunResult(
     tag: 0,
-    resultJson: '{"value": 4, "usage": {"memory_bytes_used": 0, '
+    resultJson:
+        '{"value": 4, "usage": {"memory_bytes_used": 0, '
         '"time_elapsed_ms": 0, "stack_depth_used": 0}}',
   );
 
@@ -63,7 +64,7 @@ class MockNativeBindings extends NativeBindings {
 
   /// Records of `(code, externalFunctions, scriptName)` passed to [create].
   final List<({String code, String? externalFunctions, String? scriptName})>
-      createCalls = [];
+  createCalls = [];
 
   /// Handle addresses passed to [free].
   final List<int> freeCalls = [];
@@ -86,7 +87,7 @@ class MockNativeBindings extends NativeBindings {
   /// Records of `(handle, resultsJson, errorsJson)` passed to
   /// [resolveFutures].
   final List<({int handle, String resultsJson, String errorsJson})>
-      resolveFuturesCalls = [];
+  resolveFuturesCalls = [];
 
   /// If non-null, [setMemoryLimit] throws this.
   Exception? throwOnSetMemoryLimit;
@@ -112,13 +113,11 @@ class MockNativeBindings extends NativeBindings {
 
   @override
   int create(String code, {String? externalFunctions, String? scriptName}) {
-    createCalls.add(
-      (
-        code: code,
-        externalFunctions: externalFunctions,
-        scriptName: scriptName
-      ),
-    );
+    createCalls.add((
+      code: code,
+      externalFunctions: externalFunctions,
+      scriptName: scriptName,
+    ));
     final createError = nextCreateError;
     if (createError != null) {
       throw MontyException(message: createError);
@@ -151,25 +150,17 @@ class MockNativeBindings extends NativeBindings {
     resumeCalls.add((handle: handle, valueJson: valueJson));
     if (resumeResults.isNotEmpty) return resumeResults.removeAt(0);
 
-    return const ProgressResult(
-      tag: 0,
-      resultJson: _defaultCompleteJson,
-    );
+    return const ProgressResult(tag: 0, resultJson: _defaultCompleteJson);
   }
 
   @override
   ProgressResult resumeWithError(int handle, String errorMessage) {
-    resumeWithErrorCalls.add(
-      (handle: handle, errorMessage: errorMessage),
-    );
+    resumeWithErrorCalls.add((handle: handle, errorMessage: errorMessage));
     if (resumeWithErrorResults.isNotEmpty) {
       return resumeWithErrorResults.removeAt(0);
     }
 
-    return const ProgressResult(
-      tag: 0,
-      resultJson: _defaultCompleteJson,
-    );
+    return const ProgressResult(tag: 0, resultJson: _defaultCompleteJson);
   }
 
   @override
@@ -179,10 +170,7 @@ class MockNativeBindings extends NativeBindings {
       return resumeAsFutureResults.removeAt(0);
     }
 
-    return const ProgressResult(
-      tag: 3,
-      futureCallIdsJson: '[0]',
-    );
+    return const ProgressResult(tag: 3, futureCallIdsJson: '[0]');
   }
 
   @override
@@ -191,17 +179,16 @@ class MockNativeBindings extends NativeBindings {
     String resultsJson,
     String errorsJson,
   ) {
-    resolveFuturesCalls.add(
-      (handle: handle, resultsJson: resultsJson, errorsJson: errorsJson),
-    );
+    resolveFuturesCalls.add((
+      handle: handle,
+      resultsJson: resultsJson,
+      errorsJson: errorsJson,
+    ));
     if (resolveFuturesResults.isNotEmpty) {
       return resolveFuturesResults.removeAt(0);
     }
 
-    return const ProgressResult(
-      tag: 0,
-      resultJson: _defaultCompleteJson,
-    );
+    return const ProgressResult(tag: 0, resultJson: _defaultCompleteJson);
   }
 
   @override

--- a/packages/dart_monty_ffi/test/mock_native_isolate_bindings.dart
+++ b/packages/dart_monty_ffi/test/mock_native_isolate_bindings.dart
@@ -18,10 +18,7 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
   bool nextInitResult = true;
 
   /// Result returned by [run].
-  MontyResult nextRunResult = const MontyResult(
-    value: 4,
-    usage: _zeroUsage,
-  );
+  MontyResult nextRunResult = const MontyResult(value: 4, usage: _zeroUsage);
 
   /// Result returned by [start].
   MontyProgress nextStartResult = const MontyComplete(
@@ -64,17 +61,19 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
 
   /// Records of `(code, limits, scriptName)` passed to [run].
   final List<({String code, MontyLimits? limits, String? scriptName})>
-      runCalls = [];
+  runCalls = [];
 
   /// Records of `(code, externalFunctions, limits, scriptName)` passed to
   /// [start].
   final List<
-      ({
-        String code,
-        List<String>? externalFunctions,
-        MontyLimits? limits,
-        String? scriptName,
-      })> startCalls = [];
+    ({
+      String code,
+      List<String>? externalFunctions,
+      MontyLimits? limits,
+      String? scriptName,
+    })
+  >
+  startCalls = [];
 
   /// Records of `returnValue` passed to [resume].
   final List<Object?> resumeCalls = [];
@@ -140,14 +139,12 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
     MontyLimits? limits,
     String? scriptName,
   }) async {
-    startCalls.add(
-      (
-        code: code,
-        externalFunctions: externalFunctions,
-        limits: limits,
-        scriptName: scriptName,
-      ),
-    );
+    startCalls.add((
+      code: code,
+      externalFunctions: externalFunctions,
+      limits: limits,
+      scriptName: scriptName,
+    ));
 
     return nextStartResult;
   }
@@ -157,9 +154,7 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
     resumeCalls.add(returnValue);
     if (resumeResults.isNotEmpty) return resumeResults.removeAt(0);
 
-    return const MontyComplete(
-      result: MontyResult(usage: _zeroUsage),
-    );
+    return const MontyComplete(result: MontyResult(usage: _zeroUsage));
   }
 
   @override
@@ -169,9 +164,7 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
       return resumeWithErrorResults.removeAt(0);
     }
 
-    return const MontyComplete(
-      result: MontyResult(usage: _zeroUsage),
-    );
+    return const MontyComplete(result: MontyResult(usage: _zeroUsage));
   }
 
   @override
@@ -195,9 +188,7 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
       return resolveFuturesResults.removeAt(0);
     }
 
-    return const MontyComplete(
-      result: MontyResult(usage: _zeroUsage),
-    );
+    return const MontyComplete(result: MontyResult(usage: _zeroUsage));
   }
 
   @override

--- a/packages/dart_monty_ffi/test/monty_ffi_test.dart
+++ b/packages/dart_monty_ffi/test/monty_ffi_test.dart
@@ -124,10 +124,7 @@ void main() {
     });
 
     test('frees handle even when run throws', () async {
-      mock.nextRunResult = const RunResult(
-        tag: 1,
-        errorMessage: 'boom',
-      );
+      mock.nextRunResult = const RunResult(tag: 1, errorMessage: 'boom');
 
       try {
         await monty.run('x');
@@ -197,10 +194,7 @@ void main() {
         argumentsJson: '[]',
       );
 
-      await monty.start(
-        'a()',
-        externalFunctions: ['a', 'b', 'c'],
-      );
+      await monty.start('a()', externalFunctions: ['a', 'b', 'c']);
 
       expect(mock.createCalls.first.externalFunctions, 'a,b,c');
     });
@@ -325,10 +319,7 @@ void main() {
         isError: 0,
       );
 
-      await monty.start(
-        'x',
-        limits: const MontyLimits(memoryBytes: 512),
-      );
+      await monty.start('x', limits: const MontyLimits(memoryBytes: 512));
 
       expect(mock.setMemoryLimitCalls, hasLength(1));
       expect(mock.setMemoryLimitCalls.first.bytes, 512);
@@ -402,20 +393,13 @@ void main() {
         const ProgressResult(tag: 2, errorMessage: 'runtime error'),
       );
 
-      expect(
-        () => monty.resume(null),
-        throwsA(isA<MontyException>()),
-      );
+      expect(() => monty.resume(null), throwsA(isA<MontyException>()));
     });
 
     test('throws StateError when idle', () async {
       // Complete the execution first to go back to idle.
       mock.resumeResults.add(
-        ProgressResult(
-          tag: 0,
-          resultJson: _okResultJson(null),
-          isError: 0,
-        ),
+        ProgressResult(tag: 0, resultJson: _okResultJson(null), isError: 0),
       );
       await monty.resume(null);
 
@@ -429,11 +413,7 @@ void main() {
 
     test('encodes complex return values as JSON', () async {
       mock.resumeResults.add(
-        ProgressResult(
-          tag: 0,
-          resultJson: _okResultJson(null),
-          isError: 0,
-        ),
+        ProgressResult(tag: 0, resultJson: _okResultJson(null), isError: 0),
       );
 
       await monty.resume({
@@ -477,18 +457,12 @@ void main() {
 
     test('throws StateError when idle', () {
       final freshMonty = MontyFfi(bindings: mock);
-      expect(
-        () => freshMonty.resumeWithError('err'),
-        throwsStateError,
-      );
+      expect(() => freshMonty.resumeWithError('err'), throwsStateError);
     });
 
     test('throws StateError when disposed', () async {
       await monty.dispose();
-      expect(
-        () => monty.resumeWithError('err'),
-        throwsStateError,
-      );
+      expect(() => monty.resumeWithError('err'), throwsStateError);
     });
   });
 
@@ -551,11 +525,7 @@ void main() {
 
       // resume() should be allowed (active state).
       mock.resumeResults.add(
-        ProgressResult(
-          tag: 0,
-          resultJson: _okResultJson(10),
-          isError: 0,
-        ),
+        ProgressResult(tag: 0, resultJson: _okResultJson(10), isError: 0),
       );
       final progress = await restoredFfi.resume('val');
       expect(progress, isA<MontyComplete>());
@@ -573,10 +543,7 @@ void main() {
 
     test('throws StateError when disposed', () async {
       await monty.dispose();
-      expect(
-        () => monty.restore(Uint8List.fromList([1])),
-        throwsStateError,
-      );
+      expect(() => monty.restore(Uint8List.fromList([1])), throwsStateError);
     });
 
     test('throws StateError when active', () async {
@@ -587,10 +554,7 @@ void main() {
       );
       await monty.start('x', externalFunctions: ['f']);
 
-      expect(
-        () => monty.restore(Uint8List.fromList([1])),
-        throwsStateError,
-      );
+      expect(() => monty.restore(Uint8List.fromList([1])), throwsStateError);
     });
   });
 
@@ -635,8 +599,10 @@ void main() {
     });
 
     test('run with string value in result', () async {
-      mock.nextRunResult =
-          RunResult(tag: 0, resultJson: _okResultJson('"hello"'));
+      mock.nextRunResult = RunResult(
+        tag: 0,
+        resultJson: _okResultJson('"hello"'),
+      );
 
       final result = await monty.run('"hello"');
       expect(result.value, 'hello');
@@ -662,25 +628,16 @@ void main() {
         argumentsJson: '[]',
       );
 
-      final progress = await monty.start(
-        'noop()',
-        externalFunctions: ['noop'],
-      );
+      final progress = await monty.start('noop()', externalFunctions: ['noop']);
 
       final pending = progress as MontyPending;
       expect(pending.arguments, isEmpty);
     });
 
     test('pending with null argumentsJson defaults to empty', () async {
-      mock.nextStartResult = const ProgressResult(
-        tag: 1,
-        functionName: 'noop',
-      );
+      mock.nextStartResult = const ProgressResult(tag: 1, functionName: 'noop');
 
-      final progress = await monty.start(
-        'noop()',
-        externalFunctions: ['noop'],
-      );
+      final progress = await monty.start('noop()', externalFunctions: ['noop']);
 
       final pending = progress as MontyPending;
       expect(pending.arguments, isEmpty);
@@ -726,7 +683,8 @@ void main() {
     });
 
     test('run error result includes excType and traceback', () async {
-      const errorJson = '{"value": null, "error": {'
+      const errorJson =
+          '{"value": null, "error": {'
           ' "message": "division by zero",'
           ' "exc_type": "ZeroDivisionError",'
           ' "traceback": [{"filename": "test.py", "start_line": 1,'
@@ -760,50 +718,61 @@ void main() {
       );
     });
 
-    test('run error tag=1 parses excType and traceback from resultJson',
-        () async {
-      const errorJson = '{"value": null, "error": {'
-          ' "message": "division by zero",'
-          ' "exc_type": "ZeroDivisionError",'
-          ' "filename": "test.py",'
-          ' "line_number": 1,'
-          ' "traceback": [{"filename": "test.py", "start_line": 1,'
-          ' "start_column": 0, "end_line": 1, "end_column": 3}]'
-          ' }, "usage": $_usageJson}';
-      mock.nextRunResult =
-          const RunResult(tag: 1, resultJson: errorJson, errorMessage: 'err');
+    test(
+      'run error tag=1 parses excType and traceback from resultJson',
+      () async {
+        const errorJson =
+            '{"value": null, "error": {'
+            ' "message": "division by zero",'
+            ' "exc_type": "ZeroDivisionError",'
+            ' "filename": "test.py",'
+            ' "line_number": 1,'
+            ' "traceback": [{"filename": "test.py", "start_line": 1,'
+            ' "start_column": 0, "end_line": 1, "end_column": 3}]'
+            ' }, "usage": $_usageJson}';
+        mock.nextRunResult = const RunResult(
+          tag: 1,
+          resultJson: errorJson,
+          errorMessage: 'err',
+        );
 
-      try {
-        await monty.run('1/0');
-        fail('Expected MontyException');
-      } on MontyException catch (e) {
-        expect(e.excType, 'ZeroDivisionError');
-        expect(e.message, 'division by zero');
-        expect(e.filename, 'test.py');
-        expect(e.traceback, hasLength(1));
-        expect(e.traceback.first.filename, 'test.py');
-      }
-    });
+        try {
+          await monty.run('1/0');
+          fail('Expected MontyException');
+        } on MontyException catch (e) {
+          expect(e.excType, 'ZeroDivisionError');
+          expect(e.message, 'division by zero');
+          expect(e.filename, 'test.py');
+          expect(e.traceback, hasLength(1));
+          expect(e.traceback.first.filename, 'test.py');
+        }
+      },
+    );
 
-    test('run error tag=1 falls back to errorMessage when no resultJson',
-        () async {
-      mock.nextRunResult =
-          const RunResult(tag: 1, errorMessage: 'fallback msg');
+    test(
+      'run error tag=1 falls back to errorMessage when no resultJson',
+      () async {
+        mock.nextRunResult = const RunResult(
+          tag: 1,
+          errorMessage: 'fallback msg',
+        );
 
-      expect(
-        () => monty.run('x'),
-        throwsA(
-          isA<MontyException>().having(
-            (e) => e.message,
-            'message',
-            'fallback msg',
+        expect(
+          () => monty.run('x'),
+          throwsA(
+            isA<MontyException>().having(
+              (e) => e.message,
+              'message',
+              'fallback msg',
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
 
     test('progress error parses excType from resultJson', () async {
-      const errorJson = '{"value": null, "error": {'
+      const errorJson =
+          '{"value": null, "error": {'
           ' "message": "name error",'
           ' "exc_type": "NameError",'
           ' "traceback": [{"filename": "<module>", "start_line": 1,'
@@ -993,10 +962,7 @@ void main() {
     });
 
     test('throws StateError when idle', () {
-      expect(
-        () => monty.resolveFutures({}, errors: {}),
-        throwsStateError,
-      );
+      expect(() => monty.resolveFutures({}, errors: {}), throwsStateError);
     });
   });
 
@@ -1046,10 +1012,7 @@ void main() {
   group('MontyFfi.withCore', () {
     test('constructs with pre-built core bindings', () {
       final core = FfiCoreBindings(bindings: mock);
-      final ffi = MontyFfi.withCore(
-        coreBindings: core,
-        nativeBindings: mock,
-      );
+      final ffi = MontyFfi.withCore(coreBindings: core, nativeBindings: mock);
       expect(ffi, isA<MontyFfi>());
       expect(ffi.isIdle, isTrue);
     });

--- a/packages/dart_monty_ffi/test/monty_native_test.dart
+++ b/packages/dart_monty_ffi/test/monty_native_test.dart
@@ -97,8 +97,10 @@ void main() {
     });
 
     test('throws StateError when active', () async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'fetch', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'fetch',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['fetch']);
 
       expect(() => monty.run('y'), throwsStateError);
@@ -155,8 +157,10 @@ void main() {
     });
 
     test('passes multiple external functions', () async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'a', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'a',
+        arguments: [],
+      );
 
       await monty.start('a()', externalFunctions: ['a', 'b', 'c']);
 
@@ -189,8 +193,10 @@ void main() {
     });
 
     test('throws StateError when active', () async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'f', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'f',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['f']);
 
       expect(() => monty.start('y'), throwsStateError);
@@ -213,8 +219,10 @@ void main() {
   // ===========================================================================
   group('resume()', () {
     setUp(() async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'fetch', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'fetch',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['fetch']);
     });
 
@@ -247,9 +255,7 @@ void main() {
 
     test('throws StateError when idle', () async {
       mock.resumeResults.add(
-        const MontyComplete(
-          result: MontyResult(usage: _zeroUsage),
-        ),
+        const MontyComplete(result: MontyResult(usage: _zeroUsage)),
       );
       await monty.resume(null);
 
@@ -263,9 +269,7 @@ void main() {
 
     test('passes complex return values', () async {
       mock.resumeResults.add(
-        const MontyComplete(
-          result: MontyResult(usage: _zeroUsage),
-        ),
+        const MontyComplete(result: MontyResult(usage: _zeroUsage)),
       );
 
       await monty.resume({
@@ -283,16 +287,16 @@ void main() {
   // ===========================================================================
   group('resumeWithError()', () {
     setUp(() async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'fetch', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'fetch',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['fetch']);
     });
 
     test('returns MontyComplete after error injection', () async {
       mock.resumeWithErrorResults.add(
-        const MontyComplete(
-          result: MontyResult(usage: _zeroUsage),
-        ),
+        const MontyComplete(result: MontyResult(usage: _zeroUsage)),
       );
 
       final progress = await monty.resumeWithError('network failure');
@@ -316,18 +320,12 @@ void main() {
 
     test('throws StateError when idle', () {
       final freshMonty = MontyNative(bindings: mock);
-      expect(
-        () => freshMonty.resumeWithError('err'),
-        throwsStateError,
-      );
+      expect(() => freshMonty.resumeWithError('err'), throwsStateError);
     });
 
     test('throws StateError when disposed', () async {
       await monty.dispose();
-      expect(
-        () => monty.resumeWithError('err'),
-        throwsStateError,
-      );
+      expect(() => monty.resumeWithError('err'), throwsStateError);
     });
   });
 
@@ -336,8 +334,10 @@ void main() {
   // ===========================================================================
   group('resumeAsFuture()', () {
     setUp(() async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'fetch', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'fetch',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['fetch']);
     });
 
@@ -370,8 +370,10 @@ void main() {
   // ===========================================================================
   group('resolveFutures()', () {
     setUp(() async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'fetch', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'fetch',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['fetch']);
       mock.resumeAsFutureResults.add(
         const MontyResolveFutures(pendingCallIds: [0]),
@@ -409,8 +411,10 @@ void main() {
   // ===========================================================================
   group('resolveFutures() with errors', () {
     setUp(() async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'fetch', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'fetch',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['fetch']);
       mock.resumeAsFutureResults.add(
         const MontyResolveFutures(pendingCallIds: [0, 1]),
@@ -442,18 +446,12 @@ void main() {
 
     test('throws StateError when idle', () {
       final freshMonty = MontyNative(bindings: mock);
-      expect(
-        () => freshMonty.resolveFutures({}, errors: {}),
-        throwsStateError,
-      );
+      expect(() => freshMonty.resolveFutures({}, errors: {}), throwsStateError);
     });
 
     test('throws StateError when disposed', () async {
       await monty.dispose();
-      expect(
-        () => monty.resolveFutures({}, errors: {}),
-        throwsStateError,
-      );
+      expect(() => monty.resolveFutures({}, errors: {}), throwsStateError);
     });
   });
 
@@ -462,8 +460,10 @@ void main() {
   // ===========================================================================
   group('snapshot()', () {
     setUp(() async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'f', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'f',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['f']);
     });
 
@@ -510,9 +510,7 @@ void main() {
 
       // resume() should be allowed (active state).
       mock.resumeResults.add(
-        const MontyComplete(
-          result: MontyResult(value: 10, usage: _zeroUsage),
-        ),
+        const MontyComplete(result: MontyResult(value: 10, usage: _zeroUsage)),
       );
       final progress = await restoredNative.resume('val');
       expect(progress, isA<MontyComplete>());
@@ -530,21 +528,17 @@ void main() {
 
     test('throws StateError when disposed', () async {
       await monty.dispose();
-      expect(
-        () => monty.restore(Uint8List.fromList([1])),
-        throwsStateError,
-      );
+      expect(() => monty.restore(Uint8List.fromList([1])), throwsStateError);
     });
 
     test('throws StateError when active', () async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'f', arguments: []);
+      mock.nextStartResult = const MontyPending(
+        functionName: 'f',
+        arguments: [],
+      );
       await monty.start('x', externalFunctions: ['f']);
 
-      expect(
-        () => monty.restore(Uint8List.fromList([1])),
-        throwsStateError,
-      );
+      expect(() => monty.restore(Uint8List.fromList([1])), throwsStateError);
     });
   });
 
@@ -577,13 +571,12 @@ void main() {
   // ===========================================================================
   group('edge cases', () {
     test('pending with empty arguments', () async {
-      mock.nextStartResult =
-          const MontyPending(functionName: 'noop', arguments: []);
-
-      final progress = await monty.start(
-        'noop()',
-        externalFunctions: ['noop'],
+      mock.nextStartResult = const MontyPending(
+        functionName: 'noop',
+        arguments: [],
       );
+
+      final progress = await monty.start('noop()', externalFunctions: ['noop']);
 
       final pending = progress as MontyPending;
       expect(pending.arguments, isEmpty);
@@ -635,10 +628,7 @@ void main() {
       expect(monty.isActive, isTrue);
 
       // A second concurrent run() should fail with StateError.
-      expect(
-        () => monty.run('second'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => monty.run('second'), throwsA(isA<StateError>()));
 
       // Release the gate so the first run completes.
       gate.complete();
@@ -677,9 +667,8 @@ MontyResourceUsage _usage({
   required int memory,
   required int time,
   required int stack,
-}) =>
-    MontyResourceUsage(
-      memoryBytesUsed: memory,
-      timeElapsedMs: time,
-      stackDepthUsed: stack,
-    );
+}) => MontyResourceUsage(
+  memoryBytesUsed: memory,
+  timeElapsedMs: time,
+  stackDepthUsed: stack,
+);

--- a/packages/dart_monty_ffi/test/native_library_loader_test.dart
+++ b/packages/dart_monty_ffi/test/native_library_loader_test.dart
@@ -27,9 +27,7 @@ void main() {
 
     test('override path takes precedence over env var', () {
       // Even if DART_MONTY_LIB_PATH is set, overridePath wins.
-      final path = NativeLibraryLoader.resolve(
-        overridePath: '/my/lib.dylib',
-      );
+      final path = NativeLibraryLoader.resolve(overridePath: '/my/lib.dylib');
 
       expect(path, '/my/lib.dylib');
     });

--- a/packages/dart_monty_native/lib/dart_monty_native.dart
+++ b/packages/dart_monty_native/lib/dart_monty_native.dart
@@ -13,8 +13,6 @@ export 'package:dart_monty_ffi/src/native_isolate_bindings_impl.dart';
 class DartMontyNative {
   /// Registers this plugin as the platform implementation.
   static void registerWith() {
-    MontyPlatform.instance = MontyNative(
-      bindings: NativeIsolateBindingsImpl(),
-    );
+    MontyPlatform.instance = MontyNative(bindings: NativeIsolateBindingsImpl());
   }
 }

--- a/packages/dart_monty_native/test/integration/isolate_plugin_test.dart
+++ b/packages/dart_monty_native/test/integration/isolate_plugin_test.dart
@@ -111,9 +111,7 @@ void main() {
       final await_ = _findHandler(plugin, 'isolate_await');
       final getOutput = _findHandler(plugin, 'isolate_get_output');
 
-      final handle = await spawn({
-        'code': 'print("side effect")\n42',
-      });
+      final handle = await spawn({'code': 'print("side effect")\n42'});
       final result = await await_({'handle': handle! as int});
       final output = await getOutput({'handle': handle as int});
 

--- a/packages/dart_monty_native/test/integration/session_test.dart
+++ b/packages/dart_monty_native/test/integration/session_test.dart
@@ -39,9 +39,7 @@ void main() {
     final monty = createMonty();
     final session = MontySession(platform: monty);
 
-    await session.run(
-      'nums = [1,2,3]; name = "test"; flag = True',
-    );
+    await session.run('nums = [1,2,3]; name = "test"; flag = True');
     final result = await session.run('[nums, name, flag]');
 
     expect(result.value, [
@@ -94,10 +92,7 @@ void main() {
     final sessionA = MontySession(platform: montyA);
     final sessionB = MontySession(platform: montyB);
 
-    await Future.wait([
-      sessionA.run('x = 1'),
-      sessionB.run('x = 2'),
-    ]);
+    await Future.wait([sessionA.run('x = 1'), sessionB.run('x = 2')]);
 
     final resultA = await sessionA.run('x');
     final resultB = await sessionB.run('x');

--- a/packages/dart_monty_native/test/integration/smoke_test.dart
+++ b/packages/dart_monty_native/test/integration/smoke_test.dart
@@ -65,10 +65,7 @@ void main() {
       '  result = str(e)',
       'result',
     ].join('\n');
-    final progress = await monty.start(
-      code,
-      externalFunctions: ['fetch'],
-    );
+    final progress = await monty.start(code, externalFunctions: ['fetch']);
 
     expect(progress, isA<MontyPending>());
 
@@ -87,10 +84,7 @@ void main() {
   test('error handling: invalid syntax', () async {
     final monty = createMonty();
 
-    expect(
-      () => monty.run('def'),
-      throwsA(isA<MontyException>()),
-    );
+    expect(() => monty.run('def'), throwsA(isA<MontyException>()));
 
     await monty.dispose();
   });

--- a/packages/dart_monty_platform_interface/example/example.dart
+++ b/packages/dart_monty_platform_interface/example/example.dart
@@ -133,9 +133,7 @@ void _progressPatternMatching() {
   );
 
   // Simulate a futures resolution request.
-  const MontyProgress futures = MontyResolveFutures(
-    pendingCallIds: [1, 2, 3],
-  );
+  const MontyProgress futures = MontyResolveFutures(pendingCallIds: [1, 2, 3]);
 
   // Exhaustive pattern matching on the sealed type.
   for (final progress in [pending, complete, futures]) {

--- a/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
@@ -31,7 +31,7 @@ import 'package:meta/meta.dart';
 abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   /// Creates a [BaseMontyPlatform] backed by [bindings].
   BaseMontyPlatform({required MontyCoreBindings bindings})
-      : _bindings = bindings;
+    : _bindings = bindings;
 
   final MontyCoreBindings _bindings;
 
@@ -175,9 +175,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
     assertNotDisposed('resume');
     assertActive('resume');
     try {
-      final progress = await _bindings.resume(
-        json.encode(returnValue),
-      );
+      final progress = await _bindings.resume(json.encode(returnValue));
       return translateProgress(progress);
     } catch (e) {
       markIdle();
@@ -186,15 +184,11 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   }
 
   @override
-  Future<MontyProgress> resumeWithError(
-    String errorMessage,
-  ) async {
+  Future<MontyProgress> resumeWithError(String errorMessage) async {
     assertNotDisposed('resumeWithError');
     assertActive('resumeWithError');
     try {
-      final progress = await _bindings.resumeWithError(
-        errorMessage,
-      );
+      final progress = await _bindings.resumeWithError(errorMessage);
       return translateProgress(progress);
     } catch (e) {
       markIdle();
@@ -298,9 +292,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
         );
       default:
         markIdle();
-        throw StateError(
-          'Unknown progress state: ${p.state}',
-        );
+        throw StateError('Unknown progress state: ${p.state}');
     }
   }
 
@@ -329,9 +321,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
     );
   }
 
-  List<MontyStackFrame> _parseTraceback(
-    List<dynamic>? traceback,
-  ) {
+  List<MontyStackFrame> _parseTraceback(List<dynamic>? traceback) {
     if (traceback == null) return const [];
     return MontyStackFrame.listFromJson(traceback);
   }

--- a/packages/dart_monty_platform_interface/lib/src/mock_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/mock_monty_platform.dart
@@ -117,8 +117,8 @@ class MockMontyPlatform extends MontyPlatform
   /// The external functions passed to the most recent [start] call.
   List<String>? get lastStartExternalFunctions =>
       startExternalFunctionsList.isEmpty
-          ? null
-          : startExternalFunctionsList.last;
+      ? null
+      : startExternalFunctionsList.last;
 
   /// The limits passed to the most recent [start] call.
   MontyLimits? get lastStartLimits =>

--- a/packages/dart_monty_platform_interface/lib/src/monty_exception.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_exception.dart
@@ -119,14 +119,14 @@ final class MontyException implements Exception {
 
   @override
   int get hashCode => Object.hash(
-        message,
-        filename,
-        lineNumber,
-        columnNumber,
-        sourceCode,
-        excType,
-        _deepEquality.hash(traceback),
-      );
+    message,
+    filename,
+    lineNumber,
+    columnNumber,
+    sourceCode,
+    excType,
+    _deepEquality.hash(traceback),
+  );
 
   @override
   String toString() {

--- a/packages/dart_monty_platform_interface/lib/src/monty_limits.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_limits.dart
@@ -6,11 +6,7 @@ import 'package:meta/meta.dart';
 @immutable
 final class MontyLimits {
   /// Creates a [MontyLimits] with optional resource constraints.
-  const MontyLimits({
-    this.memoryBytes,
-    this.timeoutMs,
-    this.stackDepth,
-  });
+  const MontyLimits({this.memoryBytes, this.timeoutMs, this.stackDepth});
 
   /// Creates a [MontyLimits] from a JSON map.
   ///
@@ -51,11 +47,7 @@ final class MontyLimits {
   }
 
   @override
-  int get hashCode => Object.hash(
-        memoryBytes,
-        timeoutMs,
-        stackDepth,
-      );
+  int get hashCode => Object.hash(memoryBytes, timeoutMs, stackDepth);
 
   @override
   String toString() {

--- a/packages/dart_monty_platform_interface/lib/src/monty_progress.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_progress.dart
@@ -68,10 +68,7 @@ final class MontyComplete extends MontyProgress {
 
   @override
   Map<String, dynamic> toJson() {
-    return {
-      'type': 'complete',
-      'result': result.toJson(),
-    };
+    return {'type': 'complete', 'result': result.toJson()};
   }
 
   @override
@@ -180,12 +177,12 @@ final class MontyPending extends MontyProgress {
 
   @override
   int get hashCode => Object.hash(
-        functionName,
-        _deepEquality.hash(arguments),
-        _deepEquality.hash(kwargs),
-        callId,
-        methodCall,
-      );
+    functionName,
+    _deepEquality.hash(arguments),
+    _deepEquality.hash(kwargs),
+    callId,
+    methodCall,
+  );
 
   @override
   String toString() => 'MontyPending($functionName, $arguments)';
@@ -220,9 +217,7 @@ final class MontyResolveFutures extends MontyProgress {
   factory MontyResolveFutures.fromJson(Map<String, dynamic> json) {
     final rawIds = json['pending_call_ids'] as List<dynamic>;
 
-    return MontyResolveFutures(
-      pendingCallIds: List<int>.from(rawIds),
-    );
+    return MontyResolveFutures(pendingCallIds: List<int>.from(rawIds));
   }
 
   /// The call IDs of futures that need resolution.
@@ -230,10 +225,7 @@ final class MontyResolveFutures extends MontyProgress {
 
   @override
   Map<String, dynamic> toJson() {
-    return {
-      'type': 'resolve_futures',
-      'pending_call_ids': pendingCallIds,
-    };
+    return {'type': 'resolve_futures', 'pending_call_ids': pendingCallIds};
   }
 
   @override

--- a/packages/dart_monty_platform_interface/lib/src/monty_resource_usage.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_resource_usage.dart
@@ -53,11 +53,8 @@ final class MontyResourceUsage {
   }
 
   @override
-  int get hashCode => Object.hash(
-        memoryBytesUsed,
-        timeElapsedMs,
-        stackDepthUsed,
-      );
+  int get hashCode =>
+      Object.hash(memoryBytesUsed, timeElapsedMs, stackDepthUsed);
 
   @override
   String toString() {

--- a/packages/dart_monty_platform_interface/lib/src/monty_result.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_result.dart
@@ -27,9 +27,7 @@ final class MontyResult {
       error: json['error'] != null
           ? MontyException.fromJson(json['error'] as Map<String, dynamic>)
           : null,
-      usage: MontyResourceUsage.fromJson(
-        json['usage'] as Map<String, dynamic>,
-      ),
+      usage: MontyResourceUsage.fromJson(json['usage'] as Map<String, dynamic>),
       printOutput: json['print_output'] as String?,
     );
   }

--- a/packages/dart_monty_platform_interface/lib/src/monty_session.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_session.dart
@@ -140,11 +140,7 @@ class MontySession {
   }) async {
     _checkNotDisposed();
     final wrappedCode = _wrapCode(code);
-    final allExtFns = [
-      _restoreStateFn,
-      _persistStateFn,
-      ...?externalFunctions,
-    ];
+    final allExtFns = [_restoreStateFn, _persistStateFn, ...?externalFunctions];
 
     final progress = await _safeStart(
       wrappedCode,
@@ -405,7 +401,9 @@ class MontySession {
         scriptName: scriptName,
       );
     } on MontyException catch (e) {
-      return MontyComplete(result: MontyResult(error: e, usage: _zeroUsage));
+      return MontyComplete(
+        result: MontyResult(error: e, usage: _zeroUsage),
+      );
     }
   }
 
@@ -414,7 +412,9 @@ class MontySession {
     try {
       return await _platform.resume(returnValue);
     } on MontyException catch (e) {
-      return MontyComplete(result: MontyResult(error: e, usage: _zeroUsage));
+      return MontyComplete(
+        result: MontyResult(error: e, usage: _zeroUsage),
+      );
     }
   }
 
@@ -423,7 +423,9 @@ class MontySession {
     try {
       return await _platform.resumeWithError(errorMessage);
     } on MontyException catch (e) {
-      return MontyComplete(result: MontyResult(error: e, usage: _zeroUsage));
+      return MontyComplete(
+        result: MontyResult(error: e, usage: _zeroUsage),
+      );
     }
   }
 

--- a/packages/dart_monty_platform_interface/lib/src/monty_stack_frame.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_stack_frame.dart
@@ -104,16 +104,16 @@ final class MontyStackFrame {
 
   @override
   int get hashCode => Object.hash(
-        filename,
-        startLine,
-        startColumn,
-        endLine,
-        endColumn,
-        frameName,
-        previewLine,
-        hideCaret,
-        hideFrameName,
-      );
+    filename,
+    startLine,
+    startColumn,
+    endLine,
+    endColumn,
+    frameName,
+    previewLine,
+    hideCaret,
+    hideFrameName,
+  );
 
   @override
   String toString() => 'MontyStackFrame($filename:$startLine:$startColumn)';

--- a/packages/dart_monty_platform_interface/lib/src/testing/ladder_assertions.dart
+++ b/packages/dart_monty_platform_interface/lib/src/testing/ladder_assertions.dart
@@ -16,7 +16,8 @@ void assertLadderResult(Object? actual, Map<String, dynamic> fixture) {
     expect(
       actual.toString(),
       contains(expectedContains),
-      reason: 'Fixture #${fixture['id']}: expected value to contain '
+      reason:
+          'Fixture #${fixture['id']}: expected value to contain '
           '"$expectedContains", got: "$actual"',
     );
 
@@ -39,7 +40,8 @@ void assertLadderResult(Object? actual, Map<String, dynamic> fixture) {
   expect(
     jsonEncode(sortedActual),
     jsonEncode(expected),
-    reason: 'Fixture #${fixture['id']}: '
+    reason:
+        'Fixture #${fixture['id']}: '
         'expected ${jsonEncode(expected)}, '
         'got ${jsonEncode(sortedActual)}',
   );
@@ -59,7 +61,8 @@ void assertPendingFields(MontyPending pending, Map<String, dynamic> fixture) {
     expect(
       pending.functionName,
       expectedFnName,
-      reason: 'Fixture #${fixture['id']}: expected functionName '
+      reason:
+          'Fixture #${fixture['id']}: expected functionName '
           '"$expectedFnName", got: "${pending.functionName}"',
     );
   }
@@ -69,7 +72,8 @@ void assertPendingFields(MontyPending pending, Map<String, dynamic> fixture) {
     expect(
       jsonEncode(pending.arguments),
       jsonEncode(expectedArgs),
-      reason: 'Fixture #${fixture['id']}: expected args '
+      reason:
+          'Fixture #${fixture['id']}: expected args '
           '${jsonEncode(expectedArgs)}, got: ${jsonEncode(pending.arguments)}',
     );
   }
@@ -80,7 +84,8 @@ void assertPendingFields(MontyPending pending, Map<String, dynamic> fixture) {
       expect(
         pending.kwargs,
         isNull,
-        reason: 'Fixture #${fixture['id']}: expected null kwargs, '
+        reason:
+            'Fixture #${fixture['id']}: expected null kwargs, '
             'got: ${pending.kwargs}',
       );
     } else {
@@ -90,7 +95,8 @@ void assertPendingFields(MontyPending pending, Map<String, dynamic> fixture) {
       expect(
         pending.kwargs,
         expectedMap,
-        reason: 'Fixture #${fixture['id']}: expected kwargs '
+        reason:
+            'Fixture #${fixture['id']}: expected kwargs '
             '$expectedMap, got: ${pending.kwargs}',
       );
     }
@@ -100,7 +106,8 @@ void assertPendingFields(MontyPending pending, Map<String, dynamic> fixture) {
     expect(
       pending.callId,
       isNot(0),
-      reason: 'Fixture #${fixture['id']}: expected nonzero callId, '
+      reason:
+          'Fixture #${fixture['id']}: expected nonzero callId, '
           'got: ${pending.callId}',
     );
   }
@@ -110,7 +117,8 @@ void assertPendingFields(MontyPending pending, Map<String, dynamic> fixture) {
     expect(
       pending.methodCall,
       expectedMethodCall,
-      reason: 'Fixture #${fixture['id']}: expected methodCall '
+      reason:
+          'Fixture #${fixture['id']}: expected methodCall '
           '$expectedMethodCall, got: ${pending.methodCall}',
     );
   }
@@ -134,7 +142,8 @@ void assertExceptionFields(
     expect(
       exception.excType,
       expectedExcType,
-      reason: 'Fixture #${fixture['id']}: expected excType '
+      reason:
+          'Fixture #${fixture['id']}: expected excType '
           '"$expectedExcType", got: "${exception.excType}"',
     );
   }
@@ -145,7 +154,8 @@ void assertExceptionFields(
     expect(
       traceback.length,
       greaterThanOrEqualTo(expectedMinFrames),
-      reason: 'Fixture #${fixture['id']}: expected >= $expectedMinFrames '
+      reason:
+          'Fixture #${fixture['id']}: expected >= $expectedMinFrames '
           'traceback frames, got: ${traceback.length}',
     );
   }
@@ -155,7 +165,8 @@ void assertExceptionFields(
     expect(
       exception.traceback.first.filename,
       isNotEmpty,
-      reason: 'Fixture #${fixture['id']}: expected traceback frame '
+      reason:
+          'Fixture #${fixture['id']}: expected traceback frame '
           'to have non-empty filename',
     );
   }
@@ -165,7 +176,8 @@ void assertExceptionFields(
     expect(
       exception.filename,
       expectedErrorFilename,
-      reason: 'Fixture #${fixture['id']}: expected error filename '
+      reason:
+          'Fixture #${fixture['id']}: expected error filename '
           '"$expectedErrorFilename", got: "${exception.filename}"',
     );
   }
@@ -180,7 +192,8 @@ void assertExceptionFields(
     expect(
       hasFilename,
       isTrue,
-      reason: 'Fixture #${fixture['id']}: expected traceback to contain '
+      reason:
+          'Fixture #${fixture['id']}: expected traceback to contain '
           'frame with filename "$expectedTracebackFilename"',
     );
   }

--- a/packages/dart_monty_platform_interface/lib/src/testing/ladder_runner.dart
+++ b/packages/dart_monty_platform_interface/lib/src/testing/ladder_runner.dart
@@ -13,12 +13,13 @@ import 'package:test/test.dart';
 /// Each entry is a record of `(tierName, fixtures)` where fixtures is the
 /// decoded JSON list from that tier file.
 List<(String, List<Map<String, dynamic>>)> loadLadderFixtures(Directory dir) {
-  final tierFiles = dir
-      .listSync()
-      .whereType<File>()
-      .where((f) => f.path.endsWith('.json'))
-      .toList()
-    ..sort((a, b) => a.path.compareTo(b.path));
+  final tierFiles =
+      dir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.json'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
 
   return [
     for (final file in tierFiles)
@@ -58,7 +59,8 @@ Future<void> runErrorFixture(
       expect(
         fullError.contains(errorContains),
         isTrue,
-        reason: 'Expected error to contain "$errorContains", '
+        reason:
+            'Expected error to contain "$errorContains", '
             'got: "$fullError"',
       );
     }
@@ -130,7 +132,8 @@ Future<void> runIterativeFixture(
           expect(
             e.message.contains(errorContains),
             isTrue,
-            reason: 'Expected error containing "$errorContains", '
+            reason:
+                'Expected error containing "$errorContains", '
                 'got: "${e.message}"',
           );
         }
@@ -153,7 +156,8 @@ Future<void> runIterativeFixture(
         expect(
           errorMessage.contains(errorContains),
           isTrue,
-          reason: 'Expected error containing "$errorContains", '
+          reason:
+              'Expected error containing "$errorContains", '
               'got: "$errorMessage"',
         );
       }
@@ -180,7 +184,8 @@ Future<void> runIterativeFixture(
     expect(
       callIds.toSet().length,
       callIds.length,
-      reason: 'Fixture #${fixture['id']}: expected distinct call_ids, '
+      reason:
+          'Fixture #${fixture['id']}: expected distinct call_ids, '
           'got: $callIds',
     );
   }

--- a/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
+++ b/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
@@ -65,9 +65,7 @@ class _FakeCoreBindings implements MontyCoreBindings {
   }
 
   @override
-  Future<CoreProgressResult> resumeWithError(
-    String errorMessage,
-  ) async {
+  Future<CoreProgressResult> resumeWithError(String errorMessage) async {
     lastErrorMessage = errorMessage;
     if (throwOnResumeWithError != null) throw throwOnResumeWithError!;
     return progressResult!;
@@ -81,8 +79,7 @@ class _FakeCoreBindings implements MontyCoreBindings {
   Future<CoreProgressResult> resolveFutures(
     String resultsJson,
     String errorsJson,
-  ) async =>
-      throw UnimplementedError();
+  ) async => throw UnimplementedError();
 
   @override
   Future<Uint8List> snapshot() async => throw UnimplementedError();
@@ -141,11 +138,7 @@ void main() {
 
   group('run()', () {
     test('success returns MontyResult with value and usage', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        value: 42,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, value: 42, usage: usage);
 
       final result = await platform.run('1 + 1');
 
@@ -162,11 +155,7 @@ void main() {
         error: 'division by zero',
         excType: 'ZeroDivisionError',
         traceback: [
-          {
-            'filename': '<test>',
-            'start_line': 1,
-            'start_column': 0,
-          },
+          {'filename': '<test>', 'start_line': 1, 'start_column': 0},
         ],
       );
 
@@ -175,25 +164,14 @@ void main() {
         throwsA(
           isA<MontyException>()
               .having((e) => e.message, 'message', 'division by zero')
-              .having(
-                (e) => e.excType,
-                'excType',
-                'ZeroDivisionError',
-              )
-              .having(
-                (e) => e.traceback,
-                'traceback',
-                hasLength(1),
-              ),
+              .having((e) => e.excType, 'excType', 'ZeroDivisionError')
+              .having((e) => e.traceback, 'traceback', hasLength(1)),
         ),
       );
     });
 
     test('null usage falls back to zero usage', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        value: 'hello',
-      );
+      fake.runResult = const CoreRunResult(ok: true, value: 'hello');
 
       final result = await platform.run('code');
 
@@ -213,10 +191,7 @@ void main() {
     });
 
     test('passes scriptName to bindings', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('code', scriptName: 'math.py');
 
@@ -342,26 +317,20 @@ void main() {
       expect(pending.kwargs, {'timeout': 30, 'retry': true});
     });
 
-    test(
-      'resolve_futures returns MontyResolveFutures '
-      'and marks active',
-      () async {
-        fake.progressResult = const CoreProgressResult(
-          state: 'resolve_futures',
-          pendingCallIds: [1, 2, 3],
-        );
+    test('resolve_futures returns MontyResolveFutures '
+        'and marks active', () async {
+      fake.progressResult = const CoreProgressResult(
+        state: 'resolve_futures',
+        pendingCallIds: [1, 2, 3],
+      );
 
-        final progress = await platform.start(
-          'code',
-          externalFunctions: ['fn'],
-        );
+      final progress = await platform.start('code', externalFunctions: ['fn']);
 
-        expect(progress, isA<MontyResolveFutures>());
-        final rf = progress as MontyResolveFutures;
-        expect(rf.pendingCallIds, [1, 2, 3]);
-        expect(platform.isActive, isTrue);
-      },
-    );
+      expect(progress, isA<MontyResolveFutures>());
+      final rf = progress as MontyResolveFutures;
+      expect(rf.pendingCallIds, [1, 2, 3]);
+      expect(platform.isActive, isTrue);
+    });
 
     test('error throws MontyException and marks idle', () async {
       fake.progressResult = const CoreProgressResult(
@@ -374,16 +343,8 @@ void main() {
         () => platform.start('code'),
         throwsA(
           isA<MontyException>()
-              .having(
-                (e) => e.message,
-                'message',
-                'name not defined',
-              )
-              .having(
-                (e) => e.excType,
-                'excType',
-                'NameError',
-              ),
+              .having((e) => e.message, 'message', 'name not defined')
+              .having((e) => e.excType, 'excType', 'NameError'),
         ),
       );
       expect(platform.isIdle, isTrue);
@@ -397,10 +358,7 @@ void main() {
         state: 'pending',
         functionName: 'fn',
       );
-      await platform.start(
-        'code',
-        externalFunctions: ['fn'],
-      );
+      await platform.start('code', externalFunctions: ['fn']);
 
       // Now resume.
       fake.progressResult = const CoreProgressResult(
@@ -418,32 +376,24 @@ void main() {
   });
 
   group('resumeWithError()', () {
-    test(
-      'delegates errorMessage and translates progress',
-      () async {
-        // Enter active state.
-        fake.progressResult = const CoreProgressResult(
-          state: 'pending',
-          functionName: 'fn',
-        );
-        await platform.start(
-          'code',
-          externalFunctions: ['fn'],
-        );
+    test('delegates errorMessage and translates progress', () async {
+      // Enter active state.
+      fake.progressResult = const CoreProgressResult(
+        state: 'pending',
+        functionName: 'fn',
+      );
+      await platform.start('code', externalFunctions: ['fn']);
 
-        // Resume with error -> complete.
-        fake.progressResult = const CoreProgressResult(
-          state: 'complete',
-          usage: usage,
-        );
-        final progress = await platform.resumeWithError(
-          'not found',
-        );
+      // Resume with error -> complete.
+      fake.progressResult = const CoreProgressResult(
+        state: 'complete',
+        usage: usage,
+      );
+      final progress = await platform.resumeWithError('not found');
 
-        expect(fake.lastErrorMessage, 'not found');
-        expect(progress, isA<MontyComplete>());
-      },
-    );
+      expect(fake.lastErrorMessage, 'not found');
+      expect(progress, isA<MontyComplete>());
+    });
   });
 
   group('dispose()', () {
@@ -470,77 +420,50 @@ void main() {
         state: 'pending',
         functionName: 'fn',
       );
-      await platform.start(
-        'code',
-        externalFunctions: ['fn'],
-      );
+      await platform.start('code', externalFunctions: ['fn']);
 
-      expect(
-        () => platform.run('code'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.run('code'), throwsA(isA<StateError>()));
     });
 
     test('resume() while idle throws StateError', () {
-      expect(
-        () => platform.resume(null),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.resume(null), throwsA(isA<StateError>()));
     });
 
     test('resumeWithError() while idle throws StateError', () {
-      expect(
-        () => platform.resumeWithError('err'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.resumeWithError('err'), throwsA(isA<StateError>()));
     });
 
     test('run() after disposed throws StateError', () async {
       await platform.dispose();
 
-      expect(
-        () => platform.run('code'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.run('code'), throwsA(isA<StateError>()));
     });
 
-    test(
-      'start() after disposed throws StateError',
-      () async {
-        await platform.dispose();
+    test('start() after disposed throws StateError', () async {
+      await platform.dispose();
 
-        expect(
-          () => platform.start('code'),
-          throwsA(isA<StateError>()),
-        );
-      },
-    );
+      expect(() => platform.start('code'), throwsA(isA<StateError>()));
+    });
 
-    test(
-      'resume() after disposed throws StateError',
-      () async {
-        await platform.dispose();
-        // Also not active, but disposed check comes first.
-        expect(
-          () => platform.resume(null),
-          throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
-              contains('disposed'),
-            ),
+    test('resume() after disposed throws StateError', () async {
+      await platform.dispose();
+      // Also not active, but disposed check comes first.
+      expect(
+        () => platform.resume(null),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('disposed'),
           ),
-        );
-      },
-    );
+        ),
+      );
+    });
   });
 
   group('limits encoding', () {
     test('null limits passes null to bindings', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('code');
 
@@ -548,25 +471,16 @@ void main() {
     });
 
     test('partial limits encodes JSON subset', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
-      await platform.run(
-        'code',
-        limits: const MontyLimits(memoryBytes: 1024),
-      );
+      await platform.run('code', limits: const MontyLimits(memoryBytes: 1024));
 
       final decoded = json.decode(fake.lastLimitsJson!) as Map<String, dynamic>;
       expect(decoded, {'memory_bytes': 1024});
     });
 
     test('full limits encodes all fields', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run(
         'code',
@@ -615,10 +529,7 @@ void main() {
         usage: usage,
       );
 
-      await platform.start(
-        'code',
-        externalFunctions: ['fn_a', 'fn_b'],
-      );
+      await platform.start('code', externalFunctions: ['fn_a', 'fn_b']);
 
       final decoded = json.decode(fake.lastExtFnsJson!) as List<dynamic>;
       expect(decoded, ['fn_a', 'fn_b']);
@@ -627,10 +538,7 @@ void main() {
 
   group('lazy initialization', () {
     test('first call triggers init', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('code');
 
@@ -638,10 +546,7 @@ void main() {
     });
 
     test('subsequent calls skip init', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('first');
       await platform.run('second');
@@ -652,9 +557,7 @@ void main() {
 
   group('unknown progress state', () {
     test('throws StateError', () async {
-      fake.progressResult = const CoreProgressResult(
-        state: 'bogus',
-      );
+      fake.progressResult = const CoreProgressResult(state: 'bogus');
 
       await expectLater(
         () => platform.start('code'),
@@ -685,10 +588,7 @@ void main() {
       expect(platform.isActive, isTrue);
 
       // A second concurrent run() should fail with StateError.
-      expect(
-        () => platform.run('second'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.run('second'), throwsA(isA<StateError>()));
 
       // Release the gate so the first run completes.
       gate.complete();
@@ -698,10 +598,7 @@ void main() {
     });
 
     test('run() returns to idle after error', () async {
-      fake.runResult = const CoreRunResult(
-        ok: false,
-        error: 'boom',
-      );
+      fake.runResult = const CoreRunResult(ok: false, error: 'boom');
 
       await expectLater(
         () => platform.run('code'),
@@ -710,22 +607,24 @@ void main() {
       expect(platform.isIdle, isTrue);
     });
 
-    test('start() marks active before await — concurrent start() throws',
-        () async {
-      fake.progressResult = const CoreProgressResult(
-        state: 'complete',
-        usage: zeroUsage,
-      );
+    test(
+      'start() marks active before await — concurrent start() throws',
+      () async {
+        fake.progressResult = const CoreProgressResult(
+          state: 'complete',
+          usage: zeroUsage,
+        );
 
-      // start() should mark active synchronously.
-      final first = platform.start('first');
-      // Can't easily test concurrency here since fake is synchronous,
-      // but we verify the state IS active before start returns.
-      // The real proof is the run() test above with the gate.
-      final result = await first;
-      expect(result, isA<MontyComplete>());
-      expect(platform.isIdle, isTrue);
-    });
+        // start() should mark active synchronously.
+        final first = platform.start('first');
+        // Can't easily test concurrency here since fake is synchronous,
+        // but we verify the state IS active before start returns.
+        // The real proof is the run() test above with the gate.
+        final result = await first;
+        expect(result, isA<MontyComplete>());
+        expect(platform.isIdle, isTrue);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -890,10 +789,7 @@ void main() {
       // Now make resume() throw.
       fake.throwOnResume = Exception('FFI crash');
 
-      await expectLater(
-        () => platform.resume(42),
-        throwsA(isA<Exception>()),
-      );
+      await expectLater(() => platform.resume(42), throwsA(isA<Exception>()));
       expect(
         platform.isIdle,
         isTrue,

--- a/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
+++ b/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
@@ -43,62 +43,68 @@ void main() {
       );
     });
 
-    test('Python ZeroDivisionError maps to MontyException (not sealed)',
-        () async {
-      final bindings = _FakeCoreBindings();
-      final platform = _TestPlatform(bindings: bindings);
+    test(
+      'Python ZeroDivisionError maps to MontyException (not sealed)',
+      () async {
+        final bindings = _FakeCoreBindings();
+        final platform = _TestPlatform(bindings: bindings);
 
-      bindings.nextRunResult = const CoreRunResult(
-        ok: false,
-        error: 'division by zero',
-        excType: 'ZeroDivisionError',
-      );
+        bindings.nextRunResult = const CoreRunResult(
+          ok: false,
+          error: 'division by zero',
+          excType: 'ZeroDivisionError',
+        );
 
-      await expectLater(
-        platform.run('code'),
-        throwsA(
-          isA<MontyException>().having(
-            (e) => e.excType,
-            'excType',
-            'ZeroDivisionError',
+        await expectLater(
+          platform.run('code'),
+          throwsA(
+            isA<MontyException>().having(
+              (e) => e.excType,
+              'excType',
+              'ZeroDivisionError',
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
 
-    test('progress error with KeyboardInterrupt maps to MontyCancelledError',
-        () async {
-      final bindings = _FakeCoreBindings();
-      final platform = _TestPlatform(bindings: bindings);
+    test(
+      'progress error with KeyboardInterrupt maps to MontyCancelledError',
+      () async {
+        final bindings = _FakeCoreBindings();
+        final platform = _TestPlatform(bindings: bindings);
 
-      bindings.nextStartResult = const CoreProgressResult(
-        state: 'error',
-        error: 'Execution cancelled',
-        excType: 'KeyboardInterrupt',
-      );
+        bindings.nextStartResult = const CoreProgressResult(
+          state: 'error',
+          error: 'Execution cancelled',
+          excType: 'KeyboardInterrupt',
+        );
 
-      await expectLater(
-        platform.start('code'),
-        throwsA(isA<MontyCancelledError>()),
-      );
-    });
+        await expectLater(
+          platform.start('code'),
+          throwsA(isA<MontyCancelledError>()),
+        );
+      },
+    );
 
-    test('progress error with MemoryLimitExceeded maps to MontyResourceError',
-        () async {
-      final bindings = _FakeCoreBindings();
-      final platform = _TestPlatform(bindings: bindings);
+    test(
+      'progress error with MemoryLimitExceeded maps to MontyResourceError',
+      () async {
+        final bindings = _FakeCoreBindings();
+        final platform = _TestPlatform(bindings: bindings);
 
-      bindings.nextStartResult = const CoreProgressResult(
-        state: 'error',
-        error: 'Memory limit exceeded',
-        excType: 'MemoryLimitExceeded',
-      );
+        bindings.nextStartResult = const CoreProgressResult(
+          state: 'error',
+          error: 'Memory limit exceeded',
+          excType: 'MemoryLimitExceeded',
+        );
 
-      await expectLater(
-        platform.start('code'),
-        throwsA(isA<MontyResourceError>()),
-      );
-    });
+        await expectLater(
+          platform.start('code'),
+          throwsA(isA<MontyResourceError>()),
+        );
+      },
+    );
   });
 
   group('exhaustive switch compiles', () {
@@ -128,8 +134,10 @@ void main() {
     });
 
     test('MontyScriptError preserves excType', () {
-      const error =
-          MontyScriptError('division by zero', excType: 'ZeroDivisionError');
+      const error = MontyScriptError(
+        'division by zero',
+        excType: 'ZeroDivisionError',
+      );
       expect(error.excType, 'ZeroDivisionError');
       expect(error.message, 'division by zero');
     });
@@ -158,10 +166,7 @@ void main() {
 
     test('MontyCrashError default message', () {
       const e = MontyCrashError();
-      expect(
-        e.toString(),
-        'MontyCrashError: Interpreter crashed unexpectedly',
-      );
+      expect(e.toString(), 'MontyCrashError: Interpreter crashed unexpectedly');
     });
 
     test('MontyDisposedError default message', () {
@@ -258,8 +263,7 @@ class _FakeCoreBindings implements MontyCoreBindings {
     String code, {
     String? limitsJson,
     String? scriptName,
-  }) async =>
-      nextRunResult;
+  }) async => nextRunResult;
 
   @override
   Future<CoreProgressResult> start(
@@ -267,8 +271,7 @@ class _FakeCoreBindings implements MontyCoreBindings {
     String? extFnsJson,
     String? limitsJson,
     String? scriptName,
-  }) async =>
-      nextStartResult;
+  }) async => nextStartResult;
 
   @override
   Future<CoreProgressResult> resume(String valueJson) async =>
@@ -286,8 +289,7 @@ class _FakeCoreBindings implements MontyCoreBindings {
   Future<CoreProgressResult> resolveFutures(
     String resultsJson,
     String errorsJson,
-  ) async =>
-      throw UnsupportedError('not supported');
+  ) async => throw UnsupportedError('not supported');
 
   @override
   Future<Uint8List> snapshot() async => Uint8List(0);

--- a/packages/dart_monty_platform_interface/test/monty_exception_test.dart
+++ b/packages/dart_monty_platform_interface/test/monty_exception_test.dart
@@ -20,9 +20,7 @@ void main() {
       });
 
       test('parses minimal JSON', () {
-        final exception = MontyException.fromJson(const {
-          'message': 'error',
-        });
+        final exception = MontyException.fromJson(const {'message': 'error'});
         expect(exception.message, 'error');
         expect(exception.filename, isNull);
         expect(exception.lineNumber, isNull);
@@ -134,10 +132,7 @@ void main() {
       });
 
       test('serializes excType', () {
-        const exception = MontyException(
-          message: 'bad',
-          excType: 'ValueError',
-        );
+        const exception = MontyException(message: 'bad', excType: 'ValueError');
         final json = exception.toJson();
         expect(json['exc_type'], 'ValueError');
       });
@@ -146,11 +141,7 @@ void main() {
         const exception = MontyException(
           message: 'err',
           traceback: [
-            MontyStackFrame(
-              filename: 'a.py',
-              startLine: 1,
-              startColumn: 0,
-            ),
+            MontyStackFrame(filename: 'a.py', startLine: 1, startColumn: 0),
           ],
         );
         final json = exception.toJson();
@@ -243,14 +234,8 @@ void main() {
       });
 
       test('not equal when excType differs', () {
-        const a = MontyException(
-          message: 'err',
-          excType: 'ValueError',
-        );
-        const b = MontyException(
-          message: 'err',
-          excType: 'TypeError',
-        );
+        const a = MontyException(message: 'err', excType: 'ValueError');
+        const b = MontyException(message: 'err', excType: 'TypeError');
         expect(a, isNot(b));
       });
 
@@ -258,21 +243,13 @@ void main() {
         const a = MontyException(
           message: 'err',
           traceback: [
-            MontyStackFrame(
-              filename: 'a.py',
-              startLine: 1,
-              startColumn: 0,
-            ),
+            MontyStackFrame(filename: 'a.py', startLine: 1, startColumn: 0),
           ],
         );
         const b = MontyException(
           message: 'err',
           traceback: [
-            MontyStackFrame(
-              filename: 'b.py',
-              startLine: 1,
-              startColumn: 0,
-            ),
+            MontyStackFrame(filename: 'b.py', startLine: 1, startColumn: 0),
           ],
         );
         expect(a, isNot(b));
@@ -283,22 +260,14 @@ void main() {
           message: 'err',
           excType: 'ValueError',
           traceback: [
-            MontyStackFrame(
-              filename: 'a.py',
-              startLine: 1,
-              startColumn: 0,
-            ),
+            MontyStackFrame(filename: 'a.py', startLine: 1, startColumn: 0),
           ],
         );
         const b = MontyException(
           message: 'err',
           excType: 'ValueError',
           traceback: [
-            MontyStackFrame(
-              filename: 'a.py',
-              startLine: 1,
-              startColumn: 0,
-            ),
+            MontyStackFrame(filename: 'a.py', startLine: 1, startColumn: 0),
           ],
         );
         expect(a, b);
@@ -334,10 +303,7 @@ void main() {
       });
 
       test('with filename', () {
-        const exception = MontyException(
-          message: 'err',
-          filename: 'main.py',
-        );
+        const exception = MontyException(message: 'err', filename: 'main.py');
         expect(exception.toString(), 'MontyException: err (main.py)');
       });
 

--- a/packages/dart_monty_platform_interface/test/monty_limits_test.dart
+++ b/packages/dart_monty_platform_interface/test/monty_limits_test.dart
@@ -48,9 +48,7 @@ void main() {
       });
 
       test('parses partial JSON', () {
-        final limits = MontyLimits.fromJson(const {
-          'timeout_ms': 1000,
-        });
+        final limits = MontyLimits.fromJson(const {'timeout_ms': 1000});
         expect(limits.memoryBytes, isNull);
         expect(limits.timeoutMs, 1000);
         expect(limits.stackDepth, isNull);
@@ -171,9 +169,7 @@ void main() {
     group('malformed JSON', () {
       test('throws on wrong field type', () {
         expect(
-          () => MontyLimits.fromJson(const {
-            'memory_bytes': 'not_a_number',
-          }),
+          () => MontyLimits.fromJson(const {'memory_bytes': 'not_a_number'}),
           throwsA(isA<TypeError>()),
         );
       });

--- a/packages/dart_monty_platform_interface/test/monty_platform_test.dart
+++ b/packages/dart_monty_platform_interface/test/monty_platform_test.dart
@@ -47,10 +47,7 @@ void main() {
     test('resetInstance clears the instance', () {
       MontyPlatform.instance = _TestMontyPlatform();
       MontyPlatform.resetInstance();
-      expect(
-        () => MontyPlatform.instance,
-        throwsA(isA<StateError>()),
-      );
+      expect(() => MontyPlatform.instance, throwsA(isA<StateError>()));
     });
 
     test('rejects implements without extends', () {
@@ -68,24 +65,15 @@ void main() {
       });
 
       test('run() throws', () {
-        expect(
-          () => platform.run('code'),
-          throwsUnimplementedError,
-        );
+        expect(() => platform.run('code'), throwsUnimplementedError);
       });
 
       test('start() throws', () {
-        expect(
-          () => platform.start('code'),
-          throwsUnimplementedError,
-        );
+        expect(() => platform.start('code'), throwsUnimplementedError);
       });
 
       test('resume() throws', () {
-        expect(
-          () => platform.resume(null),
-          throwsUnimplementedError,
-        );
+        expect(() => platform.resume(null), throwsUnimplementedError);
       });
 
       test('resumeWithError() throws', () {
@@ -96,10 +84,7 @@ void main() {
       });
 
       test('dispose() throws', () {
-        expect(
-          () => platform.dispose(),
-          throwsUnimplementedError,
-        );
+        expect(() => platform.dispose(), throwsUnimplementedError);
       });
     });
   });

--- a/packages/dart_monty_platform_interface/test/monty_progress_test.dart
+++ b/packages/dart_monty_platform_interface/test/monty_progress_test.dart
@@ -47,23 +47,15 @@ void main() {
 
       group('equality', () {
         test('equal when result matches', () {
-          const a = MontyComplete(
-            result: MontyResult(value: 42, usage: usage),
-          );
-          const b = MontyComplete(
-            result: MontyResult(value: 42, usage: usage),
-          );
+          const a = MontyComplete(result: MontyResult(value: 42, usage: usage));
+          const b = MontyComplete(result: MontyResult(value: 42, usage: usage));
           expect(a, b);
           expect(a.hashCode, b.hashCode);
         });
 
         test('not equal when result differs', () {
-          const a = MontyComplete(
-            result: MontyResult(value: 1, usage: usage),
-          );
-          const b = MontyComplete(
-            result: MontyResult(value: 2, usage: usage),
-          );
+          const a = MontyComplete(result: MontyResult(value: 1, usage: usage));
+          const b = MontyComplete(result: MontyResult(value: 2, usage: usage));
           expect(a, isNot(b));
         });
 
@@ -86,10 +78,7 @@ void main() {
         const complete = MontyComplete(
           result: MontyResult(value: 42, usage: usage),
         );
-        expect(
-          complete.toString(),
-          'MontyComplete(MontyResult.value(42))',
-        );
+        expect(complete.toString(), 'MontyComplete(MontyResult.value(42))');
       });
     });
 
@@ -225,10 +214,7 @@ void main() {
       });
 
       test('toJson omits kwargs when null', () {
-        const pending = MontyPending(
-          functionName: 'fn',
-          arguments: [],
-        );
+        const pending = MontyPending(functionName: 'fn', arguments: []);
         final json = pending.toJson();
         expect(json.containsKey('kwargs'), isFalse);
       });
@@ -244,10 +230,7 @@ void main() {
       });
 
       test('toJson omits callId when zero', () {
-        const pending = MontyPending(
-          functionName: 'fn',
-          arguments: [],
-        );
+        const pending = MontyPending(functionName: 'fn', arguments: []);
         final json = pending.toJson();
         expect(json.containsKey('call_id'), isFalse);
       });
@@ -263,10 +246,7 @@ void main() {
       });
 
       test('toJson omits methodCall when false', () {
-        const pending = MontyPending(
-          functionName: 'fn',
-          arguments: [],
-        );
+        const pending = MontyPending(functionName: 'fn', arguments: []);
         final json = pending.toJson();
         expect(json.containsKey('method_call'), isFalse);
       });
@@ -281,10 +261,7 @@ void main() {
       });
 
       test('JSON round-trip with empty arguments', () {
-        const original = MontyPending(
-          functionName: 'noop',
-          arguments: [],
-        );
+        const original = MontyPending(functionName: 'noop', arguments: []);
         final restored = MontyPending.fromJson(original.toJson());
         expect(restored, original);
       });
@@ -313,14 +290,8 @@ void main() {
 
       group('equality', () {
         test('equal when all fields match', () {
-          const a = MontyPending(
-            functionName: 'fn',
-            arguments: [1, 'a'],
-          );
-          const b = MontyPending(
-            functionName: 'fn',
-            arguments: [1, 'a'],
-          );
+          const a = MontyPending(functionName: 'fn', arguments: [1, 'a']);
+          const b = MontyPending(functionName: 'fn', arguments: [1, 'a']);
           expect(a, b);
           expect(a.hashCode, b.hashCode);
         });
@@ -370,10 +341,7 @@ void main() {
             arguments: [],
             kwargs: {'a': 1},
           );
-          const b = MontyPending(
-            functionName: 'fn',
-            arguments: [],
-          );
+          const b = MontyPending(functionName: 'fn', arguments: []);
           expect(a, isNot(b));
         });
 
@@ -393,24 +361,13 @@ void main() {
         });
 
         test('not equal when callId differs', () {
-          const a = MontyPending(
-            functionName: 'fn',
-            arguments: [],
-            callId: 1,
-          );
-          const b = MontyPending(
-            functionName: 'fn',
-            arguments: [],
-            callId: 2,
-          );
+          const a = MontyPending(functionName: 'fn', arguments: [], callId: 1);
+          const b = MontyPending(functionName: 'fn', arguments: [], callId: 2);
           expect(a, isNot(b));
         });
 
         test('not equal when methodCall differs', () {
-          const a = MontyPending(
-            functionName: 'fn',
-            arguments: [],
-          );
+          const a = MontyPending(functionName: 'fn', arguments: []);
           const b = MontyPending(
             functionName: 'fn',
             arguments: [],
@@ -431,10 +388,7 @@ void main() {
       });
 
       test('toString', () {
-        const pending = MontyPending(
-          functionName: 'fetch',
-          arguments: [42],
-        );
+        const pending = MontyPending(functionName: 'fetch', arguments: [42]);
         expect(pending.toString(), 'MontyPending(fetch, [42])');
       });
     });
@@ -546,9 +500,7 @@ void main() {
 
       test('throws on unknown type', () {
         expect(
-          () => MontyProgress.fromJson(const {
-            'type': 'unknown',
-          }),
+          () => MontyProgress.fromJson(const {'type': 'unknown'}),
           throwsA(isA<ArgumentError>()),
         );
       });
@@ -603,10 +555,7 @@ void main() {
           'futures: $pendingCallIds',
       };
 
-      expect(
-        description,
-        'pending: fetch(kwargs={timeout: 30}, callId=5)',
-      );
+      expect(description, 'pending: fetch(kwargs={timeout: 30}, callId=5)');
     });
 
     test('pattern matching on resolve_futures', () {
@@ -737,9 +686,7 @@ void main() {
 
       test('MontyResolveFutures.fromJson throws on missing call_ids', () {
         expect(
-          () => MontyResolveFutures.fromJson(
-            const {'type': 'resolve_futures'},
-          ),
+          () => MontyResolveFutures.fromJson(const {'type': 'resolve_futures'}),
           throwsA(isA<TypeError>()),
         );
       });

--- a/packages/dart_monty_platform_interface/test/monty_session_test.dart
+++ b/packages/dart_monty_platform_interface/test/monty_session_test.dart
@@ -22,10 +22,7 @@ void main() {
     group('run()', () {
       test('set and read variable', () async {
         // First run: x = 42 — restore empty, persist {x: 42}
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 42},
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 42});
         final r1 = await session.run('x = 42');
         expect(r1.value, isNull);
 
@@ -33,11 +30,7 @@ void main() {
         expect(mock.resumeReturnValues.first, isEmpty);
 
         // Second run: x + 1 — restore {x: 42}, persist {x: 42}
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 42},
-          resultValue: 43,
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 42}, resultValue: 43);
         final r2 = await session.run('x + 1');
         expect(r2.value, 43);
 
@@ -75,10 +68,7 @@ void main() {
       test('non-serializable silently dropped', () async {
         // The persist postamble only captures vars that don't error.
         // The mock simulates that 'math' is not in the persisted dict.
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 42},
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 42});
         await session.run('x = 42');
 
         final persisted = session.state;
@@ -125,10 +115,7 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyPending(
-              functionName: 'fetch',
-              arguments: ['url'],
-            ),
+            const MontyPending(functionName: 'fetch', arguments: ['url']),
           )
           ..enqueueProgress(
             const MontyComplete(
@@ -157,9 +144,7 @@ void main() {
               arguments: [],
             ),
           )
-          ..enqueueProgress(
-            const MontyResolveFutures(pendingCallIds: [1, 2]),
-          )
+          ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1, 2]))
           ..enqueueProgress(
             const MontyPending(
               functionName: '__persist_state__',
@@ -169,16 +154,15 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(
-              result: MontyResult(value: 1, usage: _usage),
-            ),
+            const MontyComplete(result: MontyResult(value: 1, usage: _usage)),
           );
 
         final result = await session.run('x = 1');
         expect(result.value, 1);
 
-        final nullResumes =
-            mock.resumeReturnValues.where((v) => v == null).length;
+        final nullResumes = mock.resumeReturnValues
+            .where((v) => v == null)
+            .length;
         expect(nullResumes, greaterThanOrEqualTo(2));
       });
     });
@@ -219,24 +203,14 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyPending(
-              functionName: 'fetch',
-              arguments: [],
-            ),
+            const MontyPending(functionName: 'fetch', arguments: []),
           );
 
-        await session.start(
-          'fetch()',
-          externalFunctions: ['fetch'],
-        );
+        await session.start('fetch()', externalFunctions: ['fetch']);
 
         expect(
           mock.lastStartExternalFunctions,
-          containsAll([
-            '__restore_state__',
-            '__persist_state__',
-            'fetch',
-          ]),
+          containsAll(['__restore_state__', '__persist_state__', 'fetch']),
         );
       });
 
@@ -249,16 +223,10 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyPending(
-              functionName: 'fetch',
-              arguments: [],
-            ),
+            const MontyPending(functionName: 'fetch', arguments: []),
           );
 
-        await session.start(
-          'result = fetch()',
-          externalFunctions: ['fetch'],
-        );
+        await session.start('result = fetch()', externalFunctions: ['fetch']);
 
         final code = mock.lastStartCode!;
         expect(code, contains('__restore_state__()'));
@@ -277,10 +245,7 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyPending(
-              functionName: 'fetch',
-              arguments: ['url'],
-            ),
+            const MontyPending(functionName: 'fetch', arguments: ['url']),
           );
 
         final p1 = await session.start(
@@ -321,10 +286,7 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyPending(
-              functionName: 'step1',
-              arguments: [],
-            ),
+            const MontyPending(functionName: 'step1', arguments: []),
           );
 
         await session.start(
@@ -333,10 +295,7 @@ void main() {
         );
 
         mock.enqueueProgress(
-          const MontyPending(
-            functionName: 'step2',
-            arguments: [],
-          ),
+          const MontyPending(functionName: 'step2', arguments: []),
         );
 
         final p2 = await session.resume('result1');
@@ -355,10 +314,7 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyPending(
-              functionName: 'fetch',
-              arguments: ['url'],
-            ),
+            const MontyPending(functionName: 'fetch', arguments: ['url']),
           );
 
         await session.start(
@@ -374,9 +330,7 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(
-              result: MontyResult(usage: _usage),
-            ),
+            const MontyComplete(result: MontyResult(usage: _usage)),
           );
 
         final p2 = await session.resumeWithError('network failure');
@@ -388,10 +342,7 @@ void main() {
 
     group('clearState()', () {
       test('resets persisted state', () async {
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 1},
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 1});
         await session.run('x = 1');
         expect(session.state, {'x': 1});
 
@@ -406,10 +357,7 @@ void main() {
       });
 
       test('returns copy (not mutable reference)', () async {
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 1},
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 1});
         await session.run('x = 1');
 
         final s1 = session.state;
@@ -420,10 +368,7 @@ void main() {
 
     group('dispose()', () {
       test('clears state and marks disposed', () async {
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 1},
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 1});
         await session.run('x = 1');
 
         session.dispose();
@@ -432,28 +377,19 @@ void main() {
 
       test('run() throws after dispose', () {
         session.dispose();
-        expect(
-          () => session.run('1'),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => session.run('1'), throwsA(isA<StateError>()));
       });
 
       test('clearState() throws after dispose', () {
         session.dispose();
-        expect(
-          () => session.clearState(),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => session.clearState(), throwsA(isA<StateError>()));
       });
     });
 
     group('edge cases', () {
       test('error preserves previous state', () async {
         // First run succeeds with x=10
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 10},
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 10});
         await session.run('x = 10');
         expect(session.state, {'x': 10});
 
@@ -490,10 +426,7 @@ void main() {
         final sessionA = MontySession(platform: mockA);
         final sessionB = MontySession(platform: mockB);
 
-        _enqueueRunCycle(
-          mockA,
-          stateToPersist: {'x': 1},
-        );
+        _enqueueRunCycle(mockA, stateToPersist: {'x': 1});
         await sessionA.run('x = 1');
 
         expect(sessionA.state, {'x': 1});
@@ -525,9 +458,7 @@ void main() {
               arguments: [],
             ),
           )
-          ..enqueueProgress(
-            const MontyResolveFutures(pendingCallIds: [1]),
-          );
+          ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]));
 
         final progress = await session.start(
           'x = fetch()',
@@ -563,13 +494,8 @@ void main() {
       });
 
       test('dunder and underscore variables excluded', () async {
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'public': 3},
-        );
-        await session.run(
-          '__private = 1\n_also_private = 2\npublic = 3',
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'public': 3});
+        await session.run('__private = 1\n_also_private = 2\npublic = 3');
 
         // extractAssignmentTargets should only find 'public'
         final code = mock.lastStartCode!;
@@ -596,10 +522,7 @@ void main() {
 
       test('resume() throws after dispose', () {
         session.dispose();
-        expect(
-          () => session.resume('val'),
-          throwsA(isA<StateError>()),
-        );
+        expect(() => session.resume('val'), throwsA(isA<StateError>()));
       });
 
       test('resumeWithError() throws after dispose', () {
@@ -669,11 +592,7 @@ void main() {
       });
 
       test('captures variable reference as expression', () async {
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {'x': 1},
-          resultValue: 1,
-        );
+        _enqueueRunCycle(mock, stateToPersist: {'x': 1}, resultValue: 1);
         await session.run('x');
 
         final code = mock.lastStartCode!;
@@ -681,11 +600,7 @@ void main() {
       });
 
       test('captures list literal as expression', () async {
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {},
-          resultValue: [1, 2, 3],
-        );
+        _enqueueRunCycle(mock, stateToPersist: {}, resultValue: [1, 2, 3]);
         await session.run('[1, 2, 3]');
 
         final code = mock.lastStartCode!;
@@ -693,11 +608,7 @@ void main() {
       });
 
       test('skips trailing comments and blank lines', () async {
-        _enqueueRunCycle(
-          mock,
-          stateToPersist: {},
-          resultValue: 42,
-        );
+        _enqueueRunCycle(mock, stateToPersist: {}, resultValue: 42);
         await session.run('42\n# comment\n');
 
         final code = mock.lastStartCode!;
@@ -707,17 +618,15 @@ void main() {
 
     group('extractAssignmentTargets', () {
       test('finds simple assignments', () {
-        expect(
-          MontySession.extractAssignmentTargets('x = 42'),
-          {'x'},
-        );
+        expect(MontySession.extractAssignmentTargets('x = 42'), {'x'});
       });
 
       test('finds multiple assignments', () {
-        expect(
-          MontySession.extractAssignmentTargets('x = 1\ny = 2\nz = 3'),
-          {'x', 'y', 'z'},
-        );
+        expect(MontySession.extractAssignmentTargets('x = 1\ny = 2\nz = 3'), {
+          'x',
+          'y',
+          'z',
+        });
       });
 
       test('excludes underscore-prefixed names', () {
@@ -730,10 +639,7 @@ void main() {
       });
 
       test('excludes comparisons (==)', () {
-        expect(
-          MontySession.extractAssignmentTargets('x == 42'),
-          isEmpty,
-        );
+        expect(MontySession.extractAssignmentTargets('x == 42'), isEmpty);
       });
 
       test('handles no assignments', () {
@@ -752,12 +658,11 @@ void main() {
       });
 
       test('handles semicolons (multi-statement lines)', () {
-        expect(
-          MontySession.extractAssignmentTargets(
-            'x = 1; y = 2; z = 3',
-          ),
-          {'x', 'y', 'z'},
-        );
+        expect(MontySession.extractAssignmentTargets('x = 1; y = 2; z = 3'), {
+          'x',
+          'y',
+          'z',
+        });
       });
     });
   });
@@ -772,10 +677,7 @@ void _enqueueRunCycle(
   mock
     // 1. restore
     ..enqueueProgress(
-      const MontyPending(
-        functionName: '__restore_state__',
-        arguments: [],
-      ),
+      const MontyPending(functionName: '__restore_state__', arguments: []),
     )
     // 2. persist
     ..enqueueProgress(

--- a/packages/dart_monty_platform_interface/test/monty_state_mixin_test.dart
+++ b/packages/dart_monty_platform_interface/test/monty_state_mixin_test.dart
@@ -96,10 +96,7 @@ void main() {
 
     test('assertActive throws when disposed', () {
       sm.doMarkDisposed();
-      expect(
-        () => sm.doAssertActive('resume'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => sm.doAssertActive('resume'), throwsA(isA<StateError>()));
     });
   });
 

--- a/packages/dart_monty_platform_interface/test/testing/ladder_assertions_test.dart
+++ b/packages/dart_monty_platform_interface/test/testing/ladder_assertions_test.dart
@@ -9,14 +9,13 @@ void main() {
     });
 
     test('exact match with list', () {
-      assertLadderResult([
-        1,
-        2,
-        3,
-      ], {
-        'id': 2,
-        'expected': [1, 2, 3],
-      });
+      assertLadderResult(
+        [1, 2, 3],
+        {
+          'id': 2,
+          'expected': [1, 2, 3],
+        },
+      );
     });
 
     test('null value matches null expected', () {
@@ -24,10 +23,7 @@ void main() {
     });
 
     test('expectedContains checks substring', () {
-      assertLadderResult(
-        'hello world',
-        {'id': 4, 'expectedContains': 'world'},
-      );
+      assertLadderResult('hello world', {'id': 4, 'expectedContains': 'world'});
     });
 
     test('expectedSorted sorts lists before comparison', () {
@@ -55,18 +51,12 @@ void main() {
 
   group('assertPendingFields', () {
     test('checks expectedFnName', () {
-      const pending = MontyPending(
-        functionName: 'fetch',
-        arguments: [],
-      );
+      const pending = MontyPending(functionName: 'fetch', arguments: []);
       assertPendingFields(pending, {'id': 1, 'expectedFnName': 'fetch'});
     });
 
     test('checks expectedArgs', () {
-      const pending = MontyPending(
-        functionName: 'fn',
-        arguments: [1, 'two'],
-      );
+      const pending = MontyPending(functionName: 'fn', arguments: [1, 'two']);
       assertPendingFields(pending, {
         'id': 2,
         'expectedArgs': [1, 'two'],
@@ -86,10 +76,7 @@ void main() {
     });
 
     test('checks expectedKwargs null', () {
-      const pending = MontyPending(
-        functionName: 'fn',
-        arguments: [],
-      );
+      const pending = MontyPending(functionName: 'fn', arguments: []);
       assertPendingFields(pending, {'id': 4, 'expectedKwargs': null});
     });
 
@@ -99,10 +86,7 @@ void main() {
         arguments: [],
         callId: 42,
       );
-      assertPendingFields(
-        pending,
-        {'id': 5, 'expectedCallIdNonZero': true},
-      );
+      assertPendingFields(pending, {'id': 5, 'expectedCallIdNonZero': true});
     });
 
     test('checks expectedMethodCall', () {
@@ -111,17 +95,11 @@ void main() {
         arguments: [],
         methodCall: true,
       );
-      assertPendingFields(
-        pending,
-        {'id': 6, 'expectedMethodCall': true},
-      );
+      assertPendingFields(pending, {'id': 6, 'expectedMethodCall': true});
     });
 
     test('missing keys are no-ops', () {
-      const pending = MontyPending(
-        functionName: 'fn',
-        arguments: [],
-      );
+      const pending = MontyPending(functionName: 'fn', arguments: []);
       // No assertions fail when fixture has no expected* keys.
       assertPendingFields(pending, {'id': 7});
     });
@@ -129,10 +107,7 @@ void main() {
 
   group('assertExceptionFields', () {
     test('checks expectedExcType', () {
-      const exc = MontyException(
-        message: 'bad',
-        excType: 'ValueError',
-      );
+      const exc = MontyException(message: 'bad', excType: 'ValueError');
       assertExceptionFields(exc, {'id': 1, 'expectedExcType': 'ValueError'});
     });
 
@@ -144,60 +119,39 @@ void main() {
           MontyStackFrame(filename: 'b.py', startLine: 2, startColumn: 0),
         ],
       );
-      assertExceptionFields(
-        exc,
-        {'id': 2, 'expectedTracebackMinFrames': 2},
-      );
+      assertExceptionFields(exc, {'id': 2, 'expectedTracebackMinFrames': 2});
     });
 
     test('checks expectedTracebackFrameHasFilename', () {
       const exc = MontyException(
         message: 'bad',
         traceback: [
-          MontyStackFrame(
-            filename: 'main.py',
-            startLine: 1,
-            startColumn: 0,
-          ),
+          MontyStackFrame(filename: 'main.py', startLine: 1, startColumn: 0),
         ],
       );
-      assertExceptionFields(
-        exc,
-        {'id': 3, 'expectedTracebackFrameHasFilename': true},
-      );
+      assertExceptionFields(exc, {
+        'id': 3,
+        'expectedTracebackFrameHasFilename': true,
+      });
     });
 
     test('checks expectedErrorFilename', () {
-      const exc = MontyException(
-        message: 'bad',
-        filename: 'test.py',
-      );
-      assertExceptionFields(
-        exc,
-        {'id': 4, 'expectedErrorFilename': 'test.py'},
-      );
+      const exc = MontyException(message: 'bad', filename: 'test.py');
+      assertExceptionFields(exc, {'id': 4, 'expectedErrorFilename': 'test.py'});
     });
 
     test('checks expectedTracebackFilename', () {
       const exc = MontyException(
         message: 'bad',
         traceback: [
-          MontyStackFrame(
-            filename: 'other.py',
-            startLine: 1,
-            startColumn: 0,
-          ),
-          MontyStackFrame(
-            filename: 'target.py',
-            startLine: 5,
-            startColumn: 0,
-          ),
+          MontyStackFrame(filename: 'other.py', startLine: 1, startColumn: 0),
+          MontyStackFrame(filename: 'target.py', startLine: 5, startColumn: 0),
         ],
       );
-      assertExceptionFields(
-        exc,
-        {'id': 5, 'expectedTracebackFilename': 'target.py'},
-      );
+      assertExceptionFields(exc, {
+        'id': 5,
+        'expectedTracebackFilename': 'target.py',
+      });
     });
 
     test('missing keys are no-ops', () {

--- a/packages/dart_monty_platform_interface/test/testing/ladder_runner_test.dart
+++ b/packages/dart_monty_platform_interface/test/testing/ladder_runner_test.dart
@@ -105,10 +105,7 @@ void main() {
     test('handles resumeValues path', () async {
       final mock = MockMontyPlatform()
         ..enqueueProgress(
-          const MontyPending(
-            functionName: 'fetch',
-            arguments: ['url'],
-          ),
+          const MontyPending(functionName: 'fetch', arguments: ['url']),
         )
         ..enqueueProgress(
           const MontyComplete(
@@ -139,10 +136,7 @@ void main() {
     test('handles resumeErrors path', () async {
       final mock = MockMontyPlatform()
         ..enqueueProgress(
-          const MontyPending(
-            functionName: 'fetch',
-            arguments: [],
-          ),
+          const MontyPending(functionName: 'fetch', arguments: []),
         )
         ..enqueueProgress(
           const MontyComplete(

--- a/packages/dart_monty_wasm/lib/src/monty_wasm.dart
+++ b/packages/dart_monty_wasm/lib/src/monty_wasm.dart
@@ -25,8 +25,8 @@ class MontyWasm extends BaseMontyPlatform implements MontySnapshotCapable {
   MontyWasm._({
     required WasmCoreBindings coreBindings,
     required WasmBindings wasmBindings,
-  })  : _wasmBindings = wasmBindings,
-        super(bindings: coreBindings);
+  }) : _wasmBindings = wasmBindings,
+       super(bindings: coreBindings);
 
   final WasmBindings _wasmBindings;
 

--- a/packages/dart_monty_wasm/lib/src/wasm_bindings_js.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_bindings_js.dart
@@ -104,8 +104,9 @@ class WasmBindingsJs extends WasmBindings {
     String? limitsJson,
     String? scriptName,
   }) async {
-    final resultJson =
-        await _bridge.run(code.toJS, limitsJson?.toJS, scriptName?.toJS).toDart;
+    final resultJson = await _bridge
+        .run(code.toJS, limitsJson?.toJS, scriptName?.toJS)
+        .toDart;
     final map = json.decode(resultJson.toDart) as Map<String, dynamic>;
     final rawTraceback = map['traceback'] as List<Object?>?;
 

--- a/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
@@ -152,10 +152,10 @@ class WasmCoreBindings implements MontyCoreBindings {
   // ---------------------------------------------------------------------------
 
   static MontyResourceUsage _makeUsage(int elapsedMs) => MontyResourceUsage(
-        memoryBytesUsed: 0,
-        timeElapsedMs: elapsedMs,
-        stackDepthUsed: 0,
-      );
+    memoryBytesUsed: 0,
+    timeElapsedMs: elapsedMs,
+    stackDepthUsed: 0,
+  );
 
   CoreRunResult _translateRunResult(WasmRunResult result, int elapsedMs) {
     if (result.ok) {

--- a/packages/dart_monty_wasm/test/integration/cancel_benchmark.dart
+++ b/packages/dart_monty_wasm/test/integration/cancel_benchmark.dart
@@ -65,9 +65,9 @@ Future<void> runT1_1W({int n = 50}) async {
     // Start infinite loop on default session.
     final startCompleter = Completer<String>();
     _start('while True: pass'.toJS).toDart.then(
-          (result) => startCompleter.complete('OK:${result.toDart}'),
-          onError: (Object e) => startCompleter.complete('ERR:$e'),
-        );
+      (result) => startCompleter.complete('OK:${result.toDart}'),
+      onError: (Object e) => startCompleter.complete('ERR:$e'),
+    );
 
     await Future<void>.delayed(const Duration(milliseconds: 100));
 
@@ -86,10 +86,10 @@ Future<void> runT1_1W({int n = 50}) async {
       final key = result.contains('disposed')
           ? 'Session disposed'
           : result.contains('crashed')
-              ? 'Worker crashed'
-              : result.length > 50
-                  ? '${result.substring(0, 50)}...'
-                  : result;
+          ? 'Worker crashed'
+          : result.length > 50
+          ? '${result.substring(0, 50)}...'
+          : result;
       resolvedTypes[key] = (resolvedTypes[key] ?? 0) + 1;
     }
   }
@@ -141,9 +141,9 @@ Future<void> runT1_4W({int n = 50}) async {
 
     final startCompleter = Completer<String>();
     _start('while True: pass'.toJS).toDart.then(
-          (result) => startCompleter.complete('OK:${result.toDart}'),
-          onError: (Object e) => startCompleter.complete('ERR:$e'),
-        );
+      (result) => startCompleter.complete('OK:${result.toDart}'),
+      onError: (Object e) => startCompleter.complete('ERR:$e'),
+    );
 
     await Future<void>.delayed(const Duration(milliseconds: 100));
     _fastCancel(sid);
@@ -185,9 +185,9 @@ Future<void> runT2_2W({int n = 20}) async {
 
     final startCompleter = Completer<String>();
     _start('while True: pass'.toJS).toDart.then(
-          (result) => startCompleter.complete('OK:${result.toDart}'),
-          onError: (Object e) => startCompleter.complete('ERR:$e'),
-        );
+      (result) => startCompleter.complete('OK:${result.toDart}'),
+      onError: (Object e) => startCompleter.complete('ERR:$e'),
+    );
 
     await Future<void>.delayed(const Duration(milliseconds: 100));
 
@@ -231,9 +231,9 @@ Future<void> runT3_1W({int n = 100, int warmup = 5}) async {
 
     final startCompleter = Completer<void>();
     _start('while True: pass'.toJS).toDart.then(
-          (_) => startCompleter.complete(),
-          onError: (_) => startCompleter.complete(),
-        );
+      (_) => startCompleter.complete(),
+      onError: (_) => startCompleter.complete(),
+    );
 
     await Future<void>.delayed(const Duration(milliseconds: 100));
 

--- a/packages/dart_monty_wasm/test/mock_wasm_bindings.dart
+++ b/packages/dart_monty_wasm/test/mock_wasm_bindings.dart
@@ -75,12 +75,9 @@ class MockWasmBindings extends WasmBindings {
   /// Records of `(code, extFnsJson, limitsJson, scriptName)` passed to
   /// [start].
   final List<
-      ({
-        String code,
-        String? extFnsJson,
-        String? limitsJson,
-        String? scriptName
-      })> startCalls = [];
+    ({String code, String? extFnsJson, String? limitsJson, String? scriptName})
+  >
+  startCalls = [];
 
   /// Records of `valueJson` passed to [resume].
   final List<String> resumeCalls = [];
@@ -158,14 +155,12 @@ class MockWasmBindings extends WasmBindings {
     String? limitsJson,
     String? scriptName,
   }) async {
-    startCalls.add(
-      (
-        code: code,
-        extFnsJson: extFnsJson,
-        limitsJson: limitsJson,
-        scriptName: scriptName,
-      ),
-    );
+    startCalls.add((
+      code: code,
+      extFnsJson: extFnsJson,
+      limitsJson: limitsJson,
+      scriptName: scriptName,
+    ));
     if (throwOnStart != null) throw StateError(throwOnStart!);
 
     return nextStartResult;

--- a/packages/dart_monty_wasm/test/wasm_core_bindings_test.dart
+++ b/packages/dart_monty_wasm/test/wasm_core_bindings_test.dart
@@ -403,10 +403,7 @@ void main() {
     test('run: unrecognized error rethrows as-is', () async {
       mock.throwOnRun = 'SomeOtherError';
 
-      await expectLater(
-        () => bindings.run('x'),
-        throwsA(isA<StateError>()),
-      );
+      await expectLater(() => bindings.run('x'), throwsA(isA<StateError>()));
     });
 
     test('start: MontyCancelled prefix throws MontyCancelledError', () async {
@@ -427,15 +424,17 @@ void main() {
       );
     });
 
-    test('resumeWithError: MontyCancelled prefix throws MontyCancelledError',
-        () async {
-      mock.throwOnResumeWithError = 'MontyCancelled: Worker terminated';
+    test(
+      'resumeWithError: MontyCancelled prefix throws MontyCancelledError',
+      () async {
+        mock.throwOnResumeWithError = 'MontyCancelled: Worker terminated';
 
-      await expectLater(
-        () => bindings.resumeWithError('err'),
-        throwsA(isA<MontyCancelledError>()),
-      );
-    });
+        await expectLater(
+          () => bindings.resumeWithError('err'),
+          throwsA(isA<MontyCancelledError>()),
+        );
+      },
+    );
   });
 
   // ===========================================================================

--- a/spike/web_test/bin/ladder_runner.dart
+++ b/spike/web_test/bin/ladder_runner.dart
@@ -210,12 +210,7 @@ Future<Map<String, dynamic>> _runIterative(
         return {'id': id, 'ok': false, 'error': 'Expected pending state'};
       }
       resultJson = _parseResult(
-        (await bridge
-                .resumeWithError(
-                  jsonEncode(errorMsg).toJS,
-                )
-                .toDart)
-            .toDart,
+        (await bridge.resumeWithError(jsonEncode(errorMsg).toJS).toDart).toDart,
       );
     }
   } else if (resumeValues != null) {

--- a/spike/web_test/bin/main.dart
+++ b/spike/web_test/bin/main.dart
@@ -74,13 +74,15 @@ Future<void> main() async {
   _printResult('2 + 2', r1);
 
   print('--- Test Case 2: run(\'"hello " + "world"\') ---');
-  final r2 =
-      _parseResult((await _montyRun('"hello " + "world"'.toJS).toDart).toDart);
+  final r2 = _parseResult(
+    (await _montyRun('"hello " + "world"'.toJS).toDart).toDart,
+  );
   _printResult('string concat', r2);
 
   print('--- Test Case 3: run("invalid syntax def") ---');
-  final r3 =
-      _parseResult((await _montyRun('invalid syntax def'.toJS).toDart).toDart);
+  final r3 = _parseResult(
+    (await _montyRun('invalid syntax def'.toJS).toDart).toDart,
+  );
   _printResult('syntax error', r3);
 
   // Step 4: Iterative execution (if API available)
@@ -90,8 +92,7 @@ Future<void> main() async {
       (await _montyStart(
         'result = fetch("https://example.com")'.toJS,
         '["fetch"]'.toJS,
-      ).toDart)
-          .toDart,
+      ).toDart).toDart,
     );
     print('  start() => ${s1['state']}');
 


### PR DESCRIPTION
## Summary
- Apply `dart format` (Dart 3.11 tall style) across all packages and examples
- 67 files reformatted, net reduction of ~565 lines from compact tall-style formatting
- No logic changes — formatting only

## Changes
- **example/**: desktop, flutter_web, web, web-showcase examples reformatted
- **packages/dart_monty_ffi**: lib + test files reformatted
- **packages/dart_monty_native**: lib + integration tests reformatted
- **packages/dart_monty_platform_interface**: lib + test files reformatted
- **packages/dart_monty_wasm**: lib + test files reformatted
- **spike/web_test**: bin scripts reformatted

## Test plan
- [x] `dart format .` applied — all files now pass `dart format --set-exit-if-changed`
- [x] No logic changes, formatting only