### PR TITLE
fix(ci): update pages + release workflows for WASM C-ABI

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -18,12 +18,23 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+
+      # ── Build WASM binary (Rust → wasm32-wasip1) ─────────────────────
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native
+      - name: Build WASM
+        working-directory: native
+        run: cargo build --release --target wasm32-wasip1
 
       # ── Build JS bridge ──────────────────────────────────────────────
       - uses: actions/setup-node@v4
@@ -34,6 +45,11 @@ jobs:
       - name: Build JS bridge
         working-directory: packages/dart_monty_wasm/js
         run: npm install && npm run build
+      - name: Verify WASM assets
+        run: |
+          test -f packages/dart_monty_wasm/assets/dart_monty_bridge.js
+          test -f packages/dart_monty_wasm/assets/dart_monty_worker.js
+          test -f packages/dart_monty_wasm/assets/dart_monty_native.wasm
 
       # ── Compile Dart to JS ───────────────────────────────────────────
       - uses: dart-lang/setup-dart@v1
@@ -64,8 +80,7 @@ jobs:
         run: |
           cp packages/dart_monty_wasm/assets/dart_monty_bridge.js example/web/web/
           cp packages/dart_monty_wasm/assets/dart_monty_worker.js example/web/web/
-          cp packages/dart_monty_wasm/assets/wasi-worker-browser.mjs example/web/web/
-          cp packages/dart_monty_wasm/assets/*.wasm example/web/web/
+          cp packages/dart_monty_wasm/assets/dart_monty_native.wasm example/web/web/
       - name: Copy fixture files
         run: |
           mkdir -p example/web/web/fixtures
@@ -74,6 +89,7 @@ jobs:
       # ── Build Flutter web example ──────────────────────────────────
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.41.4'
           channel: stable
           cache: true
       - name: Install Flutter web dependencies
@@ -86,8 +102,7 @@ jobs:
         run: |
           cp packages/dart_monty_wasm/assets/dart_monty_bridge.js example/flutter_web/build/web/
           cp packages/dart_monty_wasm/assets/dart_monty_worker.js example/flutter_web/build/web/
-          cp packages/dart_monty_wasm/assets/wasi-worker-browser.mjs example/flutter_web/build/web/
-          cp packages/dart_monty_wasm/assets/*.wasm example/flutter_web/build/web/
+          cp packages/dart_monty_wasm/assets/dart_monty_native.wasm example/flutter_web/build/web/
           cp example/flutter_web/web/coi-serviceworker.js example/flutter_web/build/web/
       - name: Copy fixture files to Flutter build
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,8 +166,7 @@ jobs:
           # Bridge assets
           cp packages/dart_monty_wasm/assets/dart_monty_bridge.js "$DIR/"
           cp packages/dart_monty_wasm/assets/dart_monty_worker.js "$DIR/"
-          cp packages/dart_monty_wasm/assets/wasi-worker-browser.mjs "$DIR/"
-          cp packages/dart_monty_wasm/assets/*.wasm "$DIR/"
+          cp packages/dart_monty_wasm/assets/dart_monty_native.wasm "$DIR/"
           # Fixtures
           mkdir -p "$DIR/fixtures"
           cp test/fixtures/python_ladder/tier_*.json "$DIR/fixtures/"


### PR DESCRIPTION
## Summary
- Add Rust `wasm32-wasip1` build step to Pages workflow (fixes #138)
- Remove stale `wasi-worker-browser.mjs` references from pages + release workflows
- Replace `*.wasm` glob with explicit `dart_monty_native.wasm`
- Pin Flutter version to 3.41.4 in Pages workflow
- Add asset verification step after JS bridge build
- Bump Pages timeout 15→20 min for Rust build

## Changes
- **`.github/workflows/pages.yaml`**: Add Rust toolchain + WASM build + cache, remove NAPI-RS artifacts, pin Flutter, verify assets
- **`.github/workflows/release.yaml`**: Remove `wasi-worker-browser.mjs` copy, use explicit WASM filename

## Test plan
- [x] CI passes on this branch
- [x] Pages workflow has all required build steps in correct order
- [ ] Manual: trigger Pages deploy after merge and verify site loads

Closes #138