### PR TITLE
fix(ci): replace deprecated macos-13 with macos-15-intel runner

### DIFF
--- a/.github/workflows/native-release.yaml
+++ b/.github/workflows/native-release.yaml
@@ -24,7 +24,7 @@ jobs:
             label: linux-arm64
             lib: libdart_monty_native.so
             asset: libdart_monty_native-linux-arm64.so
-          - runner: macos-13
+          - runner: macos-15-intel
             label: macos-x64
             lib: libdart_monty_native.dylib
             asset: libdart_monty_native-macos-x64.dylib


### PR DESCRIPTION
## Summary
- Replace `macos-13` with `macos-15-intel` in `native-release.yaml`
- `macos-13` was retired Dec 2025, causing the macos-x64 build to cancel on the first `native-v0.8.0` run

## Test plan
- [ ] Delete `native-v0.8.0` tag, re-tag after merge, verify all 6 builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)