### PR TITLE
feat(plugin-maker): automated plugin wrapping with add-on pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ test.py
 .env
 .env.*
 .venv/
+# Wrap process test runs (regenerate with tool/test_wrap_process.sh)
+wrap-runs/
+
 # CI review artifacts (all generated — regenerate with tool/metrics.sh)
 ci-review/
 packages/dart_monty_ffi/bin/cancel_benchmark

--- a/docs/PLUGIN-CONTRACT.md
+++ b/docs/PLUGIN-CONTRACT.md
@@ -268,6 +268,34 @@ help(cat)    # → "Read a UTF-8 text file. Usage: cat(path)"
 
 ## Testing Pattern
 
+### Handler test args must be JSON-safe primitives
+
+When testing `handler(args)`, the `args` map simulates a JSON payload coming
+from Python. It MUST contain **only** JSON-safe primitives (`String`, `int`,
+`double`, `bool`, `List`, `Map`).
+
+- **NEVER** pass Dart Enums, classes, or complex objects into the `args` map.
+- If the underlying Dart package uses Enums (e.g. `Namespace.url`), pass the
+  primitive string representation in the test, just as a Python caller would.
+- Use `final` (not `const`) when extracting values from library objects for
+  test args, to avoid Dart's strict constant evaluation errors with property
+  accessors.
+
+```dart
+// WRONG — passes an Enum into args:
+const ns = Namespace.url;
+await handler({'namespace': ns, 'name': 'test'});
+
+// WRONG — const can't evaluate .value:
+const ns = Namespace.url.value;
+
+// CORRECT — use final or a string literal:
+final ns = Namespace.url.value;
+await handler({'namespace': ns, 'name': 'test'});
+// or:
+await handler({'namespace': '6ba7b811-9dad-11d1-80b4-00c04fd430c8', 'name': 'test'});
+```
+
 ### Unit tests
 
 Test each handler in isolation with a temp directory (for I/O plugins) or mock dependencies:

--- a/docs/PLUGIN-CONTRACT.md
+++ b/docs/PLUGIN-CONTRACT.md
@@ -1,0 +1,524 @@
+# Monty Plugin Contract
+
+Everything you need to build, test, and register a MontyPlugin.
+
+## MontyPlugin Base Class
+
+Every plugin extends `MontyPlugin` from `dart_monty_bridge`:
+
+```dart
+import 'package:dart_monty_bridge/dart_monty_bridge.dart';
+
+class MyPlugin extends MontyPlugin {
+  @override
+  String get namespace => 'my';
+
+  @override
+  String? get systemPromptContext => 'One-line LLM description.';
+
+  @override
+  String get pythonPrelude => '''
+def my_helper(x):
+    return my_do_thing(x=x)
+_help_docs[my_helper] = "Does a thing. Usage: my_helper(x)"
+_help_list = _help_list + [["my_helper", "Does a thing"]]''';
+
+  @override
+  List<HostFunction> get functions => [_doThing()];
+
+  @override
+  Future<void> onRegister(MontyBridge bridge) async {}
+
+  @override
+  Future<void> onDispose() async {}
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `namespace` | Yes | Unique lowercase identifier (`[a-z][a-z0-9_]*`, max 32 chars) |
+| `systemPromptContext` | No | Short description injected into the LLM system prompt |
+| `pythonPrelude` | No | Python code evaluated once on session creation |
+| `functions` | Yes | List of `HostFunction`s callable from Python |
+| `onRegister(bridge)` | No | Called when attached to a bridge (setup) |
+| `onDispose()` | No | Called when session ends (cleanup, must be idempotent) |
+
+### Reserved namespaces
+
+`introspection` is reserved for built-in functions.
+
+## HostFunction
+
+A host function is a schema + async handler:
+
+```dart
+HostFunction _doThing() => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'my_do_thing',
+        description: 'Does a thing with x.',
+        params: [
+          HostParam(
+            name: 'x',
+            type: HostParamType.string,
+            description: 'The thing to do.',
+          ),
+        ],
+      ),
+      handler: (args) async {
+        final x = args['x'];
+        if (x is! String) {
+          throw ArgumentError('x must be a string.');
+        }
+        return 'did $x';
+      },
+    );
+```
+
+### HostFunctionSchema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | `String` | Function name as registered with the interpreter. **Must** start with `{namespace}_`. |
+| `description` | `String` | Human-readable description (shown to LLM in tool schemas). |
+| `params` | `List<HostParam>` | Ordered parameter definitions. Positional args from Python map to params by order; keyword args overlay by name. |
+
+### HostParam
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `String` | — | Parameter name (becomes key in the validated args map). |
+| `type` | `HostParamType` | — | Expected type. |
+| `isRequired` | `bool` | `true` | Whether the caller must supply a value. |
+| `description` | `String?` | `null` | Human-readable description for schema export. |
+| `defaultValue` | `Object?` | `null` | Default when absent and not required. |
+
+### HostParamType
+
+| Enum value | Dart type | Python type | JSON Schema |
+|------------|-----------|-------------|-------------|
+| `string` | `String` | `str` | `"string"` |
+| `integer` | `int` | `int` | `"integer"` |
+| `number` | `num` | `float` | `"number"` |
+| `boolean` | `bool` | `bool` | `"boolean"` |
+| `list` | `List<Object?>` | `list` | `"array"` |
+| `map` | `Map<String, Object?>` | `dict` | `"object"` |
+| `any` | `Object?` | any | `"string"` |
+
+**Rule:** Only use JSON-safe primitive types. Never use `dynamic`. The `any` type passes through without validation — use it sparingly for polymorphic values.
+
+### Type coercion
+
+- `integer` params accept `int`, `num` (truncated), or numeric `String`
+- `number` params accept `num` or numeric `String`
+- All other types require exact match
+
+## Naming Rules
+
+1. **Namespace prefix:** Every function name must start with `{namespace}_`. Example: namespace `fs` → functions `fs_cat`, `fs_ls`, `fs_write`.
+2. **Valid namespace:** lowercase, `[a-z][a-z0-9_]*`, max 32 characters.
+3. **No duplicates:** Two plugins cannot register the same function name.
+4. **No duplicate namespaces:** Each namespace can only be registered once.
+
+## Type Marshalling (Dart to Python)
+
+| Dart | Python | Notes |
+|------|--------|-------|
+| `String` | `str` | |
+| `int` | `int` | |
+| `double` | `float` | |
+| `bool` | `bool` | |
+| `null` | `None` | |
+| `List<Object?>` | `list` | Elements must be JSON-safe |
+| `Map<String, Object?>` | `dict` | Keys must be strings, values JSON-safe |
+
+**Prohibited:** `DateTime`, `Uint8List`, custom classes, `dynamic`. Convert to a JSON-safe representation first (e.g. ISO 8601 string for dates).
+
+## Error Handling
+
+1. **Validate arguments explicitly** — use `is!` type checks, throw `ArgumentError`:
+   ```dart
+   final path = args['path'];
+   if (path is! String) {
+     throw ArgumentError('path must be a string.');
+   }
+   ```
+2. **Never** use bare `as` casts — they throw `TypeError` which is not catchable from Python.
+3. **Throw `ArgumentError`** for bad input, `StateError` for invalid state.
+4. Errors thrown by handlers are surfaced to the Monty runtime as Python exceptions.
+
+## Monty Python Subset
+
+Monty is a restricted Python subset. Prelude code and all user-facing Python must follow these rules.
+
+### Supported
+
+| Feature | Example |
+|---------|---------|
+| Variables | `x = 42` |
+| Arithmetic | `+`, `-`, `*`, `/`, `//`, `%`, `**` |
+| Comparison | `==`, `!=`, `<`, `>`, `<=`, `>=` |
+| Boolean | `and`, `or`, `not`, `is`, `is not` |
+| Strings | `"hello"`, `'world'`, `"""multi"""` |
+| String ops | `+` concatenation, `*` repeat, `[i]` index, `[a:b]` slice |
+| String methods | `.upper()`, `.lower()`, `.strip()`, `.split()`, `.replace()`, `.startswith()`, `.endswith()`, `.find()`, `.join()` |
+| Lists | `[1, 2, 3]`, `.append()`, `[i]`, `[a:b]`, `len()` |
+| Dicts | `{"k": v}`, `[key]`, `.get()`, `.keys()`, `.values()`, `.items()` |
+| Tuples | `(1, 2, 3)` |
+| `if`/`elif`/`else` | Standard |
+| `while` loops | `while i < n:` |
+| Functions | `def f(x, y=0):` |
+| `print()` | Output captured in `MontyResult.printOutput` |
+| `len()` | Works on str, list, dict |
+| `str()`, `int()`, `float()`, `bool()` | Type conversions |
+| `None`, `True`, `False` | Literals |
+| `pass` | No-op |
+| `return` | From functions |
+| Functions as values | `d = {f: "docs"}` — functions are hashable |
+
+### NOT Supported
+
+| Feature | Workaround |
+|---------|------------|
+| `for x in items:` | Use `while` loop with index |
+| `range()` | Use `while i < n: ... i = i + 1` |
+| f-strings `f"{x}"` | Use `str(x)` + concatenation |
+| `import` | Not available — host functions are globals |
+| List comprehensions | Use `while` loop + `.append()` |
+| `try`/`except` | Not available from user code |
+| `class` definitions | Not available |
+| `with` statements | Not available |
+| `lambda` | Use `def` instead |
+| `*args`, `**kwargs` | Use explicit parameters |
+| Decorators | Not available |
+| `assert` | Not available |
+| `type()` | Not available |
+| Sets | Use lists or dicts |
+
+### Side-by-side workarounds
+
+**Iterating a list:**
+```python
+# NOT supported:
+# for item in items:
+#     process(item)
+
+# Workaround:
+i = 0
+while i < len(items):
+    process(items[i])
+    i = i + 1
+```
+
+**Building a string from parts:**
+```python
+# NOT supported:
+# result = f"Hello {name}, you are {age}"
+
+# Workaround:
+result = "Hello " + name + ", you are " + str(age)
+```
+
+**Filtering a list:**
+```python
+# NOT supported:
+# evens = [x for x in nums if x % 2 == 0]
+
+# Workaround:
+evens = []
+i = 0
+while i < len(nums):
+    if nums[i] % 2 == 0:
+        evens.append(nums[i])
+    i = i + 1
+```
+
+## pythonPrelude Rules
+
+The prelude is evaluated **once** on session creation, before any user code runs.
+
+1. Must be valid Monty Python (see subset above).
+2. Define convenience wrapper functions that call your `{namespace}_*` host functions.
+3. Register help entries using `_help_docs` (function ref → description) and `_help_list` (ordered display list). These globals are initialized by the runtime before your prelude runs.
+4. Keep it short — the prelude adds to every session's startup cost.
+
+### Prelude template
+
+```python
+def my_helper(x):
+    return my_do_thing(x=x)
+_help_docs[my_helper] = "Does a thing. Usage: my_helper(x)"
+_help_list = _help_list + [["my_helper", "Does a thing"]]
+
+def my_other(a, b):
+    return my_combine(a=a, b=b)
+_help_docs[my_other] = "Combine a and b. Usage: my_other(a, b)"
+_help_list = _help_list + [["my_other", "Combine a and b"]]
+```
+
+**Important:** Use `_help_list = _help_list + [[...]]` (list concatenation), not `.append()`, for maximum Monty compatibility.
+
+### Help system
+
+The runtime generates a global `help()` function after all plugin preludes:
+
+```python
+help()       # → formatted list of all registered functions
+help(cat)    # → "Read a UTF-8 text file. Usage: cat(path)"
+```
+
+## Testing Pattern
+
+### Unit tests
+
+Test each handler in isolation with a temp directory (for I/O plugins) or mock dependencies:
+
+```dart
+import 'package:test/test.dart';
+
+void main() {
+  group('MyPlugin', () {
+    late MyPlugin plugin;
+
+    setUp(() {
+      plugin = MyPlugin();
+    });
+
+    test('namespace is my', () {
+      expect(plugin.namespace, 'my');
+    });
+
+    test('provides N functions', () {
+      expect(plugin.functions, hasLength(N));
+      final names = plugin.functions.map((f) => f.schema.name).toSet();
+      expect(names, containsAll(['my_do_thing', 'my_combine']));
+    });
+
+    test('pythonPrelude defines wrapper functions', () {
+      expect(plugin.pythonPrelude, contains('def my_helper('));
+    });
+
+    group('my_do_thing', () {
+      late Map<String, HostFunction> byName;
+
+      setUp(() {
+        byName = {for (final f in plugin.functions) f.schema.name: f};
+      });
+
+      test('happy path', () async {
+        final result = await byName['my_do_thing']!.handler({
+          'x': 'hello',
+        });
+        expect(result, 'did hello');
+      });
+
+      test('rejects non-string x', () async {
+        expect(
+          () => byName['my_do_thing']!.handler({'x': 123}),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+  });
+}
+```
+
+### Integration tests
+
+Use a `RecordingBridge` to verify registration, or a `_ScriptableBridge` to test the full pipeline:
+
+```dart
+test('registers onto bridge via PluginRegistry', () async {
+  final bridge = RecordingBridge();
+  final registry = PluginRegistry()..register(plugin);
+  await registry.attachTo(bridge);
+
+  final names = bridge.registered.map((f) => f.schema.name).toSet();
+  expect(names, contains('my_do_thing'));
+});
+```
+
+### Schema tests
+
+Verify parameter definitions:
+
+```dart
+test('my_do_thing has x param', () {
+  final schema = byName['my_do_thing']!.schema;
+  expect(schema.params, hasLength(1));
+  expect(schema.params[0].name, 'x');
+  expect(schema.params[0].type, HostParamType.string);
+});
+```
+
+## Registration
+
+### In soliplex_scripting (factory)
+
+Pass your plugin via the `extraPlugins` parameter:
+
+```dart
+final factory = createMontyScriptEnvironmentFactory(
+  hostApi: hostApi,
+  extraPlugins: [MyPlugin()],
+);
+```
+
+### In dart_monty_mcp (MCP server)
+
+```dart
+final server = MontyMcpServer(platformFactory: platformFactory);
+server.registerPlugin(MyPlugin());
+```
+
+The MCP server exposes plugin functions both as Python-callable host functions and as direct MCP tools.
+
+### In soliplex_cli (TUI)
+
+Plugins passed via `extraPlugins` are available in the interactive REPL.
+
+## Complete Worked Example: LocalFsPlugin
+
+A sandboxed file system plugin with 8 functions, path traversal prevention, and Linux-style naming.
+
+```dart
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:soliplex_interpreter_monty/soliplex_interpreter_monty.dart';
+
+class LocalFsPlugin extends MontyPlugin {
+  LocalFsPlugin({required String rootPath})
+      : _rootPath = Directory(rootPath).resolveSymbolicLinksSync();
+
+  final String _rootPath;
+
+  @override
+  String get namespace => 'fs';
+
+  @override
+  String? get systemPromptContext =>
+      'Read and write local files within the sandbox root. '
+      'Commands mirror Linux: cat, ls, write, mkdir, rm, stat, '
+      'exists, find.';
+
+  @override
+  String get pythonPrelude => '''
+def cat(path):
+    return fs_cat(path=path)
+_help_docs[cat] = "Read a UTF-8 text file. Usage: cat(path)"
+_help_list = _help_list + [["cat", "Read a UTF-8 text file"]]
+
+def ls(path=".", recursive=False):
+    return fs_ls(path=path, recursive=recursive)
+_help_docs[ls] = "List directory entries. Usage: ls(path, recursive=False)"
+_help_list = _help_list + [["ls", "List directory entries"]]
+
+def write(path, content):
+    fs_write(path=path, content=content)
+_help_docs[write] = "Write text to a file. Usage: write(path, content)"
+_help_list = _help_list + [["write", "Write text to a file"]]
+
+def mkdir(path):
+    fs_mkdir(path=path)
+_help_docs[mkdir] = "Create directory (recursive). Usage: mkdir(path)"
+_help_list = _help_list + [["mkdir", "Create directory (recursive)"]]
+
+def rm(path):
+    fs_rm(path=path)
+_help_docs[rm] = "Delete a file or empty directory. Usage: rm(path)"
+_help_list = _help_list + [["rm", "Delete a file or empty directory"]]
+
+def stat(path):
+    return fs_stat(path=path)
+_help_docs[stat] = "Get file metadata. Usage: stat(path)"
+_help_list = _help_list + [["stat", "Get file metadata"]]
+
+def exists(path):
+    return fs_exists(path=path)
+_help_docs[exists] = "Check if path exists. Usage: exists(path)"
+_help_list = _help_list + [["exists", "Check if path exists"]]
+
+def find(path=".", pattern="*"):
+    return fs_find(path=path, pattern=pattern)
+_help_docs[find] = "Find files by glob. Usage: find(path, pattern)"
+_help_list = _help_list + [["find", "Find files by glob"]]''';
+
+  @override
+  List<HostFunction> get functions => [
+        _cat(), _ls(), _write(), _mkdir(),
+        _rm(), _stat(), _exists(), _find(),
+      ];
+
+  /// Resolves path within sandbox. Uses resolveSymbolicLinksSync for
+  /// existing paths (catches symlink escapes), p.canonicalize for new
+  /// paths (handles .. traversal).
+  String _resolve(String path) {
+    if (path.isEmpty) {
+      throw ArgumentError('path must be a non-empty string.');
+    }
+    final joined = p.join(_rootPath, path);
+    final normalized =
+        FileSystemEntity.typeSync(joined) != FileSystemEntityType.notFound
+            ? File(joined).resolveSymbolicLinksSync()
+            : p.canonicalize(joined);
+    if (!p.isWithin(_rootPath, normalized) && normalized != _rootPath) {
+      throw ArgumentError('Path escapes sandbox root: $path');
+    }
+    return normalized;
+  }
+
+  HostFunction _cat() => HostFunction(
+        schema: const HostFunctionSchema(
+          name: 'fs_cat',
+          description: 'Read a UTF-8 text file and return its contents.',
+          params: [
+            HostParam(
+              name: 'path',
+              type: HostParamType.string,
+              description: 'Relative path within the sandbox root.',
+            ),
+          ],
+        ),
+        handler: (args) async {
+          final path = args['path'];
+          if (path is! String) {
+            throw ArgumentError('path must be a string.');
+          }
+          final resolved = _resolve(path);
+          final file = File(resolved);
+          if (!file.existsSync()) {
+            throw ArgumentError('File does not exist: $path');
+          }
+          return file.readAsStringSync();
+        },
+      );
+
+  // ... remaining 7 functions follow the same pattern:
+  // _ls(), _write(), _mkdir(), _rm(), _stat(), _exists(), _find()
+}
+```
+
+### Key patterns in this example
+
+1. **Constructor validates rootPath** — `resolveSymbolicLinksSync()` on the root itself
+2. **`_resolve()` prevents escapes** — symlink resolution for existing paths, canonicalization for new paths
+3. **Explicit type checks** — `path is! String` with `ArgumentError`, never bare `as`
+4. **Prelude registers help** — both `_help_docs[fn]` (for `help(fn)`) and `_help_list` (for `help()`)
+5. **Linux-style naming** — wrapper functions (`cat`, `ls`) hide the `fs_` prefix
+6. **Schema descriptions** — clear enough for an LLM to use without additional context
+
+## Checklist
+
+Before submitting a plugin:
+
+- [ ] Namespace is lowercase, `[a-z][a-z0-9_]*`, max 32 chars
+- [ ] All function names start with `{namespace}_`
+- [ ] All params use `HostParamType` (no `dynamic`)
+- [ ] Handler validates args with `is!` checks, throws `ArgumentError`
+- [ ] No bare `as` casts
+- [ ] `pythonPrelude` uses only Monty-safe Python (no for-in, f-strings, imports, range)
+- [ ] Help entries registered in `_help_docs` and `_help_list`
+- [ ] Unit tests for each handler (happy + error paths)
+- [ ] Integration test via `PluginRegistry.attachTo(bridge)`
+- [ ] `dart analyze --fatal-infos` clean
+- [ ] `dart test` passes

--- a/docs/WRAP-TUTORIAL.md
+++ b/docs/WRAP-TUTORIAL.md
@@ -1,0 +1,153 @@
+# Plugin Wrap Process Tutorial
+
+Generate a MontyPlugin wrapper for any pub.dev package using a local LLM.
+
+## Prerequisites
+
+- Dart SDK 3.5+
+- Python 3.10+
+- An LLM backend (Ollama recommended for offline use)
+- Native Monty library built (`cd native && cargo build --release`)
+
+## Quick Start
+
+```bash
+# Default: local Ollama with qwen2.5-coder:14b
+bash tool/test_wrap_process.sh phone_numbers_parser
+
+# Specific model on a remote Ollama server
+OLLAMA_HOST=http://gpu-server:11434 LLM_MODEL=gpt-oss:120b \
+  bash tool/test_wrap_process.sh uuid
+
+# Gemini cloud
+LLM_PROVIDER=gemini GEMINI_API_KEY=... \
+  bash tool/test_wrap_process.sh path
+```
+
+## How It Works
+
+The wrap process is a **three-stage pipeline**:
+
+### Stage 1: WRAP (agentic TDD loop)
+
+1. **Fetch** package info from pub.dev + README from GitHub
+2. **Scaffold** a clean-room Dart project with `very_good_analysis`
+3. **Build prompts** — system prompt (RULES + PLUGIN-CONTRACT.md) + user prompt (package description + README)
+4. **Iterate**:
+   - Call LLM to generate plugin + test code
+   - Extract code blocks from markdown response
+   - `dart fix --apply` + `dart format` (mechanical lint fixes)
+   - `dart analyze --fatal-infos` — if fail, feed errors back to LLM
+   - `dart test` — if fail, feed errors back to LLM
+   - Repeat until pass or max iterations reached
+
+### Stage 2: PRELUDE_LINT (static analysis)
+
+Checks the generated `pythonPrelude` for Monty-unsafe Python patterns:
+- `for x in items:` (use `while` loop)
+- f-strings (use `str()` + concatenation)
+- `import`, `try/except`, `class`, `lambda`, list comprehensions
+- Any other syntax not in the Monty Python subset
+
+### Stage 3: MONTY_SMOKE (integration test)
+
+If the native Monty library is available:
+1. Adds `dart_monty_ffi` + `dart_monty_platform_interface` to the clean room
+2. Generates a Dart test that creates a real `DefaultMontyBridge`
+3. Registers the plugin via `PluginRegistry`
+4. Runs the `pythonPrelude` through the Monty interpreter
+5. Calls every wrapper function through Monty and verifies no errors
+
+## Pipeline Outputs
+
+Each run creates a timestamped directory under `wrap-runs/<package>/`:
+
+```
+wrap-runs/uuid/2026-03-10_22-48-56/
+  report.json           # Structured results (iterations, durations, status)
+  report.txt            # Human-readable summary
+  run.log.jsonl         # Machine-parseable event log
+  conversation.jsonl    # Full LLM conversation history
+  workspace/            # The clean-room Dart project
+    lib/src/plugins/uuid_plugin.dart      # Generated plugin
+    test/src/plugins/uuid_plugin_test.dart # Generated unit tests
+    test/src/plugins/uuid_smoke_test.dart  # Generated Monty smoke test
+  artifacts/
+    system_prompt.txt   # System prompt sent to LLM
+    initial_prompt.txt  # First user message
+    readme.md           # Fetched library README
+    iter_N_response.md  # LLM response per iteration
+    iter_N_plugin.dart  # Extracted plugin code per iteration
+    iter_N_test.dart    # Extracted test code per iteration
+    iter_N_analyze.txt  # dart analyze output per iteration
+    iter_N_test_output.txt  # dart test output (when analyze passes)
+    turns/turn_NNN.json # Multi-turn conversation state
+    smoke_test.dart     # Generated Monty smoke test (copy)
+    prelude_lint.txt    # Prelude lint results
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLM_PROVIDER` | `ollama` | `ollama`, `openai`, or `gemini` |
+| `LLM_MODEL` | per-provider | Model name (e.g., `gpt-oss:120b`) |
+| `OLLAMA_HOST` | `http://localhost:11434` | Ollama server URL |
+| `OPENAI_BASE_URL` | `http://localhost:11434/v1` | OpenAI-compatible endpoint |
+| `OPENAI_API_KEY` | — | API key for OpenAI provider |
+| `GEMINI_API_KEY` | — | API key for Gemini provider |
+| `WRAP_MAX_ITERATIONS` | 8/5/3 | Max fix iterations (ollama/openai/gemini) |
+| `DART_MONTY_BRIDGE` | auto-detected | Path to dart_monty_bridge package |
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | SUCCESS — all stages passed |
+| 1 | FAILURE or PARTIAL — WRAP failed, or add-on stage failed |
+| 2 | Setup failure (bad args, missing deps) |
+| 3 | LLM failure (API error, no code blocks) |
+
+## Tool Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `tool/test_wrap_process.sh` | Main harness — orchestrates all stages |
+| `tool/llm_call.py` | Provider-agnostic LLM API caller |
+| `tool/extract_code_blocks.py` | Extracts Dart code blocks from LLM markdown |
+| `tool/generate_report.py` | Generates JSON report from run data |
+| `tool/lint_prelude.py` | Static linter for pythonPrelude |
+| `tool/generate_smoke_test.py` | Generates Monty integration smoke test |
+
+## Design Decisions
+
+### Why `dart fix --apply` before `dart analyze`?
+
+Local models (20B-120B params) consistently miss `very_good_analysis` lint
+rules like `const` constructors, nullable casts, and trailing commas.
+`dart fix` resolves 60-80% of these mechanically, letting the LLM focus on
+semantic correctness.
+
+### Why disable `lines_longer_than_80_chars` and `require_trailing_commas`?
+
+LLMs cannot reliably count characters or manage trailing comma placement.
+These rules wasted 1-3 iterations per run with no semantic benefit. Disabling
+them in the clean room's `analysis_options.yaml` is a pragmatic tradeoff.
+
+### Why provider-aware iteration defaults?
+
+Cloud models (Gemini, GPT-4o) typically solve in 1-3 iterations. Local models
+need 3-8. Giving each provider an appropriate budget avoids both premature
+failure and wasted compute.
+
+### Why loop detection?
+
+If the LLM produces identical error output for two consecutive iterations,
+it's stuck. The harness aborts early with a `STUCK` status instead of burning
+remaining iterations on the same error.
+
+### Why `_help_docs = {}` in the smoke test?
+
+The Monty runtime normally initializes `_help_docs` and `_help_list` globals
+before plugin preludes run. In bare-bridge mode (no full runtime), the smoke
+test must initialize these itself so the prelude's help registration works.

--- a/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
@@ -183,6 +183,15 @@ class DefaultMontyBridge implements MontyBridge {
             return;
         }
       }
+    } on MontyCancelledError {
+      controller.add(const BridgeRunError(message: 'Execution cancelled'));
+    } on MontyError catch (e) {
+      log.warning('Monty error', attributes: {'error': e.message});
+      _flushPrintBuffer(printBuffer, controller);
+      final output = printBuffer.isNotEmpty ? printBuffer.toString() : null;
+      controller.add(
+        BridgeRunError(message: e.message, printOutput: output),
+      );
     } on MontyException catch (e) {
       log.warning('Python error', attributes: {'error': e.message});
       _flushPrintBuffer(printBuffer, controller);

--- a/packages/dart_monty_bridge/lib/src/bridge/monty_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/monty_plugin.dart
@@ -16,6 +16,16 @@ abstract class MontyPlugin {
   /// its function schemas.
   String? get systemPromptContext => null;
 
+  /// Python code to prepend to every session using this plugin.
+  ///
+  /// Use this to provide convenience wrapper functions that call the
+  /// plugin's host functions. The prelude is evaluated once on session
+  /// creation, before any user code runs.
+  ///
+  /// Must be valid Monty Python (no for-in, no f-strings, no imports).
+  /// Returns empty string by default (no prelude).
+  String get pythonPrelude => '';
+
   /// Host functions this plugin provides.
   List<HostFunction> get functions;
 

--- a/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
@@ -106,6 +106,20 @@ class PluginRegistry {
     }
   }
 
+  /// Concatenates non-empty [MontyPlugin.pythonPrelude]s in registration order.
+  ///
+  /// Returns an empty string when no plugin provides a prelude.
+  String combinedPythonPrelude() {
+    final buf = StringBuffer();
+    for (final plugin in _plugins) {
+      final prelude = plugin.pythonPrelude;
+      if (prelude.isNotEmpty) {
+        buf.writeln(prelude);
+      }
+    }
+    return buf.toString().trimRight();
+  }
+
   /// Auto-generates an LLM system prompt from plugin schemas.
   ///
   /// Each plugin produces a markdown section with its namespace as heading,

--- a/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
@@ -97,7 +97,44 @@ void main() {
       // Should complete without error.
       await plugin.onDispose();
     });
+
+    test('pythonPrelude defaults to empty string', () {
+      final plugin = _TestPlugin(namespace: 'ns', functions: []);
+
+      expect(plugin.pythonPrelude, isEmpty);
+    });
+
+    test('pythonPrelude can be overridden', () {
+      final plugin = _PreludePlugin(
+        namespace: 'math',
+        functions: [],
+        pythonPrelude: 'def add(a, b):\n    return a + b',
+      );
+
+      expect(plugin.pythonPrelude, 'def add(a, b):\n    return a + b');
+    });
   });
+}
+
+/// Plugin with a custom [pythonPrelude] for testing.
+class _PreludePlugin extends MontyPlugin {
+  _PreludePlugin({
+    required this.namespace,
+    required this.functions,
+    required this.pythonPrelude,
+  });
+
+  @override
+  final String namespace;
+
+  @override
+  final String? systemPromptContext = null;
+
+  @override
+  final List<HostFunction> functions;
+
+  @override
+  final String pythonPrelude;
 }
 
 /// Minimal [MontyBridge] for lifecycle tests — not exercised.

--- a/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
@@ -451,7 +451,104 @@ void main() {
         expect(alphaIdx, lessThan(betaIdx));
       });
     });
+
+    group('combinedPythonPrelude', () {
+      test('empty registry returns empty string', () {
+        expect(registry.combinedPythonPrelude(), isEmpty);
+      });
+
+      test('plugin with empty prelude returns empty string', () {
+        registry.register(_TestPlugin(namespace: 'ns'));
+
+        expect(registry.combinedPythonPrelude(), isEmpty);
+      });
+
+      test('single plugin prelude returned as-is', () {
+        registry.register(
+          _PreludePlugin(
+            namespace: 'math',
+            functions: [_fn('math_add')],
+            pythonPrelude: 'def add(a, b):\n    return a + b',
+          ),
+        );
+
+        expect(
+          registry.combinedPythonPrelude(),
+          'def add(a, b):\n    return a + b',
+        );
+      });
+
+      test('multiple plugins concatenated in registration order', () {
+        registry
+          ..register(
+            _PreludePlugin(
+              namespace: 'alpha',
+              functions: [_fn('alpha_x')],
+              pythonPrelude: 'x = 1',
+            ),
+          )
+          ..register(
+            _PreludePlugin(
+              namespace: 'beta',
+              functions: [_fn('beta_x')],
+              pythonPrelude: 'y = 2',
+            ),
+          );
+
+        final prelude = registry.combinedPythonPrelude();
+
+        expect(prelude, contains('x = 1'));
+        expect(prelude, contains('y = 2'));
+        expect(prelude.indexOf('x = 1'), lessThan(prelude.indexOf('y = 2')));
+      });
+
+      test('skips plugins with empty prelude', () {
+        registry
+          ..register(
+            _PreludePlugin(
+              namespace: 'alpha',
+              functions: [_fn('alpha_x')],
+              pythonPrelude: 'x = 1',
+            ),
+          )
+          ..register(_TestPlugin(namespace: 'beta', functions: [_fn('beta_x')]))
+          ..register(
+            _PreludePlugin(
+              namespace: 'gamma',
+              functions: [_fn('gamma_x')],
+              pythonPrelude: 'z = 3',
+            ),
+          );
+
+        final prelude = registry.combinedPythonPrelude();
+
+        expect(prelude, contains('x = 1'));
+        expect(prelude, contains('z = 3'));
+        expect(prelude, isNot(contains('beta')));
+      });
+    });
   });
+}
+
+/// Plugin with a configurable [pythonPrelude] for testing.
+class _PreludePlugin extends MontyPlugin {
+  _PreludePlugin({
+    required this.namespace,
+    required this.functions,
+    required this.pythonPrelude,
+  });
+
+  @override
+  final String namespace;
+
+  @override
+  final String? systemPromptContext = null;
+
+  @override
+  final List<HostFunction> functions;
+
+  @override
+  final String pythonPrelude;
 }
 
 /// Plugin with configurable lifecycle callbacks for testing.

--- a/tool/extract_code_blocks.py
+++ b/tool/extract_code_blocks.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Extract fenced Dart code blocks from LLM markdown output.
+
+Usage:
+    python3 tool/extract_code_blocks.py <response_file> <plugin_out> <test_out>
+
+Looks for ```dart code blocks. Identifies plugin vs test by content heuristics:
+- Contains 'extends MontyPlugin' → plugin file
+- Contains "import 'package:test/" → test file
+- Filename hints in code fence (```dart:foo_plugin.dart) also used
+
+Exits 0 if both files extracted, 1 if plugin missing, 2 if test missing.
+"""
+
+import re
+import sys
+
+
+def extract_blocks(text: str) -> list[tuple[str, str]]:
+    """Return list of (hint, code) tuples from fenced code blocks."""
+    pattern = r'```dart(?::([^\n]*))?[ \t]*\n(.*?)```'
+    matches = re.findall(pattern, text, re.DOTALL)
+    return [(hint.strip(), code.strip()) for hint, code in matches]
+
+
+def classify(blocks: list[tuple[str, str]]) -> tuple[str | None, str | None]:
+    """Classify blocks into plugin source and test source."""
+    plugin_src = None
+    test_src = None
+
+    for hint, code in blocks:
+        hint_lower = hint.lower()
+
+        # Filename hint classification
+        if 'test' in hint_lower:
+            test_src = code
+            continue
+        if 'plugin' in hint_lower and 'test' not in hint_lower:
+            plugin_src = code
+            continue
+
+        # Content heuristic classification
+        if "extends MontyPlugin" in code:
+            plugin_src = code
+        elif "import 'package:test/" in code or 'import "package:test/' in code:
+            test_src = code
+
+    # Handle single-block-concatenated case (LLM put both files in one block).
+    if len(blocks) == 1 and plugin_src is None and test_src is None:
+        _, code = blocks[0]
+        test_markers = [
+            "import 'package:test/test.dart';",
+            'import "package:test/test.dart";',
+        ]
+        for marker in test_markers:
+            if marker in code:
+                parts = code.split(marker, 1)
+                potential_plugin = parts[0].strip()
+                potential_test = marker + parts[1]
+                if 'extends MontyPlugin' in potential_plugin:
+                    plugin_src = potential_plugin
+                    test_src = potential_test.strip()
+                    break
+
+    # Fallback: if exactly 2 blocks and one is unclassified
+    if len(blocks) == 2:
+        if plugin_src is None and test_src is not None:
+            other = [c for _, c in blocks if c != test_src]
+            if other:
+                plugin_src = other[0]
+        elif test_src is None and plugin_src is not None:
+            other = [c for _, c in blocks if c != plugin_src]
+            if other:
+                test_src = other[0]
+        elif plugin_src is None and test_src is None:
+            # Guess: first block is plugin, second is test
+            plugin_src = blocks[0][1]
+            test_src = blocks[1][1]
+
+    return plugin_src, test_src
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <response_file> <plugin_out> <test_out>",
+              file=sys.stderr)
+        sys.exit(3)
+
+    response_file, plugin_out, test_out = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    with open(response_file) as f:
+        text = f.read()
+
+    blocks = extract_blocks(text)
+    if not blocks:
+        print("ERROR: No ```dart code blocks found in response.", file=sys.stderr)
+        sys.exit(1)
+
+    plugin_src, test_src = classify(blocks)
+
+    exit_code = 0
+    if plugin_src:
+        with open(plugin_out, 'w') as f:
+            f.write(plugin_src + '\n')
+        print(f"OK: Plugin written to {plugin_out} ({len(plugin_src)} chars)")
+    else:
+        print("ERROR: Could not identify plugin code block.", file=sys.stderr)
+        exit_code = 1
+
+    if test_src:
+        with open(test_out, 'w') as f:
+            f.write(test_src + '\n')
+        print(f"OK: Test written to {test_out} ({len(test_src)} chars)")
+    else:
+        print("ERROR: Could not identify test code block.", file=sys.stderr)
+        exit_code = max(exit_code, 2)
+
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/tool/generate_report.py
+++ b/tool/generate_report.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Generate JSON report for wrap process test harness.
+
+Usage:
+    python3 tool/generate_report.py <package_name> <version> <timestamp> \
+        <model> <max_iter> <iter_used> <duration> <status> <run_dir> \
+        <iterations_json_file>
+
+Reads iteration data from a JSON file (not inline) to avoid shell quoting.
+"""
+
+import json
+import sys
+
+
+def main():
+    if len(sys.argv) != 11:
+        print(
+            f"Usage: {sys.argv[0]} <package_name> <version> <timestamp> "
+            "<model> <max_iter> <iter_used> <duration> <status> <run_dir> "
+            "<iterations_json_file>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    (
+        package_name,
+        version,
+        timestamp,
+        model,
+        max_iter,
+        iter_used,
+        duration,
+        status,
+        run_dir,
+        iterations_file,
+    ) = sys.argv[1:]
+
+    with open(iterations_file) as f:
+        iterations = json.load(f)
+
+    report = {
+        "package_name": package_name,
+        "package_version": version,
+        "run_timestamp": timestamp,
+        "gemini_model": model,
+        "max_iterations": int(max_iter),
+        "iterations_used": int(iter_used),
+        "total_duration_seconds": int(duration),
+        "status": status,
+        "run_dir": run_dir,
+        "iterations": iterations,
+    }
+
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tool/generate_smoke_test.py
+++ b/tool/generate_smoke_test.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Generate a Monty integration smoke test from a generated MontyPlugin.
+
+Usage:
+    python3 tool/generate_smoke_test.py <plugin_dart_file> <package_name> <output_test_file>
+
+Parses the generated plugin to extract:
+  - Class name (e.g., UuidPlugin)
+  - pythonPrelude wrapper function definitions
+  - HostFunctionSchema param types (for generating test arg values)
+
+Produces a Dart test file that:
+  1. Creates MontyFfi + DefaultMontyBridge
+  2. Registers the plugin via PluginRegistry
+  3. Runs the pythonPrelude through Monty
+  4. Calls each wrapper function through Monty
+  5. Verifies no BridgeRunError for each call
+
+Exit codes:
+    0 — Test file generated successfully
+    1 — Could not parse plugin file
+"""
+
+import re
+import sys
+
+
+def extract_class_name(dart_src: str) -> str | None:
+    """Find the MontyPlugin subclass name."""
+    match = re.search(r'class\s+(\w+)\s+extends\s+MontyPlugin', dart_src)
+    return match.group(1) if match else None
+
+
+def extract_prelude(dart_src: str) -> str | None:
+    """Extract pythonPrelude string content."""
+    pattern = r"get\s+pythonPrelude\s*=>\s*'''(.*?)'''"
+    match = re.search(pattern, dart_src, re.DOTALL)
+    if match:
+        return match.group(1)
+    pattern = r'get\s+pythonPrelude\s*=>\s*"""(.*?)"""'
+    match = re.search(pattern, dart_src, re.DOTALL)
+    return match.group(1) if match else None
+
+
+def extract_prelude_functions(prelude: str) -> list[tuple[str, list[str]]]:
+    """Extract function defs from prelude: [(name, [arg_names])]."""
+    funcs = []
+    for match in re.finditer(r'^def\s+(\w+)\s*\(([^)]*)\)\s*:', prelude, re.MULTILINE):
+        name = match.group(1)
+        args_str = match.group(2).strip()
+        if args_str:
+            args = [a.strip().split('=')[0].strip() for a in args_str.split(',')]
+        else:
+            args = []
+        funcs.append((name, args))
+    return funcs
+
+
+def extract_host_params(dart_src: str) -> dict[str, list[tuple[str, str]]]:
+    """Extract HostFunctionSchema params: {func_name: [(param_name, param_type)]}."""
+    result = {}
+    # Find each HostFunctionSchema block.
+    schema_pattern = re.compile(
+        r"HostFunctionSchema\(\s*name:\s*'(\w+)'.*?params:\s*\[(.*?)\]",
+        re.DOTALL,
+    )
+    param_pattern = re.compile(
+        r"HostParam\(\s*name:\s*'(\w+)'.*?type:\s*HostParamType\.(\w+)",
+        re.DOTALL,
+    )
+    for schema_match in schema_pattern.finditer(dart_src):
+        func_name = schema_match.group(1)
+        params_block = schema_match.group(2)
+        params = []
+        for param_match in param_pattern.finditer(params_block):
+            params.append((param_match.group(1), param_match.group(2)))
+        result[func_name] = params
+    return result
+
+
+def python_test_value(param_name: str, param_type: str) -> str:
+    """Generate a sensible Python test value based on param name and type."""
+    # Name-based heuristics first.
+    name_lower = param_name.lower()
+    if 'uuid' in name_lower:
+        return '"110ec58a-a0f2-4ac4-8393-c866d813b8d1"'
+    if 'namespace' in name_lower:
+        return '"6ba7b811-9dad-11d1-80b4-00c04fd430c8"'
+    if 'url' in name_lower:
+        return '"https://example.com"'
+    if 'path' in name_lower or 'file' in name_lower:
+        return '"/tmp/test.txt"'
+    if 'phone' in name_lower or 'number' in name_lower and param_type == 'string':
+        return '"+1234567890"'
+    if 'email' in name_lower:
+        return '"test@example.com"'
+
+    # Type-based fallback.
+    type_defaults = {
+        'string': '"test"',
+        'integer': '42',
+        'number': '3.14',
+        'boolean': 'True',
+        'list': '[1, 2, 3]',
+        'map': '{"key": "value"}',
+        'any': '"test"',
+    }
+    return type_defaults.get(param_type, '"test"')
+
+
+def generate_smoke_test(
+    class_name: str,
+    package_name: str,
+    prelude_funcs: list[tuple[str, list[str]]],
+    host_params: dict[str, list[tuple[str, str]]],
+    namespace: str,
+    native_lib_path: str | None = None,
+) -> str:
+    """Generate the Dart smoke test source."""
+    # Build the Python smoke script that combines prelude + calls.
+    # We generate individual test cases for each function.
+    import_path = f'package:wrap_test_{package_name}/src/plugins/{package_name}_plugin.dart'
+
+    # Native library path for NativeBindingsFfi constructor.
+    lib_path_arg = ''
+    if native_lib_path:
+        lib_path_arg = f"libraryPath: '{native_lib_path}'"
+
+    # Map prelude function names to their host function names.
+    # Convention: prelude func "v1" calls host func "uuid_v1".
+    func_to_host = {}
+    for func_name, _ in prelude_funcs:
+        host_name = f'{namespace}_{func_name}'
+        func_to_host[func_name] = host_name
+
+    # Build test code for each function.
+    test_cases = []
+
+    for func_name, func_args in prelude_funcs:
+        host_name = func_to_host.get(func_name, '')
+        host_param_list = host_params.get(host_name, [])
+
+        if not func_args:
+            # No-arg function — just call it.
+            python_call = f'{func_name}()'
+        else:
+            # Build args from host param types.
+            call_args = []
+            for i, arg_name in enumerate(func_args):
+                if i < len(host_param_list):
+                    _, ptype = host_param_list[i]
+                else:
+                    ptype = 'string'
+                call_args.append(python_test_value(arg_name, ptype))
+            python_call = f'{func_name}({", ".join(call_args)})'
+
+        test_cases.append((func_name, python_call))
+
+    # Generate the Dart test file.
+    test_blocks = []
+    for func_name, python_call in test_cases:
+        # Escape single quotes in the Python call for Dart string.
+        escaped = python_call.replace("'", r"\'")
+        test_blocks.append(f"""
+    test('{func_name}() executes without error', () async {{
+      final result = await _run(bridge, prelude + '\\n{escaped}');
+      expect(result.error, isNull,
+          reason: '{func_name} failed: ${{result.error}}');
+      expect(result.value, isNotNull,
+          reason: '{func_name} returned null');
+    }});""")
+
+    tests_joined = '\n'.join(test_blocks)
+
+    return f"""// Generated Monty smoke test — do not edit.
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty_bridge/dart_monty_bridge.dart';
+import 'package:dart_monty_ffi/dart_monty_ffi.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:test/test.dart';
+import '{import_path}';
+
+/// Result of a single Python execution.
+class _PyResult {{
+  _PyResult({{this.value, this.error}});
+  final Object? value;
+  final String? error;
+}}
+
+/// Execute Python code on the bridge, return value or error.
+Future<_PyResult> _run(DefaultMontyBridge bridge, String code) async {{
+  final events = await bridge.execute(code).toList();
+  final err = events.whereType<BridgeRunError>().firstOrNull;
+  if (err != null) {{
+    return _PyResult(error: err.message);
+  }}
+  final fin = events.whereType<BridgeRunFinished>().firstOrNull;
+  return _PyResult(value: fin?.value);
+}}
+
+void main() {{
+  late MontyFfi monty;
+  late DefaultMontyBridge bridge;
+  late PluginRegistry registry;
+  late String prelude;
+
+  setUpAll(() async {{
+    monty = MontyFfi(bindings: NativeBindingsFfi({lib_path_arg}));
+    bridge = DefaultMontyBridge(platform: monty);
+    registry = PluginRegistry()..register({class_name}());
+    await registry.attachTo(bridge);
+    // The Monty runtime normally initializes _help_docs and _help_list before
+    // plugin preludes run. In this bare-bridge context, we must init them
+    // ourselves so the prelude's help registration lines don't fail.
+    prelude = '_help_docs = {{}}\\n_help_list = []\\n' +
+        registry.combinedPythonPrelude();
+  }});
+
+  tearDownAll(() async {{
+    await registry.disposeAll();
+    bridge.dispose();
+  }});
+
+  test('pythonPrelude evaluates without error', () async {{
+    final result = await _run(bridge, prelude);
+    expect(result.error, isNull,
+        reason: 'Prelude failed: ${{result.error}}');
+  }});
+
+  // help() requires full runtime initialization (not available in bare-bridge
+  // mode), so we skip it in the smoke test.
+{tests_joined}
+}}
+"""
+
+
+def main():
+    if len(sys.argv) < 4 or len(sys.argv) > 5:
+        print(
+            f'Usage: {sys.argv[0]} <plugin_dart_file> <package_name> <output_test_file> [native_lib_path]',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    plugin_file, package_name, output_file = sys.argv[1], sys.argv[2], sys.argv[3]
+    native_lib_path = sys.argv[4] if len(sys.argv) == 5 else None
+
+    with open(plugin_file) as f:
+        dart_src = f.read()
+
+    class_name = extract_class_name(dart_src)
+    if not class_name:
+        print('ERROR: Could not find MontyPlugin subclass.', file=sys.stderr)
+        sys.exit(1)
+
+    prelude = extract_prelude(dart_src)
+    if prelude is None:
+        print('WARN: No pythonPrelude found — generating minimal test.', file=sys.stderr)
+        prelude = ''
+
+    # Extract namespace from the plugin source.
+    ns_match = re.search(r"get\s+namespace\s*=>\s*'(\w+)'", dart_src)
+    namespace = ns_match.group(1) if ns_match else package_name
+
+    prelude_funcs = extract_prelude_functions(prelude)
+    host_params = extract_host_params(dart_src)
+
+    test_src = generate_smoke_test(
+        class_name=class_name,
+        package_name=package_name,
+        prelude_funcs=prelude_funcs,
+        host_params=host_params,
+        namespace=namespace,
+        native_lib_path=native_lib_path,
+    )
+
+    with open(output_file, 'w') as f:
+        f.write(test_src)
+
+    func_names = [name for name, _ in prelude_funcs]
+    print(f'OK: Generated smoke test for {class_name} ({len(prelude_funcs)} functions: {", ".join(func_names)})')
+    print(f'    Output: {output_file}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tool/lint_prelude.py
+++ b/tool/lint_prelude.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Lint pythonPrelude for Monty-unsafe Python patterns.
+
+Usage:
+    python3 tool/lint_prelude.py <plugin_dart_file>
+
+Extracts the pythonPrelude string from a MontyPlugin .dart file and checks
+for patterns that are NOT supported by the Monty Python subset.
+
+Exit codes:
+    0 — No violations found
+    1 — Violations found (printed to stdout)
+    2 — Could not extract prelude from file
+"""
+
+import re
+import sys
+
+
+# Forbidden patterns with human-readable descriptions.
+FORBIDDEN = [
+    (r'\bfor\s+\w+\s+in\b', 'for-in loop (use while + index)'),
+    (r'\brange\s*\(', 'range() (use while + index)'),
+    (r'(?<!\w)f"', 'f-string (use str() + concatenation)'),
+    (r"(?<!\w)f'", 'f-string (use str() + concatenation)'),
+    (r'^\s*import\s+', 'import statement (not available)'),
+    (r'^\s*from\s+\w+\s+import\b', 'from-import statement (not available)'),
+    (r'\[.*\bfor\b.*\bin\b.*\]', 'list comprehension (use while + append)'),
+    (r'\{.*\bfor\b.*\bin\b.*\}', 'dict/set comprehension (not available)'),
+    (r'\btry\s*:', 'try block (not available)'),
+    (r'\bexcept\b', 'except block (not available)'),
+    (r'^\s*class\s+\w+', 'class definition (not available)'),
+    (r'\blambda\b', 'lambda (use def instead)'),
+    (r'^\s*assert\s+', 'assert (not available)'),
+    (r'\btype\s*\(', 'type() (not available)'),
+    (r'\bwith\s+\w+', 'with statement (not available)'),
+    (r'\*args', '*args (use explicit params)'),
+    (r'\*\*kwargs', '**kwargs (use explicit params)'),
+    (r'^\s*@\w+', 'decorator (not available)'),
+]
+
+
+def extract_prelude(dart_source: str) -> str | None:
+    """Extract the pythonPrelude string from a MontyPlugin Dart source file."""
+    # Match: String get pythonPrelude => '''...''';
+    # or: String get pythonPrelude => """...""";
+    pattern = r"get\s+pythonPrelude\s*=>\s*'''(.*?)'''"
+    match = re.search(pattern, dart_source, re.DOTALL)
+    if match:
+        return match.group(1)
+
+    pattern = r'get\s+pythonPrelude\s*=>\s*"""(.*?)"""'
+    match = re.search(pattern, dart_source, re.DOTALL)
+    if match:
+        return match.group(1)
+
+    return None
+
+
+def lint_prelude(prelude: str) -> list[tuple[int, str, str]]:
+    """Check prelude for forbidden patterns.
+
+    Returns list of (line_number, line_text, violation_description).
+    """
+    violations = []
+    lines = prelude.split('\n')
+
+    for line_num, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+
+        for pattern, description in FORBIDDEN:
+            if re.search(pattern, line):
+                violations.append((line_num, stripped, description))
+                break  # One violation per line is enough.
+
+    return violations
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f'Usage: {sys.argv[0]} <plugin_dart_file>', file=sys.stderr)
+        sys.exit(2)
+
+    with open(sys.argv[1]) as f:
+        dart_source = f.read()
+
+    prelude = extract_prelude(dart_source)
+    if prelude is None:
+        print('ERROR: Could not extract pythonPrelude from file.', file=sys.stderr)
+        sys.exit(2)
+
+    if not prelude.strip():
+        print('OK: pythonPrelude is empty — nothing to lint.')
+        sys.exit(0)
+
+    violations = lint_prelude(prelude)
+
+    if not violations:
+        line_count = len([l for l in prelude.split('\n') if l.strip()])
+        print(f'OK: pythonPrelude ({line_count} lines) — no Monty-unsafe patterns found.')
+        sys.exit(0)
+
+    print(f'FAIL: {len(violations)} Monty-unsafe pattern(s) in pythonPrelude:\n')
+    for line_num, line_text, description in violations:
+        print(f'  line {line_num}: {description}')
+        print(f'    → {line_text}')
+        print()
+
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tool/llm_call.py
+++ b/tool/llm_call.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""LLM API caller — supports Ollama, OpenAI-compatible, and Gemini backends.
+
+Usage:
+    python3 tool/llm_call.py \
+        --provider ollama \
+        --model qwen2.5-coder:14b \
+        --system-file system_prompt.txt \
+        --turns-dir artifacts/turns/ \
+        --output response.md
+
+Providers:
+    ollama   — Local Ollama server (default: http://localhost:11434)
+               Uses /api/chat endpoint.
+               Env: OLLAMA_HOST (optional, default localhost:11434)
+
+    openai   — Any OpenAI-compatible endpoint (Ollama /v1, LM Studio, vLLM, etc.)
+               Env: OPENAI_API_KEY (optional), OPENAI_BASE_URL (default: http://localhost:11434/v1)
+
+    gemini   — Google Gemini API
+               Env: GEMINI_API_KEY (required)
+
+The script reads system_prompt.txt and all turn_*.json files from turns_dir,
+builds a multi-turn conversation, calls the LLM, and writes the response text
+to the output file.
+
+Turn files are JSON: {"role": "user"|"model"|"assistant", "parts": [{"text": "..."}]}
+(Gemini format — converted to OpenAI format internally for openai/ollama providers.)
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+
+def load_turns(turns_dir: str) -> list[dict]:
+    """Load ordered turn files from the turns directory."""
+    turn_files = sorted(glob.glob(os.path.join(turns_dir, 'turn_*.json')))
+    turns = []
+    for tf in turn_files:
+        with open(tf) as f:
+            turns.append(json.load(f))
+    return turns
+
+
+def gemini_to_openai_role(role: str) -> str:
+    """Convert Gemini role names to OpenAI role names."""
+    return {'model': 'assistant', 'user': 'user', 'assistant': 'assistant'}.get(
+        role, role
+    )
+
+
+def turns_to_openai_messages(
+    system_text: str, turns: list[dict]
+) -> list[dict]:
+    """Convert Gemini-format turns to OpenAI chat messages."""
+    messages = [{'role': 'system', 'content': system_text}]
+    for turn in turns:
+        role = gemini_to_openai_role(turn['role'])
+        text = turn['parts'][0]['text']
+        messages.append({'role': role, 'content': text})
+    return messages
+
+
+def call_ollama(
+    model: str,
+    system_text: str,
+    turns: list[dict],
+    host: str,
+) -> str:
+    """Call Ollama's /api/chat endpoint (native format)."""
+    messages = turns_to_openai_messages(system_text, turns)
+    # Ollama native /api/chat uses the same message format as OpenAI.
+    payload = {
+        'model': model,
+        'messages': messages,
+        'stream': False,
+        'options': {
+            'temperature': 0.2,
+            'num_predict': 16384,
+        },
+    }
+
+    url = f'{host}/api/chat'
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f'ERROR: Ollama returned HTTP {e.code}: {body}', file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f'ERROR: Cannot connect to Ollama at {host}: {e.reason}', file=sys.stderr)
+        print('Is Ollama running? Start with: ollama serve', file=sys.stderr)
+        sys.exit(1)
+
+    return data['message']['content']
+
+
+def call_openai(
+    model: str,
+    system_text: str,
+    turns: list[dict],
+    base_url: str,
+    api_key: str | None,
+) -> str:
+    """Call any OpenAI-compatible /v1/chat/completions endpoint."""
+    messages = turns_to_openai_messages(system_text, turns)
+    payload = {
+        'model': model,
+        'messages': messages,
+        'temperature': 0.2,
+        'max_tokens': 16384,
+    }
+
+    url = f'{base_url}/chat/completions'
+    headers = {'Content-Type': 'application/json'}
+    if api_key:
+        headers['Authorization'] = f'Bearer {api_key}'
+
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers=headers,
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f'ERROR: OpenAI-compatible API returned HTTP {e.code}: {body}', file=sys.stderr)
+        sys.exit(1)
+
+    return data['choices'][0]['message']['content']
+
+
+def call_gemini(
+    model: str,
+    system_text: str,
+    turns: list[dict],
+    api_key: str,
+) -> str:
+    """Call Google Gemini generateContent API."""
+    # Convert turns to Gemini format (they're already in Gemini format).
+    contents = []
+    for turn in turns:
+        contents.append(turn)
+
+    payload = {
+        'system_instruction': {'parts': [{'text': system_text}]},
+        'contents': contents,
+        'generationConfig': {
+            'temperature': 0.2,
+            'maxOutputTokens': 16384,
+        },
+    }
+
+    url = (
+        f'https://generativelanguage.googleapis.com/v1beta/models'
+        f'/{model}:generateContent?key={api_key}'
+    )
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            data = json.load(resp)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()
+        print(f'ERROR: Gemini API returned HTTP {e.code}: {body}', file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        return data['candidates'][0]['content']['parts'][0]['text']
+    except (KeyError, IndexError):
+        print('ERROR: Unexpected Gemini response structure:', file=sys.stderr)
+        json.dump(data, sys.stderr, indent=2)
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Call LLM API (Ollama/OpenAI/Gemini)')
+    parser.add_argument('--provider', required=True, choices=['ollama', 'openai', 'gemini'])
+    parser.add_argument('--model', required=True)
+    parser.add_argument('--system-file', required=True)
+    parser.add_argument('--turns-dir', required=True)
+    parser.add_argument('--output', required=True)
+    args = parser.parse_args()
+
+    with open(args.system_file) as f:
+        system_text = f.read()
+
+    turns = load_turns(args.turns_dir)
+
+    if args.provider == 'ollama':
+        host = os.environ.get('OLLAMA_HOST', 'http://localhost:11434')
+        result = call_ollama(args.model, system_text, turns, host)
+
+    elif args.provider == 'openai':
+        base_url = os.environ.get('OPENAI_BASE_URL', 'http://localhost:11434/v1')
+        api_key = os.environ.get('OPENAI_API_KEY')
+        result = call_openai(args.model, system_text, turns, base_url, api_key)
+
+    elif args.provider == 'gemini':
+        api_key = os.environ.get('GEMINI_API_KEY')
+        if not api_key:
+            print('ERROR: GEMINI_API_KEY not set', file=sys.stderr)
+            sys.exit(1)
+        result = call_gemini(args.model, system_text, turns, api_key)
+
+    with open(args.output, 'w') as f:
+        f.write(result)
+
+    print(f'OK: Response written to {args.output} ({len(result)} chars)')
+
+
+if __name__ == '__main__':
+    main()

--- a/tool/test_wrap_process.sh
+++ b/tool/test_wrap_process.sh
@@ -365,6 +365,7 @@ analyzer:
 linter:
   rules:
     lines_longer_than_80_chars: false
+    require_trailing_commas: false
 YAML
 
 log_event "SCAFFOLD" "INFO" "Clean room scaffolded"
@@ -612,7 +613,128 @@ FIXEOF
   break
 done
 
-# ─── Phase 5: Generate reports ─────────────────────────────────────────────
+# ─── Phase 5: Add-on pipeline (runs only if WRAP succeeded) ───────────────
+
+PRELUDE_LINT_PASSED="skip"
+MONTY_SMOKE_PASSED="skip"
+
+if [[ "$FINAL_STATUS" == "SUCCESS" ]]; then
+  PRELUDE_LINTER="$SCRIPT_DIR/lint_prelude.py"
+  SMOKE_GENERATOR="$SCRIPT_DIR/generate_smoke_test.py"
+  NATIVE_LIB_DIR="$PROJECT_ROOT/native/target/release"
+
+  # ── 5a. Prelude lint ──
+  echo ""
+  echo "=== Add-on: Prelude Lint ==="
+  PRELUDE_LINT_FILE="$ARTIFACTS/prelude_lint.txt"
+
+  if python3 "$PRELUDE_LINTER" "$PLUGIN_FILE" > "$PRELUDE_LINT_FILE" 2>&1; then
+    PRELUDE_LINT_PASSED="true"
+    echo "    PASS: $(head -1 "$PRELUDE_LINT_FILE")"
+    log_event "PRELUDE_LINT" "INFO" "Prelude lint passed"
+  else
+    PRELUDE_LINT_PASSED="false"
+    echo "    FAIL: Monty-unsafe patterns found"
+    cat "$PRELUDE_LINT_FILE"
+    log_event_file "PRELUDE_LINT" "ERROR" "Prelude lint failed" "$PRELUDE_LINT_FILE"
+    FINAL_STATUS="PARTIAL"
+  fi
+
+  # ── 5b. Monty smoke test ──
+  # Only attempt if native library is available.
+  if [[ -f "$NATIVE_LIB_DIR/libdart_monty_native.dylib" ]] || \
+     [[ -f "$NATIVE_LIB_DIR/libdart_monty_native.so" ]]; then
+
+    echo ""
+    echo "=== Add-on: Monty Smoke Test ==="
+
+    # Add FFI deps to clean room.
+    FFI_PATH="$PROJECT_ROOT/packages/dart_monty_ffi"
+    PI_PATH="$PROJECT_ROOT/packages/dart_monty_platform_interface"
+
+    if [[ -d "$FFI_PATH" && -d "$PI_PATH" ]]; then
+      # Append FFI deps to pubspec using dependency_overrides to avoid
+      # version conflicts between local path deps and hosted constraints.
+      cat >> "$WORKSPACE/pubspec.yaml" << DEPS
+
+dependency_overrides:
+  dart_monty_ffi:
+    path: $FFI_PATH
+  dart_monty_platform_interface:
+    path: $PI_PATH
+  dart_monty_bridge:
+    path: $BRIDGE_PATH
+DEPS
+
+      echo "    Adding FFI dependencies..."
+      PUB_GET_EXIT=0
+      (cd "$WORKSPACE" && dart pub get) > "$ARTIFACTS/smoke_pub_get.txt" 2>&1 || PUB_GET_EXIT=$?
+
+      if [[ $PUB_GET_EXIT -ne 0 ]]; then
+        echo "    SKIP: dart pub get failed for FFI deps"
+        log_event "MONTY_SMOKE" "WARN" "pub get failed for FFI deps"
+        MONTY_SMOKE_PASSED="skip"
+      else
+        # Generate smoke test.
+        SMOKE_TEST_FILE="$WORKSPACE/test/src/plugins/${PACKAGE_NAME}_smoke_test.dart"
+        SMOKE_TEST_ARTIFACT="$ARTIFACTS/smoke_test.dart"
+
+        # Find native library (dylib on macOS, so on Linux).
+        NATIVE_LIB=""
+        if [[ -f "$NATIVE_LIB_DIR/libdart_monty_native.dylib" ]]; then
+          NATIVE_LIB="$NATIVE_LIB_DIR/libdart_monty_native.dylib"
+        elif [[ -f "$NATIVE_LIB_DIR/libdart_monty_native.so" ]]; then
+          NATIVE_LIB="$NATIVE_LIB_DIR/libdart_monty_native.so"
+        fi
+
+        if python3 "$SMOKE_GENERATOR" "$PLUGIN_FILE" "$PACKAGE_NAME" "$SMOKE_TEST_FILE" "$NATIVE_LIB" \
+            > "$ARTIFACTS/smoke_generate.txt" 2>&1; then
+          cp "$SMOKE_TEST_FILE" "$SMOKE_TEST_ARTIFACT"
+          echo "    $(head -1 "$ARTIFACTS/smoke_generate.txt")"
+
+          # Run smoke test with native library.
+          echo "    Running Monty smoke test..."
+          SMOKE_OUTPUT="$ARTIFACTS/smoke_test_output.txt"
+          SMOKE_EXIT=0
+          (cd "$WORKSPACE" && \
+            DYLD_LIBRARY_PATH="$NATIVE_LIB_DIR" \
+            LD_LIBRARY_PATH="$NATIVE_LIB_DIR" \
+            dart test --tags=integration "$SMOKE_TEST_FILE") \
+            > "$SMOKE_OUTPUT" 2>&1 || SMOKE_EXIT=$?
+
+          if [[ $SMOKE_EXIT -eq 0 ]]; then
+            SMOKE_PASS_COUNT=$(grep -oE '\+[0-9]+' "$SMOKE_OUTPUT" 2>/dev/null | tail -1 | tr -d '+' || echo "0")
+            MONTY_SMOKE_PASSED="true"
+            echo "    PASS: Monty smoke ($SMOKE_PASS_COUNT tests)"
+            log_event "MONTY_SMOKE" "INFO" "Monty smoke passed ($SMOKE_PASS_COUNT tests)"
+          else
+            MONTY_SMOKE_PASSED="false"
+            echo "    FAIL: Monty smoke test"
+            tail -20 "$SMOKE_OUTPUT"
+            log_event_file "MONTY_SMOKE" "ERROR" "Monty smoke failed" "$SMOKE_OUTPUT"
+            FINAL_STATUS="PARTIAL"
+          fi
+        else
+          echo "    SKIP: Could not generate smoke test"
+          cat "$ARTIFACTS/smoke_generate.txt"
+          MONTY_SMOKE_PASSED="skip"
+        fi
+      fi
+    else
+      echo ""
+      echo "=== Add-on: Monty Smoke Test ==="
+      echo "    SKIP: dart_monty_ffi or platform_interface not found"
+      MONTY_SMOKE_PASSED="skip"
+    fi
+  else
+    echo ""
+    echo "=== Add-on: Monty Smoke Test ==="
+    echo "    SKIP: Native library not found at $NATIVE_LIB_DIR"
+    MONTY_SMOKE_PASSED="skip"
+  fi
+fi
+
+# ─── Phase 6: Generate reports ─────────────────────────────────────────────
 
 END_TIME=$(date +%s)
 TOTAL_DURATION=$((END_TIME - START_TIME))
@@ -642,6 +764,10 @@ python3 "$REPORTER" \
   echo "Duration:    ${TOTAL_DURATION}s"
   echo "Iterations:  $ITERATIONS_USED / $MAX_ITERATIONS"
   echo "Status:      $FINAL_STATUS"
+  echo ""
+  echo "Add-on pipeline:"
+  echo "  Prelude lint:  $PRELUDE_LINT_PASSED"
+  echo "  Monty smoke:   $MONTY_SMOKE_PASSED"
   echo ""
 } > "$REPORT_TXT"
 

--- a/tool/test_wrap_process.sh
+++ b/tool/test_wrap_process.sh
@@ -1,0 +1,709 @@
+#!/usr/bin/env bash
+# test_wrap_process.sh — Automated test harness for the plugin wrap process.
+#
+# Generates a MontyPlugin wrapper for a pub.dev package using an LLM,
+# then validates it with dart analyze + dart test, iterating on errors.
+#
+# Usage:
+#   bash tool/test_wrap_process.sh <package_name> [output_dir]
+#
+# Examples:
+#   # Local Ollama (default — works offline):
+#   bash tool/test_wrap_process.sh phone_numbers_parser
+#
+#   # Specific Ollama model:
+#   LLM_MODEL=qwen2.5-coder:32b bash tool/test_wrap_process.sh path
+#
+#   # Gemini cloud:
+#   LLM_PROVIDER=gemini GEMINI_API_KEY=... bash tool/test_wrap_process.sh uuid
+#
+#   # OpenAI-compatible (LM Studio, vLLM, etc.):
+#   LLM_PROVIDER=openai OPENAI_BASE_URL=http://localhost:1234/v1 \
+#     bash tool/test_wrap_process.sh collection
+#
+# Environment:
+#   LLM_PROVIDER         — ollama (default), openai, gemini
+#   LLM_MODEL            — Model name. Defaults per provider:
+#                          ollama: qwen2.5-coder:14b
+#                          openai: gpt-4o
+#                          gemini: gemini-2.5-pro
+#   OLLAMA_HOST          — Ollama server URL (default: http://localhost:11434)
+#   OPENAI_BASE_URL      — OpenAI-compatible endpoint (default: http://localhost:11434/v1)
+#   OPENAI_API_KEY       — Optional for OpenAI-compatible endpoints
+#   GEMINI_API_KEY       — Required for gemini provider
+#   WRAP_MAX_ITERATIONS  — Max fix iterations (default: 8 ollama, 5 openai, 3 gemini)
+#   DART_MONTY_BRIDGE    — Path to dart_monty_bridge package (auto-detected)
+#
+# Exit codes:
+#   0 — Success (plugin generated and validated)
+#   1 — Failure (max iterations reached)
+#   2 — Setup failure (bad args, missing deps, pub get failed)
+#   3 — LLM failure (API error, no code blocks extracted)
+
+set -euo pipefail
+
+# ─── Configuration ──────────────────────────────────────────────────────────
+
+LLM_PROVIDER="${LLM_PROVIDER:-ollama}"
+
+# Default iteration count: higher for local models which need more attempts.
+if [[ -z "${WRAP_MAX_ITERATIONS:-}" ]]; then
+  case "$LLM_PROVIDER" in
+    ollama)  MAX_ITERATIONS=8 ;;
+    openai)  MAX_ITERATIONS=5 ;;
+    gemini)  MAX_ITERATIONS=3 ;;
+    *)       MAX_ITERATIONS=5 ;;
+  esac
+else
+  MAX_ITERATIONS="$WRAP_MAX_ITERATIONS"
+fi
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONTRACT_FILE="$PROJECT_ROOT/docs/PLUGIN-CONTRACT.md"
+BRIDGE_PATH="${DART_MONTY_BRIDGE:-$PROJECT_ROOT/packages/dart_monty_bridge}"
+EXTRACTOR="$SCRIPT_DIR/extract_code_blocks.py"
+REPORTER="$SCRIPT_DIR/generate_report.py"
+LLM_CALLER="$SCRIPT_DIR/llm_call.py"
+
+# Default models per provider.
+case "$LLM_PROVIDER" in
+  ollama)  LLM_MODEL="${LLM_MODEL:-qwen2.5-coder:14b}" ;;
+  openai)  LLM_MODEL="${LLM_MODEL:-gpt-4o}" ;;
+  gemini)  LLM_MODEL="${LLM_MODEL:-gemini-2.5-pro}" ;;
+  *)
+    echo "ERROR: Unknown LLM_PROVIDER '$LLM_PROVIDER'. Use: ollama, openai, gemini" >&2
+    exit 2
+    ;;
+esac
+
+# ─── Argument parsing ──────────────────────────────────────────────────────
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <package_name> [output_dir]"
+  echo ""
+  echo "Environment:"
+  echo "  LLM_PROVIDER=ollama|openai|gemini  (default: ollama)"
+  echo "  LLM_MODEL=<model_name>             (default: per provider)"
+  echo "  WRAP_MAX_ITERATIONS=3              (default: 3)"
+  exit 2
+fi
+
+PACKAGE_NAME="$1"
+OUTPUT_BASE="${2:-$PROJECT_ROOT/wrap-runs}"
+
+# ─── Preflight checks ─────────────────────────────────────────────────────
+
+for cmd in dart python3 curl; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: $cmd is required but not found on PATH." >&2
+    exit 2
+  fi
+done
+
+if [[ ! -f "$CONTRACT_FILE" ]]; then
+  echo "ERROR: PLUGIN-CONTRACT.md not found at $CONTRACT_FILE" >&2
+  exit 2
+fi
+
+if [[ ! -d "$BRIDGE_PATH" ]]; then
+  echo "ERROR: dart_monty_bridge not found at $BRIDGE_PATH" >&2
+  exit 2
+fi
+
+# Provider-specific checks.
+if [[ "$LLM_PROVIDER" == "gemini" && -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "ERROR: GEMINI_API_KEY required for gemini provider." >&2
+  exit 2
+fi
+
+if [[ "$LLM_PROVIDER" == "ollama" ]]; then
+  OLLAMA_HOST="${OLLAMA_HOST:-http://localhost:11434}"
+  if ! curl -s --max-time 5 "$OLLAMA_HOST/api/tags" > /dev/null 2>&1; then
+    echo "ERROR: Cannot connect to Ollama at $OLLAMA_HOST" >&2
+    echo "Start Ollama with: ollama serve" >&2
+    exit 2
+  fi
+  echo "--- Ollama is running at $OLLAMA_HOST"
+fi
+
+# ─── Run directory setup ───────────────────────────────────────────────────
+
+TIMESTAMP=$(date +"%Y-%m-%d_%H-%M-%S")
+RUN_DIR="$OUTPUT_BASE/$PACKAGE_NAME/$TIMESTAMP"
+WORKSPACE="$RUN_DIR/workspace"
+ARTIFACTS="$RUN_DIR/artifacts"
+TURNS_DIR="$ARTIFACTS/turns"
+LOG_FILE="$RUN_DIR/run.log.jsonl"
+CONVO_FILE="$RUN_DIR/conversation.jsonl"
+REPORT_JSON="$RUN_DIR/report.json"
+REPORT_TXT="$RUN_DIR/report.txt"
+ITERATIONS_FILE="$ARTIFACTS/iterations.json"
+
+mkdir -p "$WORKSPACE/lib/src/plugins" "$WORKSPACE/test/src/plugins" "$ARTIFACTS" "$TURNS_DIR"
+
+echo '[]' > "$ITERATIONS_FILE"
+
+# ─── Helpers ───────────────────────────────────────────────────────────────
+
+log_event() {
+  local stage="$1" level="$2" message="$3"
+  python3 -c "
+import json, sys
+entry = {'stage': sys.argv[1], 'level': sys.argv[2], 'message': sys.argv[3]}
+print(json.dumps(entry))
+" "$stage" "$level" "$message" >> "$LOG_FILE"
+}
+
+log_event_file() {
+  local stage="$1" level="$2" message="$3" data_file="$4"
+  python3 -c "
+import json, sys
+entry = {'stage': sys.argv[1], 'level': sys.argv[2], 'message': sys.argv[3], 'data_file': sys.argv[4]}
+print(json.dumps(entry))
+" "$stage" "$level" "$message" "$data_file" >> "$LOG_FILE"
+}
+
+log_convo() {
+  local role="$1" content_file="$2"
+  python3 -c "
+import json, sys
+entry = {'role': sys.argv[1], 'content_file': sys.argv[2]}
+print(json.dumps(entry))
+" "$role" "$content_file" >> "$CONVO_FILE"
+}
+
+PREV_ERROR_HASH=""
+
+# Detect if the model is stuck producing the same error.
+check_stuck() {
+  local error_file="$1"
+  local current_hash
+  current_hash=$(md5 -q "$error_file" 2>/dev/null || md5sum "$error_file" 2>/dev/null | cut -d' ' -f1)
+  if [[ "$current_hash" == "$PREV_ERROR_HASH" ]]; then
+    echo "    STUCK: Same error as previous iteration — aborting early."
+    log_event "LOOP" "WARN" "Model stuck: identical error output for consecutive iterations"
+    return 0  # stuck
+  fi
+  PREV_ERROR_HASH="$current_hash"
+  return 1  # not stuck
+}
+
+TURN_INDEX=0
+
+add_turn() {
+  local role="$1" text_file="$2"
+  local idx
+  idx=$(printf "%03d" "$TURN_INDEX")
+  python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    text = f.read()
+turn = {'role': sys.argv[2], 'parts': [{'text': text}]}
+json.dump(turn, sys.stdout)
+" "$text_file" "$role" > "$TURNS_DIR/turn_${idx}.json"
+  TURN_INDEX=$((TURN_INDEX + 1))
+}
+
+# Call the LLM via the provider-agnostic Python script.
+call_llm() {
+  local response_file="$1" system_file="$2"
+  python3 "$LLM_CALLER" \
+    --provider "$LLM_PROVIDER" \
+    --model "$LLM_MODEL" \
+    --system-file "$system_file" \
+    --turns-dir "$TURNS_DIR" \
+    --output "$response_file"
+}
+
+append_iteration() {
+  local iter="$1" duration="$2" analyze_passed="$3" analyze_errors="$4" \
+        test_passed="$5" test_count="$6" test_skipped="$7"
+  python3 -c "
+import json, sys
+ifile = sys.argv[1]
+with open(ifile) as f:
+    iters = json.load(f)
+entry = {
+    'iteration': int(sys.argv[2]),
+    'duration_seconds': int(sys.argv[3]),
+    'analyze': {'passed': sys.argv[4] == 'true', 'error_count': int(sys.argv[5])},
+    'test': {'passed': sys.argv[6] == 'true', 'test_count': int(sys.argv[7]) if sys.argv[7] != '0' else 0, 'skipped': sys.argv[8] == 'true'},
+}
+iters.append(entry)
+with open(ifile, 'w') as f:
+    json.dump(iters, f, indent=2)
+" "$ITERATIONS_FILE" "$iter" "$duration" "$analyze_passed" "$analyze_errors" \
+  "$test_passed" "$test_count" "$test_skipped"
+}
+
+# ─── Phase 1: Fetch package info from pub.dev ──────────────────────────────
+
+echo "==> Wrap process: $PACKAGE_NAME"
+echo "    Provider: $LLM_PROVIDER ($LLM_MODEL)"
+echo "    Run dir:  $RUN_DIR"
+echo "    Max iter: $MAX_ITERATIONS"
+echo ""
+
+log_event "SETUP" "INFO" "Starting wrap: $PACKAGE_NAME, provider=$LLM_PROVIDER, model=$LLM_MODEL"
+
+echo "--- Fetching package info from pub.dev..."
+PUB_INFO_FILE="$ARTIFACTS/pub_dev_info.json"
+
+http_code=$(curl -s -w "%{http_code}" -o "$PUB_INFO_FILE" \
+  -H "User-Agent: dart_monty-plugin-maker/1.0" \
+  "https://pub.dev/api/packages/$PACKAGE_NAME")
+
+if [[ "$http_code" != "200" ]]; then
+  echo "ERROR: pub.dev returned HTTP $http_code for $PACKAGE_NAME" >&2
+  log_event "PUB_DEV" "ERROR" "HTTP $http_code from pub.dev"
+  exit 2
+fi
+
+LATEST_VERSION=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(data['latest']['version'])
+" "$PUB_INFO_FILE")
+
+PACKAGE_DESC=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(data['latest']['pubspec'].get('description', 'No description'))
+" "$PUB_INFO_FILE")
+
+log_event "PUB_DEV" "INFO" "Found $PACKAGE_NAME v$LATEST_VERSION"
+echo "    $PACKAGE_NAME v$LATEST_VERSION"
+echo "    $PACKAGE_DESC"
+
+# Fetch README from GitHub (pub.dev renders via JS, curl can't get it).
+echo "--- Fetching README..."
+README_MD="$ARTIFACTS/readme.md"
+
+python3 -c "
+import json, sys, urllib.request, urllib.error, re
+
+pub_info_file = sys.argv[1]
+package_name = sys.argv[2]
+output_file = sys.argv[3]
+
+with open(pub_info_file) as f:
+    data = json.load(f)
+
+pubspec = data['latest']['pubspec']
+repo = pubspec.get('repository', '') or pubspec.get('homepage', '') or ''
+
+readme_text = ''
+
+# Try GitHub raw README (supports github.com repos).
+if 'github.com' in repo:
+    # Extract owner/repo from URL.
+    match = re.search(r'github\.com/([^/]+/[^/]+)', repo)
+    if match:
+        gh_repo = match.group(1).rstrip('/')
+        for branch in ['main', 'master']:
+            url = f'https://raw.githubusercontent.com/{gh_repo}/{branch}/README.md'
+            try:
+                req = urllib.request.Request(url, headers={'User-Agent': 'dart_monty/1.0'})
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    readme_text = resp.read().decode('utf-8', errors='replace')
+                    break
+            except urllib.error.HTTPError:
+                continue
+            except Exception:
+                continue
+
+# Fallback: minimal description.
+if not readme_text or len(readme_text) < 100:
+    desc = pubspec.get('description', 'No description')
+    readme_text = f'# {package_name}\n\n{desc}\n\n(README could not be fetched from GitHub.)\n'
+
+# Cap at 8K chars.
+with open(output_file, 'w') as f:
+    f.write(readme_text[:8000])
+
+print(f'README: {len(readme_text[:8000])} bytes', file=sys.stderr)
+" "$PUB_INFO_FILE" "$PACKAGE_NAME" "$README_MD" 2>&1
+
+README_SIZE=$(wc -c < "$README_MD" | tr -d ' ')
+log_event "PUB_DEV" "INFO" "README extracted ($README_SIZE bytes)"
+echo "    README: $README_SIZE bytes"
+
+# ─── Phase 2: Scaffold clean room ─────────────────────────────────────────
+
+echo ""
+echo "--- Scaffolding clean room..."
+
+cat > "$WORKSPACE/pubspec.yaml" << YAML
+name: wrap_test_${PACKAGE_NAME}
+description: Clean room for wrapping ${PACKAGE_NAME}.
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  dart_monty_bridge:
+    path: $BRIDGE_PATH
+  $PACKAGE_NAME: ^$LATEST_VERSION
+
+dev_dependencies:
+  test: ^1.25.0
+  very_good_analysis: ^6.0.0
+YAML
+
+cat > "$WORKSPACE/analysis_options.yaml" << 'YAML'
+include: package:very_good_analysis/analysis_options.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+    strict-raw-types: true
+
+linter:
+  rules:
+    lines_longer_than_80_chars: false
+YAML
+
+log_event "SCAFFOLD" "INFO" "Clean room scaffolded"
+
+echo "--- Running dart pub get..."
+PUB_GET_OUTPUT="$ARTIFACTS/pub_get_output.txt"
+if ! (cd "$WORKSPACE" && dart pub get) > "$PUB_GET_OUTPUT" 2>&1; then
+  echo "ERROR: dart pub get failed" >&2
+  cat "$PUB_GET_OUTPUT" >&2
+  log_event_file "PUB_GET" "ERROR" "dart pub get failed" "$PUB_GET_OUTPUT"
+  exit 2
+fi
+log_event "PUB_GET" "INFO" "dart pub get succeeded"
+echo "    Dependencies resolved."
+
+# ─── Phase 3: Build prompts ───────────────────────────────────────────────
+
+SYSTEM_PROMPT_FILE="$ARTIFACTS/system_prompt.txt"
+cat > "$SYSTEM_PROMPT_FILE" << 'SYSPROMPT'
+You are a Dart plugin code generator. You generate MontyPlugin subclasses that
+wrap Dart/Flutter libraries for use in the Monty Python sandbox.
+
+RULES:
+- Follow the plugin contract EXACTLY (provided below).
+- Generated code must pass `dart analyze --fatal-infos` with zero issues
+  using `very_good_analysis` (strict-casts, strict-raw-types enabled).
+- Generated test file must pass `dart test`.
+- Use only Monty-compatible Python in pythonPrelude (NO for-in, NO f-strings,
+  NO imports, NO list comprehensions, NO try/except, NO range()).
+- Use `while` loops with index for iteration in pythonPrelude.
+- Use string concatenation, not f-strings, in pythonPrelude.
+- Every host function must validate arguments with `is!` checks, throw ArgumentError.
+- No bare `as` casts.
+- No `// ignore:` directives.
+- Return only JSON-safe types from handlers (Map, List, String, int, double, bool, null).
+- Use single quotes for strings (unless the string contains a single quote).
+- Sort dependencies alphabetically in any generated pubspec references.
+- If you need to use classes or enums from the wrapped library in your tests,
+  ensure you add the package import to the test file.
+- In tests, use `final` (not `const`) when extracting values from library
+  enums or objects for handler args.
+
+Output EXACTLY two fenced code blocks with filename hints:
+```dart:lib/src/plugins/<namespace>_plugin.dart
+...code...
+```
+```dart:test/src/plugins/<namespace>_plugin_test.dart
+...code...
+```
+
+PLUGIN CONTRACT:
+SYSPROMPT
+
+cat "$CONTRACT_FILE" >> "$SYSTEM_PROMPT_FILE"
+
+INITIAL_PROMPT_FILE="$ARTIFACTS/initial_prompt.txt"
+python3 -c "
+import sys
+package_name, version, description, readme_file = sys.argv[1:5]
+with open(readme_file) as f:
+    readme = f.read()
+prompt = f'''Generate a MontyPlugin that wraps the \`{package_name}\` library (v{version}).
+
+Package description: {description}
+
+The package is already in pubspec.yaml as a dependency. Import it as:
+\`import 'package:{package_name}/{package_name}.dart';\`
+
+Import the plugin base as:
+\`import 'package:dart_monty_bridge/dart_monty_bridge.dart';\`
+
+The test file should import the plugin as:
+\`import 'package:wrap_test_{package_name}/src/plugins/{package_name}_plugin.dart';\`
+
+Here is the library documentation for API context:
+
+{readme}
+
+Choose the most useful 3-6 functions from the library to expose. Focus on the
+primary use cases shown in the README. Each function MUST be prefixed with
+the namespace you choose.'''
+print(prompt)
+" "$PACKAGE_NAME" "$LATEST_VERSION" "$PACKAGE_DESC" "$README_MD" > "$INITIAL_PROMPT_FILE"
+
+log_event "PROMPT" "INFO" "Prompts built"
+
+# ─── Phase 4: Agentic iteration loop ──────────────────────────────────────
+
+add_turn "user" "$INITIAL_PROMPT_FILE"
+log_convo "user" "$INITIAL_PROMPT_FILE"
+
+PLUGIN_FILE="$WORKSPACE/lib/src/plugins/${PACKAGE_NAME}_plugin.dart"
+TEST_FILE="$WORKSPACE/test/src/plugins/${PACKAGE_NAME}_plugin_test.dart"
+
+START_TIME=$(date +%s)
+FINAL_STATUS="FAILURE"
+ITERATIONS_USED=0
+
+echo ""
+for ITER in $(seq 1 "$MAX_ITERATIONS"); do
+  ITER_START=$(date +%s)
+  ITERATIONS_USED=$ITER
+  echo "=== Iteration $ITER/$MAX_ITERATIONS ==="
+  log_event "ITERATION" "INFO" "Starting iteration $ITER"
+
+  # ── 4a. Call LLM ──
+  echo "    Calling $LLM_PROVIDER/$LLM_MODEL..."
+  LLM_RESPONSE_MD="$ARTIFACTS/iter_${ITER}_response.md"
+
+  if ! call_llm "$LLM_RESPONSE_MD" "$SYSTEM_PROMPT_FILE"; then
+    echo "    ERROR: LLM call failed" >&2
+    log_event "LLM" "ERROR" "Call failed on iteration $ITER"
+    exit 3
+  fi
+
+  RESPONSE_SIZE=$(wc -c < "$LLM_RESPONSE_MD" | tr -d ' ')
+  echo "    Response: $RESPONSE_SIZE bytes"
+  log_event "LLM" "INFO" "Response received ($RESPONSE_SIZE bytes)"
+
+  add_turn "model" "$LLM_RESPONSE_MD"
+  log_convo "model" "$LLM_RESPONSE_MD"
+
+  # ── 4b. Extract code blocks ──
+  ITER_PLUGIN="$ARTIFACTS/iter_${ITER}_plugin.dart"
+  ITER_TEST="$ARTIFACTS/iter_${ITER}_test.dart"
+
+  if ! python3 "$EXTRACTOR" "$LLM_RESPONSE_MD" "$ITER_PLUGIN" "$ITER_TEST"; then
+    echo "    ERROR: Code extraction failed" >&2
+    log_event "EXTRACT" "ERROR" "Failed to extract code blocks on iteration $ITER"
+
+    FIX_PROMPT="$ARTIFACTS/iter_${ITER}_fix_prompt.txt"
+    cat > "$FIX_PROMPT" << 'FIXEOF'
+Your previous response could not be parsed. The script failed to find two
+separate ```dart code blocks.
+
+Please regenerate the code and ensure you follow the output format EXACTLY:
+- One code block for the plugin file, fenced as: ```dart:lib/src/plugins/<name>_plugin.dart
+- One code block for the test file, fenced as: ```dart:test/src/plugins/<name>_plugin_test.dart
+
+Do not add extra explanations outside the code blocks.
+FIXEOF
+    add_turn "user" "$FIX_PROMPT"
+    log_convo "user" "$FIX_PROMPT"
+
+    ITER_END=$(date +%s)
+    append_iteration "$ITER" "$((ITER_END - ITER_START))" "false" "0" "false" "0" "true"
+    echo ""
+    continue
+  fi
+
+  cp "$ITER_PLUGIN" "$PLUGIN_FILE"
+  cp "$ITER_TEST" "$TEST_FILE"
+
+  # ── 4c. Auto-fix then analyze ──
+  # Run dart fix first to resolve trivial lint issues the LLM commonly misses
+  # (const constructors, nullable casts, redundant args, etc.)
+  echo "    Running dart fix..."
+  (cd "$WORKSPACE" && dart fix --apply) > "$ARTIFACTS/iter_${ITER}_fix_output.txt" 2>&1 || true
+  # Also format to catch whitespace/line-length issues.
+  (cd "$WORKSPACE" && dart format .) > /dev/null 2>&1 || true
+
+  echo "    Running dart analyze..."
+  ANALYZE_FILE="$ARTIFACTS/iter_${ITER}_analyze.txt"
+  ANALYZE_EXIT=0
+  (cd "$WORKSPACE" && dart analyze --fatal-infos) > "$ANALYZE_FILE" 2>&1 || ANALYZE_EXIT=$?
+
+  if [[ $ANALYZE_EXIT -ne 0 ]]; then
+    ANALYZE_ERRORS=$(grep -c "error\|warning\|info" "$ANALYZE_FILE" 2>/dev/null || echo "0")
+    echo "    FAIL: dart analyze ($ANALYZE_ERRORS issues)"
+    log_event_file "ANALYZE" "ERROR" "dart analyze failed ($ANALYZE_ERRORS issues)" "$ANALYZE_FILE"
+
+    if check_stuck "$ANALYZE_FILE"; then
+      ITER_END=$(date +%s)
+      append_iteration "$ITER" "$((ITER_END - ITER_START))" "false" "$ANALYZE_ERRORS" "false" "0" "true"
+      break
+    fi
+
+    FIX_PROMPT="$ARTIFACTS/iter_${ITER}_fix_prompt.txt"
+    {
+      echo '`dart analyze --fatal-infos` failed with these issues:'
+      echo ''
+      cat "$ANALYZE_FILE"
+      echo ''
+      echo 'Fix ALL issues. Output the complete updated files (both plugin and test)'
+      echo 'as two fenced code blocks with the same filename format.'
+    } > "$FIX_PROMPT"
+
+    add_turn "user" "$FIX_PROMPT"
+    log_convo "user" "$FIX_PROMPT"
+
+    ITER_END=$(date +%s)
+    append_iteration "$ITER" "$((ITER_END - ITER_START))" "false" "$ANALYZE_ERRORS" "false" "0" "true"
+    echo ""
+    continue
+  fi
+
+  echo "    PASS: dart analyze clean"
+  log_event "ANALYZE" "INFO" "dart analyze passed"
+
+  # ── 4d. dart test ──
+  echo "    Running dart test..."
+  TEST_OUTPUT_FILE="$ARTIFACTS/iter_${ITER}_test_output.txt"
+  TEST_EXIT=0
+  (cd "$WORKSPACE" && dart test) > "$TEST_OUTPUT_FILE" 2>&1 || TEST_EXIT=$?
+
+  if [[ $TEST_EXIT -ne 0 ]]; then
+    TEST_FAILURES=$(grep -c '\-[0-9]' "$TEST_OUTPUT_FILE" 2>/dev/null | tail -1 || echo "0")
+    echo "    FAIL: dart test ($TEST_FAILURES failures)"
+    log_event_file "TEST" "ERROR" "dart test failed" "$TEST_OUTPUT_FILE"
+
+    if check_stuck "$TEST_OUTPUT_FILE"; then
+      ITER_END=$(date +%s)
+      append_iteration "$ITER" "$((ITER_END - ITER_START))" "true" "0" "false" "$TEST_FAILURES" "false"
+      break
+    fi
+
+    FIX_PROMPT="$ARTIFACTS/iter_${ITER}_fix_prompt.txt"
+    {
+      echo '`dart analyze` passed, but `dart test` failed:'
+      echo ''
+      cat "$TEST_OUTPUT_FILE"
+      echo ''
+      echo 'Fix the implementation and/or the tests. Output the complete updated files'
+      echo '(both plugin and test) as two fenced code blocks.'
+    } > "$FIX_PROMPT"
+
+    add_turn "user" "$FIX_PROMPT"
+    log_convo "user" "$FIX_PROMPT"
+
+    ITER_END=$(date +%s)
+    append_iteration "$ITER" "$((ITER_END - ITER_START))" "true" "0" "false" "$TEST_FAILURES" "false"
+    echo ""
+    continue
+  fi
+
+  # ── SUCCESS ──
+  TEST_PASS_COUNT=$(grep -oE '\+[0-9]+' "$TEST_OUTPUT_FILE" 2>/dev/null | tail -1 | tr -d '+' || echo "0")
+  echo "    PASS: dart test ($TEST_PASS_COUNT tests)"
+  log_event "TEST" "INFO" "dart test passed ($TEST_PASS_COUNT tests)"
+
+  ITER_END=$(date +%s)
+  append_iteration "$ITER" "$((ITER_END - ITER_START))" "true" "0" "true" "${TEST_PASS_COUNT:-0}" "false"
+
+  FINAL_STATUS="SUCCESS"
+  break
+done
+
+# ─── Phase 5: Generate reports ─────────────────────────────────────────────
+
+END_TIME=$(date +%s)
+TOTAL_DURATION=$((END_TIME - START_TIME))
+
+echo ""
+echo "================================================="
+
+python3 "$REPORTER" \
+  "$PACKAGE_NAME" \
+  "$LATEST_VERSION" \
+  "$TIMESTAMP" \
+  "$LLM_PROVIDER/$LLM_MODEL" \
+  "$MAX_ITERATIONS" \
+  "$ITERATIONS_USED" \
+  "$TOTAL_DURATION" \
+  "$FINAL_STATUS" \
+  "$RUN_DIR" \
+  "$ITERATIONS_FILE" > "$REPORT_JSON"
+
+{
+  echo "================================================="
+  echo "  Wrap Process Test Report"
+  echo "================================================="
+  echo "Package:     $PACKAGE_NAME v$LATEST_VERSION"
+  echo "LLM:         $LLM_PROVIDER / $LLM_MODEL"
+  echo "Run:         $TIMESTAMP"
+  echo "Duration:    ${TOTAL_DURATION}s"
+  echo "Iterations:  $ITERATIONS_USED / $MAX_ITERATIONS"
+  echo "Status:      $FINAL_STATUS"
+  echo ""
+} > "$REPORT_TXT"
+
+for ITER_NUM in $(seq 1 "$ITERATIONS_USED"); do
+  echo "--- Iteration $ITER_NUM ---" >> "$REPORT_TXT"
+  if [[ -f "$ARTIFACTS/iter_${ITER_NUM}_analyze.txt" ]]; then
+    if grep -q "No issues found" "$ARTIFACTS/iter_${ITER_NUM}_analyze.txt" 2>/dev/null; then
+      echo "  [PASS] dart analyze" >> "$REPORT_TXT"
+    else
+      ISSUES=$(grep -c "error\|warning\|info" "$ARTIFACTS/iter_${ITER_NUM}_analyze.txt" 2>/dev/null || echo "?")
+      echo "  [FAIL] dart analyze: $ISSUES issues" >> "$REPORT_TXT"
+    fi
+  else
+    echo "  [SKIP] dart analyze" >> "$REPORT_TXT"
+  fi
+  if [[ -f "$ARTIFACTS/iter_${ITER_NUM}_test_output.txt" ]]; then
+    if grep -q "All tests passed" "$ARTIFACTS/iter_${ITER_NUM}_test_output.txt" 2>/dev/null; then
+      echo "  [PASS] dart test" >> "$REPORT_TXT"
+    else
+      echo "  [FAIL] dart test" >> "$REPORT_TXT"
+    fi
+  else
+    echo "  [SKIP] dart test" >> "$REPORT_TXT"
+  fi
+  echo "" >> "$REPORT_TXT"
+done
+
+{
+  echo "================================================="
+  echo "  RESULT: $FINAL_STATUS"
+  echo "================================================="
+} >> "$REPORT_TXT"
+
+cat "$REPORT_TXT"
+
+if [[ -f "$PLUGIN_FILE" ]]; then
+  echo ""
+  echo "Plugin: $PLUGIN_FILE"
+  echo "Test:   $TEST_FILE"
+fi
+
+echo ""
+echo "Artifacts: $ARTIFACTS"
+echo "Report:    $REPORT_JSON"
+
+# Show diffs between iterations.
+if [[ $ITERATIONS_USED -gt 1 ]]; then
+  echo ""
+  echo "--- Diffs ---"
+  for i in $(seq 2 "$ITERATIONS_USED"); do
+    PREV=$((i - 1))
+    if [[ -f "$ARTIFACTS/iter_${PREV}_plugin.dart" && -f "$ARTIFACTS/iter_${i}_plugin.dart" ]]; then
+      echo "  iter_${PREV} -> iter_${i} (plugin):"
+      diff -u "$ARTIFACTS/iter_${PREV}_plugin.dart" "$ARTIFACTS/iter_${i}_plugin.dart" \
+        | head -20 || true
+      echo ""
+    fi
+  done
+fi
+
+if [[ "$FINAL_STATUS" == "SUCCESS" ]]; then
+  exit 0
+else
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Automated system that generates MontyPlugin wrappers for arbitrary pub.dev packages using local LLMs (Ollama-first, offline-capable)
- Three-stage pipeline: WRAP (agentic TDD loop) → PRELUDE_LINT (static Monty safety) → MONTY_SMOKE (real interpreter execution)
- Provider-agnostic: supports Ollama, OpenAI-compatible, and Gemini backends
- Validated: `uuid` package wraps successfully in 2-3 iterations with gpt-oss:120b, all wrapper functions execute through real Monty interpreter

## Changes
- **PLUGIN-CONTRACT.md**: Complete MontyPlugin specification (namespace, HostFunction, params, pythonPrelude, testing patterns, worked example)
- **test_wrap_process.sh**: Main harness — scaffolds clean room, calls LLM, extracts code, runs dart fix/analyze/test, iterates on errors, runs add-on pipeline
- **llm_call.py**: Provider-agnostic LLM API caller (Ollama native, OpenAI /v1, Gemini generateContent)
- **extract_code_blocks.py**: Parses LLM markdown to extract plugin + test code blocks
- **lint_prelude.py**: Static linter for pythonPrelude — catches Monty-unsafe Python patterns
- **generate_smoke_test.py**: Generates Dart integration test that runs wrapper functions through real Monty interpreter
- **WRAP-TUTORIAL.md**: Full tutorial documenting the pipeline, env vars, outputs, and design decisions
- **dart_monty_bridge**: Added `pythonPrelude` to MontyPlugin, `combinedPythonPrelude()` to PluginRegistry, MontyCancelledError catch blocks

## Test plan
- [x] `uuid` package: 2 iterations, 10/10 unit tests, 6/6 Monty smoke tests
- [x] Prelude lint catches forbidden patterns (for-in, f-strings, imports)
- [x] Loop detection aborts when model gets stuck on same error
- [x] Provider-aware iteration defaults (ollama=8, openai=5, gemini=3)
- [ ] Test matrix across multiple libraries (path, phone_numbers_parser, collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)