### PR TITLE
feat(pages): add last-generated timestamp to page footers

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -113,6 +113,13 @@ jobs:
           mkdir -p example/web/web/flutter
           cp -r example/flutter_web/build/web/* example/web/web/flutter/
 
+      # ── Stamp build date ─────────────────────────────────────────────
+      - name: Stamp build date into HTML
+        run: |
+          stamp="$(date -u +'%Y-%m-%d %H:%M UTC')"
+          sed -i "s/__BUILD_DATE__/$stamp/g" example/web/web/index.html
+          sed -i "s/__BUILD_DATE__/$stamp/g" example/web/web/mcp-docs.html
+
       # ── Deploy ───────────────────────────────────────────────────────
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3

--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -94,6 +94,7 @@
   </div>
   <div class="footer">
     <a href="https://github.com/runyaga/dart_monty">GitHub</a>
+    <br>Last generated: __BUILD_DATE__
   </div>
 </body>
 </html>

--- a/example/web/web/mcp-docs.html
+++ b/example/web/web/mcp-docs.html
@@ -82,6 +82,7 @@
   </div>
   <div class="footer">
     <a href="https://github.com/runyaga/dart_monty/tree/main/packages/dart_monty_mcp">dart_monty_mcp on GitHub</a>
+    <br>Last generated: __BUILD_DATE__
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds a "Last generated: YYYY-MM-DD HH:MM UTC" line to the footer of both `index.html` and `mcp-docs.html`
- HTML files contain a `__BUILD_DATE__` placeholder that the Pages workflow replaces with the actual UTC build timestamp via `sed` before deployment

## Changes
- **example/web/web/index.html**: Added `__BUILD_DATE__` placeholder in footer
- **example/web/web/mcp-docs.html**: Added `__BUILD_DATE__` placeholder in footer
- **.github/workflows/pages.yaml**: Added "Stamp build date" step before deploy

## Test plan
- [x] Verify placeholder is visible in source HTML
- [x] Pages workflow stamps the date on deploy (visible in footer after next deploy)