### PR TITLE
chore(ci): add native-release workflow for pre-built binaries

### DIFF
--- a/.github/workflows/native-release.yaml
+++ b/.github/workflows/native-release.yaml
@@ -36,6 +36,10 @@ jobs:
             label: windows-x64
             lib: dart_monty_native.dll
             asset: dart_monty_native-windows-x64.dll
+          - runner: windows-11-arm
+            label: windows-arm64
+            lib: dart_monty_native.dll
+            asset: dart_monty_native-windows-arm64.dll
     steps:
       - uses: actions/checkout@v4
 
@@ -95,4 +99,5 @@ jobs:
             libdart_monty_native-linux-arm64.so \
             libdart_monty_native-macos-x64.dylib \
             libdart_monty_native-macos-arm64.dylib \
-            dart_monty_native-windows-x64.dll
+            dart_monty_native-windows-x64.dll \
+            dart_monty_native-windows-arm64.dll


### PR DESCRIPTION
## Summary
- Adds `native-release.yaml` workflow triggered on `native-v*` tags
- Builds Rust native library on **native platform runners** (zero cross-compilation)
- Uploads binaries to GitHub Releases with exact naming convention `hook/build.dart` expects

## Platform Matrix

| Target | Runner | Asset Name |
|--------|--------|------------|
| linux-x64 | `ubuntu-latest` | `libdart_monty_native-linux-x64.so` |
| linux-arm64 | `ubuntu-24.04-arm` | `libdart_monty_native-linux-arm64.so` |
| macos-x64 | `macos-13` | `libdart_monty_native-macos-x64.dylib` |
| macos-arm64 | `macos-14` | `libdart_monty_native-macos-arm64.dylib` |
| windows-x64 | `windows-latest` | `dart_monty_native-windows-x64.dll` |
| windows-arm64 | `windows-11-arm` | `dart_monty_native-windows-arm64.dll` |

## Consumer flow
1. Tag `native-v0.7.0` → workflow builds all 6 binaries → creates GitHub Release
2. `dart run` invokes `hook/build.dart` → detects no `Cargo.toml` → downloads binary from release
3. Build system bundles the `.dylib`/`.so`/`.dll` into the compiled app

## Test plan
- [x] YAML passes `check-yaml` pre-commit hook
- [x] Asset names match `hook/build.dart` `_download()` filename construction
- [x] Tag pattern `native-v*` matches hook URL: `releases/download/native-v$_version/$filename`
- [ ] Push `native-v0.7.0` tag after merge to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)