### PR TITLE
chore(ci): enforce tall format via page_width and pin Flutter 3.41.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.41.4'
           channel: stable
           cache: true
       - name: Download FFI bindings
@@ -119,6 +120,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.41.4'
           channel: stable
           cache: true
       - name: Download FFI bindings
@@ -156,6 +158,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.41.4'
           channel: stable
           cache: true
       - name: Download FFI bindings
@@ -192,6 +195,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.41.4'
           channel: stable
           cache: true
       - name: Install dependencies
@@ -245,6 +249,7 @@ jobs:
           cache-dependency-path: packages/dart_monty_wasm/js/package-lock.json
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.41.4'
           channel: stable
           cache: true
       - name: Download WASM binary
@@ -359,6 +364,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.41.4'
           channel: stable
           cache: true
       - uses: dtolnay/rust-toolchain@stable

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,6 @@
+formatter:
+  page_width: 80
+
 include:
   - package:very_good_analysis/analysis_options.10.0.0.yaml
   - dcm_options.yaml


### PR DESCRIPTION
## Summary
- Add `formatter: page_width: 80` to root `analysis_options.yaml`
- Pin Flutter version to 3.41.4 in all 6 CI jobs

## Why
`dart format` output differed between local and CI because:
1. No explicit `formatter:` section meant behavior depended on SDK defaults
2. `channel: stable` in CI drifts as new Flutter versions release

## Test plan
- [x] `dart format --set-exit-if-changed .` passes locally with resolved packages
- [x] `dart analyze --fatal-infos` passes