### PR TITLE
fix(pages): merge duplicate MCP cards into one

### DIFF
--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -80,13 +80,9 @@
   </div>
   <h2 style="color: #dcdcaa; margin-top: 2rem; margin-bottom: 0.5rem; font-size: 1rem;">MCP Server</h2>
   <div class="cards">
-    <a class="card" href="https://github.com/runyaga/dart_monty/tree/main/packages/dart_monty_mcp#readme">
-      <h2>dart_monty_mcp</h2>
-      <p>Give your LLM a Python interpreter. MCP server for Claude Desktop, Cursor, or any MCP client — with host function plugins.</p>
-    </a>
     <a class="card" href="mcp-docs.html">
-      <h2>MCP Documentation</h2>
-      <p>Setup guides, host function API, session persistence, Python subset reference, and architecture docs.</p>
+      <h2>dart_monty_mcp</h2>
+      <p>Give your LLM a Python interpreter. MCP server with host function plugins, session persistence, and 6 guides covering setup through architecture.</p>
     </a>
   </div>
   <h2 style="color: #dcdcaa; margin-top: 2rem; margin-bottom: 0.5rem; font-size: 1rem;">Flutter Web</h2>


### PR DESCRIPTION
## Summary
- Combine redundant dart_monty_mcp + MCP Documentation cards into single card
- Single card links to docs landing page (`mcp-docs.html`)
- GitHub README link remains accessible via mcp-docs.html footer

## Test plan
- [ ] Verify single MCP card on landing page after deploy