### PR TITLE
chore(ffi): bump dart_monty_ffi to 0.8.0

### DIFF
--- a/packages/dart_monty_ffi/hook/build.dart
+++ b/packages/dart_monty_ffi/hook/build.dart
@@ -4,7 +4,7 @@ import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
 
 /// dart_monty native library version. Must match a GitHub Release tag.
-const _version = '0.7.0';
+const _version = '0.8.0';
 
 /// GitHub repository for pre-built binary downloads.
 const _repo = 'runyaga/dart_monty';
@@ -40,11 +40,11 @@ void main(List<String> args) async {
       // Contributor path: always run cargo (handles incremental builds).
       final triple = _rustTriple(os, arch);
       final targetArgs = triple != null ? ['--target', triple] : <String>[];
-      final result = await Process.run(
-        'cargo',
-        ['build', '--release', ...targetArgs],
-        workingDirectory: Directory.fromUri(nativeDir).path,
-      );
+      final result = await Process.run('cargo', [
+        'build',
+        '--release',
+        ...targetArgs,
+      ], workingDirectory: Directory.fromUri(nativeDir).path);
       if (result.exitCode != 0) {
         throw StateError(
           'cargo build failed.\n'

--- a/packages/dart_monty_ffi/pubspec.yaml
+++ b/packages/dart_monty_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_ffi
 description: Native FFI backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.0
+version: 0.8.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues


### PR DESCRIPTION
## Summary
- Bump `pubspec.yaml` version from 0.7.0 → 0.8.0 (aligns with CHANGELOG)
- Update `hook/build.dart` `_version` from `'0.7.0'` → `'0.8.0'` so consumer downloads resolve to `native-v0.8.0` release tag

## After merge
Tag `native-v0.8.0` to trigger the native-release workflow and publish binaries.

## Test plan
- [x] Version string in hook matches tag pattern `native-v0.8.0`
- [x] `dart format` clean
- [ ] Tag `native-v0.8.0` after merge → verify 6 binaries on release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)