### PR TITLE
fix(ci): rename binary release tag to native-lib-v*

### DIFF
--- a/.github/workflows/native-release.yaml
+++ b/.github/workflows/native-release.yaml
@@ -2,7 +2,7 @@ name: Native Release
 
 on:
   push:
-    tags: ['native-v*']
+    tags: ['native-lib-v*']
 
 permissions:
   contents: write

--- a/docs/native_build.md
+++ b/docs/native_build.md
@@ -45,7 +45,7 @@ No Rust toolchain required for consumers.
 
 ## GitHub Releases Binary Naming
 
-Pre-built binaries are hosted on GitHub Releases with tag `native-v<version>`.
+Pre-built binaries are hosted on GitHub Releases with tag `native-lib-v<version>`.
 The naming convention is:
 
 ```text
@@ -57,8 +57,8 @@ dart_monty_native-windows-arm64.dll
 dart_monty_native-windows-x64.dll
 ```
 
-The version in `hook/build.dart` (`_version = '0.7.0'`) must match the
-GitHub Release tag (`native-v0.7.0`).
+The version in `hook/build.dart` (`_version = '0.8.0'`) must match the
+GitHub Release tag (`native-lib-v0.8.0`).
 
 ## Contributor Setup
 
@@ -92,7 +92,7 @@ The build hook now prints both `stdout` and `stderr` from cargo. Check:
 ### Download fails (consumer)
 
 - Check your network connection and firewall/proxy settings
-- Verify the release exists: `https://github.com/runyaga/dart_monty/releases/tag/native-v0.7.0`
+- Verify the release exists: `https://github.com/runyaga/dart_monty/releases/tag/native-lib-v0.8.0`
 - Corrupt `.tmp` files are automatically cleaned up; re-run the build
 
 ### Stale hook cache

--- a/packages/dart_monty_ffi/hook/build.dart
+++ b/packages/dart_monty_ffi/hook/build.dart
@@ -116,7 +116,7 @@ Future<bool> _download(
   if (filename == null) return false;
 
   final url = Uri.parse(
-    'https://github.com/$_repo/releases/download/native-v$_version/$filename',
+    'https://github.com/$_repo/releases/download/native-lib-v$_version/$filename',
   );
 
   final tmpFile = File('${outFile.path}.tmp');


### PR DESCRIPTION
## Summary
- Rename binary release tag pattern from `native-v*` to `native-lib-v*`
- Fixes collision with `publish_native.yaml` which triggers on `native-v*` to publish `dart_monty_native` to pub.dev

## Changes
- **native-release.yaml**: trigger `native-v*` → `native-lib-v*`
- **hook/build.dart**: download URL `native-v` → `native-lib-v`
- **docs/native_build.md**: tag references updated + version bumped to 0.8.0

## After merge
```bash
git tag native-lib-v0.8.0 main && git push origin native-lib-v0.8.0
```

## Test plan
- [x] Tag pattern no longer collides with `publish_native.yaml` (`native-v*`)
- [x] Download URL in hook matches new tag: `releases/download/native-lib-v0.8.0/<filename>`
- [ ] Tag `native-lib-v0.8.0` after merge → verify 6 binaries on release page

🤖 Generated with [Claude Code](https://claude.com/claude-code)