### PR TITLE
fix(pages): add MCP documentation landing page

### DIFF
--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -84,7 +84,7 @@
       <h2>dart_monty_mcp</h2>
       <p>Give your LLM a Python interpreter. MCP server for Claude Desktop, Cursor, or any MCP client — with host function plugins.</p>
     </a>
-    <a class="card" href="https://github.com/runyaga/dart_monty/tree/main/packages/dart_monty_mcp/docs">
+    <a class="card" href="mcp-docs.html">
       <h2>MCP Documentation</h2>
       <p>Setup guides, host function API, session persistence, Python subset reference, and architecture docs.</p>
     </a>

--- a/example/web/web/mcp-docs.html
+++ b/example/web/web/mcp-docs.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>MCP Documentation — dart_monty</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+      background: #1e1e1e;
+      color: #d4d4d4;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      padding: 2rem;
+    }
+    h1 { color: #569cd6; font-size: 1.8rem; margin-bottom: 0.5rem; }
+    .tagline { color: #808080; margin-bottom: 2rem; font-size: 0.95rem; }
+    .back {
+      color: #569cd6;
+      text-decoration: none;
+      font-size: 0.85rem;
+      margin-bottom: 1.5rem;
+    }
+    .back:hover { text-decoration: underline; }
+    .docs { display: flex; gap: 1.5rem; flex-wrap: wrap; justify-content: center; max-width: 900px; }
+    .doc-card {
+      background: #252526;
+      border: 1px solid #404040;
+      border-radius: 6px;
+      padding: 1.5rem;
+      width: 280px;
+      text-decoration: none;
+      color: #d4d4d4;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .doc-card:hover { border-color: #569cd6; transform: translateY(-2px); }
+    .doc-card h2 { color: #dcdcaa; font-size: 1rem; margin-bottom: 0.5rem; }
+    .doc-card p { font-size: 0.85rem; color: #808080; line-height: 1.5; }
+    .footer {
+      margin-top: 3rem;
+      font-size: 0.8rem;
+      color: #555;
+    }
+    .footer a { color: #569cd6; }
+  </style>
+</head>
+<body>
+  <a class="back" href="index.html">&larr; Back to dart_monty</a>
+  <h1>MCP Documentation</h1>
+  <p class="tagline">dart_monty_mcp — give your LLM a Python interpreter</p>
+  <div class="docs">
+    <a class="doc-card" href="https://github.com/runyaga/dart_monty/blob/main/packages/dart_monty_mcp/docs/client_setup.md">
+      <h2>Client Setup</h2>
+      <p>Configure MCP clients (Claude Desktop, Cursor, etc.) to connect to the dart_monty_mcp server.</p>
+    </a>
+    <a class="doc-card" href="https://github.com/runyaga/dart_monty/blob/main/packages/dart_monty_mcp/docs/host_functions.md">
+      <h2>Host Functions</h2>
+      <p>Extend the Monty interpreter with Dart-implemented capabilities callable from Python.</p>
+    </a>
+    <a class="doc-card" href="https://github.com/runyaga/dart_monty/blob/main/packages/dart_monty_mcp/docs/session_persistence.md">
+      <h2>Session Persistence</h2>
+      <p>Save and restore Python state between calls using JSON serialization.</p>
+    </a>
+    <a class="doc-card" href="https://github.com/runyaga/dart_monty/blob/main/packages/dart_monty_mcp/docs/startup_modes.md">
+      <h2>Startup Modes</h2>
+      <p>Stdio transport, custom configuration, and embedding the server in your own app.</p>
+    </a>
+    <a class="doc-card" href="https://github.com/runyaga/dart_monty/blob/main/packages/dart_monty_mcp/docs/python_subset.md">
+      <h2>Python Subset</h2>
+      <p>What Python features Monty supports — types, control flow, functions, classes, and known limitations.</p>
+    </a>
+    <a class="doc-card" href="https://github.com/runyaga/dart_monty/blob/main/packages/dart_monty_mcp/docs/architecture.md">
+      <h2>Architecture</h2>
+      <p>Component tree, session lifecycle, bridge event flow, and how the MCP server wires together.</p>
+    </a>
+  </div>
+  <div class="footer">
+    <a href="https://github.com/runyaga/dart_monty/tree/main/packages/dart_monty_mcp">dart_monty_mcp on GitHub</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- MCP Documentation card linked to GitHub file tree — replace with styled landing page
- New `mcp-docs.html` with cards linking to each of the 6 docs (client setup, host functions, session persistence, startup modes, Python subset, architecture)
- Update `index.html` to point to local page instead of GitHub tree URL

## Changes
- **`example/web/web/mcp-docs.html`**: New page matching site theme
- **`example/web/web/index.html`**: Update MCP Documentation href

## Test plan
- [x] `dart_monty_mcp` README card unchanged (still links to GitHub)
- [x] MCP Documentation card now links to `mcp-docs.html`
- [ ] Deploy and verify at https://runyaga.github.io/dart_monty/