### PR TITLE
refactor(platform): extract MontyCancelRegistry from BaseMontyPlatform

### DIFF
--- a/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
+++ b/packages/dart_monty_ffi/lib/src/native_bindings_ffi.dart
@@ -19,7 +19,7 @@ class NativeBindingsFfi extends NativeBindings {
   /// Dart runtime. No manual path resolution is needed.
   NativeBindingsFfi() {
     _instance ??= this;
-    BaseMontyPlatform.registerNativeCancel(
+    MontyCancelRegistry.registerNativeCancel(
       cancelById: (id) => instanceOrNull?.cancelById(id) ?? false,
       isCancelledById: (id) => instanceOrNull?.isCancelledById(id),
       ensureInitialized: NativeBindingsFfi.ensureInitialized,
@@ -41,17 +41,13 @@ class NativeBindingsFfi extends NativeBindings {
   ///
   /// The [libraryPath] parameter is ignored — with native asset hooks, the
   /// library is resolved automatically by the Dart runtime. It is retained
-  /// for API compatibility with [BaseMontyPlatform.registerNativeCancel].
+  /// for API compatibility with [MontyCancelRegistry.registerNativeCancel].
   static void ensureInitialized([String? libraryPath]) {
     _instance ??= NativeBindingsFfi();
   }
 
   @override
-  int create(
-    String code, {
-    String? externalFunctions,
-    String? scriptName,
-  }) {
+  int create(String code, {String? externalFunctions, String? scriptName}) {
     final cCode = code.toNativeUtf8().cast<Char>();
     final nullChar = nullptr.cast<Char>();
     final cExtFns = externalFunctions != null
@@ -340,11 +336,7 @@ class NativeBindingsFfi extends NativeBindings {
         final resultJson = _readAndFreeString(resultJsonPtr);
         final isError = ffi_native.monty_complete_is_error(ptr);
 
-        return ProgressResult(
-          tag: 0,
-          resultJson: resultJson,
-          isError: isError,
-        );
+        return ProgressResult(tag: 0, resultJson: resultJson, isError: isError);
 
       case ffi_native.MontyProgressTag.MONTY_PROGRESS_PENDING:
         final fnNamePtr = ffi_native.monty_pending_fn_name(ptr);

--- a/packages/dart_monty_platform_interface/lib/dart_monty_platform_interface.dart
+++ b/packages/dart_monty_platform_interface/lib/dart_monty_platform_interface.dart
@@ -6,6 +6,7 @@ library;
 
 export 'src/base_monty_platform.dart';
 export 'src/core_bindings.dart';
+export 'src/monty_cancel_registry.dart';
 export 'src/monty_cancel_token.dart';
 export 'src/monty_error.dart';
 export 'src/monty_exception.dart';

--- a/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_monty_platform_interface/src/core_bindings.dart';
+import 'package:dart_monty_platform_interface/src/monty_cancel_registry.dart';
 import 'package:dart_monty_platform_interface/src/monty_cancel_token.dart';
 import 'package:dart_monty_platform_interface/src/monty_error.dart';
 import 'package:dart_monty_platform_interface/src/monty_exception.dart';
@@ -48,80 +49,46 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   bool _initialized = false;
 
   // ---------------------------------------------------------------------------
-  // Native cancel callbacks (registered by dart_monty_ffi at init time)
+  // Deprecated forwards — use MontyCancelRegistry directly.
   // ---------------------------------------------------------------------------
 
-  static bool Function(int handleId)? _nativeCancelById;
-  static bool? Function(int handleId)? _nativeIsCancelledById;
-  static void Function([String? libraryPath])? _nativeEnsureInitialized;
-
-  /// Register native cancel functions. Called by `dart_monty_ffi` at init.
-  ///
-  /// Since `dart_monty_platform_interface` cannot depend on `dart_monty_ffi`,
-  /// the FFI package registers its cancel callbacks here at construction time.
+  /// Use [MontyCancelRegistry.registerNativeCancel] instead.
+  @Deprecated('Use MontyCancelRegistry.registerNativeCancel')
   static void registerNativeCancel({
     required bool Function(int handleId) cancelById,
     required bool? Function(int handleId) isCancelledById,
     required void Function([String? libraryPath]) ensureInitialized,
-  }) {
-    _nativeCancelById = cancelById;
-    _nativeIsCancelledById = isCancelledById;
-    _nativeEnsureInitialized = ensureInitialized;
-  }
+  }) =>
+      MontyCancelRegistry.registerNativeCancel(
+        cancelById: cancelById,
+        isCancelledById: isCancelledById,
+        ensureInitialized: ensureInitialized,
+      );
 
-  // ---------------------------------------------------------------------------
-  // Web registry for cross-session cancelById
-  // ---------------------------------------------------------------------------
+  /// Use [MontyCancelRegistry.webRegister] instead.
+  @Deprecated('Use MontyCancelRegistry.webRegister')
+  static int webRegister(MontyCoreBindings bindings) =>
+      MontyCancelRegistry.webRegister(bindings);
 
-  static final Map<int, MontyCoreBindings> _webRegistry = {};
-  static int _webNextId = 1;
+  /// Use [MontyCancelRegistry.webUnregister] instead.
+  @Deprecated('Use MontyCancelRegistry.webUnregister')
+  static void webUnregister(int handleId) =>
+      MontyCancelRegistry.webUnregister(handleId);
 
-  /// Register a web bindings instance for cross-session cancel.
-  /// Returns the assigned handle ID.
-  static int webRegister(MontyCoreBindings bindings) {
-    final id = _webNextId++;
-    _webRegistry[id] = bindings;
-    return id;
-  }
+  /// Use [MontyCancelRegistry.cancelById] instead.
+  @Deprecated('Use MontyCancelRegistry.cancelById')
+  static bool cancelById(int handleId) =>
+      MontyCancelRegistry.cancelById(handleId);
 
-  /// Unregister a web bindings instance.
-  static void webUnregister(int handleId) {
-    _webRegistry.remove(handleId);
-  }
+  /// Use [MontyCancelRegistry.ensureInitialized] instead.
+  @Deprecated('Use MontyCancelRegistry.ensureInitialized')
+  static void ensureInitialized([String? libraryPath]) =>
+      MontyCancelRegistry.ensureInitialized(libraryPath);
 
-  // ---------------------------------------------------------------------------
-  // Static cancel API
-  // ---------------------------------------------------------------------------
-
-  /// Cancel a handle by ID. Works cross-platform (native registry or web).
-  ///
-  /// Returns `true` if the handle was found and cancelled.
-  static bool cancelById(int handleId) {
-    if (_nativeCancelById != null) {
-      return _nativeCancelById!(handleId);
-    }
-    return _webCancelById(handleId);
-  }
-
-  static bool _webCancelById(int handleId) {
-    final bindings = _webRegistry[handleId];
-    if (bindings == null) return false;
-    unawaited(bindings.cancel());
-    return true;
-  }
-
-  /// Ensure the native FFI library is loaded. No-op on web.
-  static void ensureInitialized([String? libraryPath]) {
-    _nativeEnsureInitialized?.call(libraryPath);
-  }
-
-  /// Check if a handle is still alive (registered and not freed).
-  static bool isHandleAlive(int handleId) {
-    if (_nativeIsCancelledById != null) {
-      return _nativeIsCancelledById!(handleId) != null;
-    }
-    return _webRegistry.containsKey(handleId);
-  }
+  /// Use [MontyCancelRegistry.isHandleAlive] instead.
+  @Deprecated('Use MontyCancelRegistry.isHandleAlive')
+  static bool isHandleAlive(int handleId) =>
+      MontyCancelRegistry.isHandleAlive(handleId);
 
   @override
   Future<MontyResult> run(
@@ -175,9 +142,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
     assertNotDisposed('resume');
     assertActive('resume');
     try {
-      final progress = await _bindings.resume(
-        json.encode(returnValue),
-      );
+      final progress = await _bindings.resume(json.encode(returnValue));
       return translateProgress(progress);
     } catch (e) {
       markIdle();
@@ -186,15 +151,11 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   }
 
   @override
-  Future<MontyProgress> resumeWithError(
-    String errorMessage,
-  ) async {
+  Future<MontyProgress> resumeWithError(String errorMessage) async {
     assertNotDisposed('resumeWithError');
     assertActive('resumeWithError');
     try {
-      final progress = await _bindings.resumeWithError(
-        errorMessage,
-      );
+      final progress = await _bindings.resumeWithError(errorMessage);
       return translateProgress(progress);
     } catch (e) {
       markIdle();
@@ -298,9 +259,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
         );
       default:
         markIdle();
-        throw StateError(
-          'Unknown progress state: ${p.state}',
-        );
+        throw StateError('Unknown progress state: ${p.state}');
     }
   }
 
@@ -329,9 +288,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
     );
   }
 
-  List<MontyStackFrame> _parseTraceback(
-    List<dynamic>? traceback,
-  ) {
+  List<MontyStackFrame> _parseTraceback(List<dynamic>? traceback) {
     if (traceback == null) return const [];
     return MontyStackFrame.listFromJson(traceback);
   }

--- a/packages/dart_monty_platform_interface/lib/src/monty_cancel_registry.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_cancel_registry.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:dart_monty_platform_interface/src/core_bindings.dart';
+
+/// Cross-platform cancel and handle registry.
+///
+/// Provides static methods for cancelling interpreter handles by ID,
+/// regardless of whether the handle lives in a native FFI isolate or a
+/// web Worker. Native backends register their callbacks via
+/// [registerNativeCancel]; web backends register individual bindings
+/// via [webRegister]/[webUnregister].
+///
+/// This class is stateless — all state is held in static fields scoped
+/// to the current isolate.
+abstract final class MontyCancelRegistry {
+  // ---------------------------------------------------------------------------
+  // Native cancel callbacks (registered by dart_monty_ffi at init time)
+  // ---------------------------------------------------------------------------
+
+  static bool Function(int handleId)? _nativeCancelById;
+  static bool? Function(int handleId)? _nativeIsCancelledById;
+  static void Function([String? libraryPath])? _nativeEnsureInitialized;
+
+  /// Register native cancel functions. Called by `dart_monty_ffi` at init.
+  ///
+  /// Since `dart_monty_platform_interface` cannot depend on `dart_monty_ffi`,
+  /// the FFI package registers its cancel callbacks here at construction time.
+  static void registerNativeCancel({
+    required bool Function(int handleId) cancelById,
+    required bool? Function(int handleId) isCancelledById,
+    required void Function([String? libraryPath]) ensureInitialized,
+  }) {
+    _nativeCancelById = cancelById;
+    _nativeIsCancelledById = isCancelledById;
+    _nativeEnsureInitialized = ensureInitialized;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Web registry for cross-session cancelById
+  // ---------------------------------------------------------------------------
+
+  static final Map<int, MontyCoreBindings> _webRegistry = {};
+  static int _webNextId = 1;
+
+  /// Register a web bindings instance for cross-session cancel.
+  /// Returns the assigned handle ID.
+  static int webRegister(MontyCoreBindings bindings) {
+    final id = _webNextId++;
+    _webRegistry[id] = bindings;
+    return id;
+  }
+
+  /// Unregister a web bindings instance.
+  static void webUnregister(int handleId) {
+    _webRegistry.remove(handleId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public cancel API
+  // ---------------------------------------------------------------------------
+
+  /// Cancel a handle by ID. Works cross-platform (native registry or web).
+  ///
+  /// Returns `true` if the handle was found and cancelled.
+  static bool cancelById(int handleId) {
+    if (_nativeCancelById != null) {
+      return _nativeCancelById!(handleId);
+    }
+    return _webCancelById(handleId);
+  }
+
+  static bool _webCancelById(int handleId) {
+    final bindings = _webRegistry[handleId];
+    if (bindings == null) return false;
+    unawaited(bindings.cancel());
+    return true;
+  }
+
+  /// Ensure the native FFI library is loaded. No-op on web.
+  static void ensureInitialized([String? libraryPath]) {
+    _nativeEnsureInitialized?.call(libraryPath);
+  }
+
+  /// Check if a handle is still alive (registered and not freed).
+  static bool isHandleAlive(int handleId) {
+    if (_nativeIsCancelledById != null) {
+      return _nativeIsCancelledById!(handleId) != null;
+    }
+    return _webRegistry.containsKey(handleId);
+  }
+}

--- a/packages/dart_monty_platform_interface/lib/src/monty_cancel_token.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_cancel_token.dart
@@ -1,4 +1,4 @@
-import 'package:dart_monty_platform_interface/src/base_monty_platform.dart';
+import 'package:dart_monty_platform_interface/src/monty_cancel_registry.dart';
 
 /// Opaque, serializable token for cross-isolate cancel.
 ///
@@ -8,8 +8,8 @@ extension type const MontyCancelToken(int id) {
   /// Cancel the interpreter this token refers to.
   ///
   /// Returns `true` if the handle was found and cancelled.
-  bool cancel() => BaseMontyPlatform.cancelById(id);
+  bool cancel() => MontyCancelRegistry.cancelById(id);
 
   /// Check if the target interpreter handle is still alive.
-  bool get isAlive => BaseMontyPlatform.isHandleAlive(id);
+  bool get isAlive => MontyCancelRegistry.isHandleAlive(id);
 }

--- a/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
+++ b/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
@@ -65,9 +65,7 @@ class _FakeCoreBindings implements MontyCoreBindings {
   }
 
   @override
-  Future<CoreProgressResult> resumeWithError(
-    String errorMessage,
-  ) async {
+  Future<CoreProgressResult> resumeWithError(String errorMessage) async {
     lastErrorMessage = errorMessage;
     if (throwOnResumeWithError != null) throw throwOnResumeWithError!;
     return progressResult!;
@@ -141,11 +139,7 @@ void main() {
 
   group('run()', () {
     test('success returns MontyResult with value and usage', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        value: 42,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, value: 42, usage: usage);
 
       final result = await platform.run('1 + 1');
 
@@ -162,11 +156,7 @@ void main() {
         error: 'division by zero',
         excType: 'ZeroDivisionError',
         traceback: [
-          {
-            'filename': '<test>',
-            'start_line': 1,
-            'start_column': 0,
-          },
+          {'filename': '<test>', 'start_line': 1, 'start_column': 0},
         ],
       );
 
@@ -175,25 +165,14 @@ void main() {
         throwsA(
           isA<MontyException>()
               .having((e) => e.message, 'message', 'division by zero')
-              .having(
-                (e) => e.excType,
-                'excType',
-                'ZeroDivisionError',
-              )
-              .having(
-                (e) => e.traceback,
-                'traceback',
-                hasLength(1),
-              ),
+              .having((e) => e.excType, 'excType', 'ZeroDivisionError')
+              .having((e) => e.traceback, 'traceback', hasLength(1)),
         ),
       );
     });
 
     test('null usage falls back to zero usage', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        value: 'hello',
-      );
+      fake.runResult = const CoreRunResult(ok: true, value: 'hello');
 
       final result = await platform.run('code');
 
@@ -213,10 +192,7 @@ void main() {
     });
 
     test('passes scriptName to bindings', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('code', scriptName: 'math.py');
 
@@ -343,25 +319,20 @@ void main() {
     });
 
     test(
-      'resolve_futures returns MontyResolveFutures '
-      'and marks active',
-      () async {
-        fake.progressResult = const CoreProgressResult(
-          state: 'resolve_futures',
-          pendingCallIds: [1, 2, 3],
-        );
+        'resolve_futures returns MontyResolveFutures '
+        'and marks active', () async {
+      fake.progressResult = const CoreProgressResult(
+        state: 'resolve_futures',
+        pendingCallIds: [1, 2, 3],
+      );
 
-        final progress = await platform.start(
-          'code',
-          externalFunctions: ['fn'],
-        );
+      final progress = await platform.start('code', externalFunctions: ['fn']);
 
-        expect(progress, isA<MontyResolveFutures>());
-        final rf = progress as MontyResolveFutures;
-        expect(rf.pendingCallIds, [1, 2, 3]);
-        expect(platform.isActive, isTrue);
-      },
-    );
+      expect(progress, isA<MontyResolveFutures>());
+      final rf = progress as MontyResolveFutures;
+      expect(rf.pendingCallIds, [1, 2, 3]);
+      expect(platform.isActive, isTrue);
+    });
 
     test('error throws MontyException and marks idle', () async {
       fake.progressResult = const CoreProgressResult(
@@ -374,16 +345,8 @@ void main() {
         () => platform.start('code'),
         throwsA(
           isA<MontyException>()
-              .having(
-                (e) => e.message,
-                'message',
-                'name not defined',
-              )
-              .having(
-                (e) => e.excType,
-                'excType',
-                'NameError',
-              ),
+              .having((e) => e.message, 'message', 'name not defined')
+              .having((e) => e.excType, 'excType', 'NameError'),
         ),
       );
       expect(platform.isIdle, isTrue);
@@ -397,10 +360,7 @@ void main() {
         state: 'pending',
         functionName: 'fn',
       );
-      await platform.start(
-        'code',
-        externalFunctions: ['fn'],
-      );
+      await platform.start('code', externalFunctions: ['fn']);
 
       // Now resume.
       fake.progressResult = const CoreProgressResult(
@@ -418,32 +378,24 @@ void main() {
   });
 
   group('resumeWithError()', () {
-    test(
-      'delegates errorMessage and translates progress',
-      () async {
-        // Enter active state.
-        fake.progressResult = const CoreProgressResult(
-          state: 'pending',
-          functionName: 'fn',
-        );
-        await platform.start(
-          'code',
-          externalFunctions: ['fn'],
-        );
+    test('delegates errorMessage and translates progress', () async {
+      // Enter active state.
+      fake.progressResult = const CoreProgressResult(
+        state: 'pending',
+        functionName: 'fn',
+      );
+      await platform.start('code', externalFunctions: ['fn']);
 
-        // Resume with error -> complete.
-        fake.progressResult = const CoreProgressResult(
-          state: 'complete',
-          usage: usage,
-        );
-        final progress = await platform.resumeWithError(
-          'not found',
-        );
+      // Resume with error -> complete.
+      fake.progressResult = const CoreProgressResult(
+        state: 'complete',
+        usage: usage,
+      );
+      final progress = await platform.resumeWithError('not found');
 
-        expect(fake.lastErrorMessage, 'not found');
-        expect(progress, isA<MontyComplete>());
-      },
-    );
+      expect(fake.lastErrorMessage, 'not found');
+      expect(progress, isA<MontyComplete>());
+    });
   });
 
   group('dispose()', () {
@@ -470,77 +422,50 @@ void main() {
         state: 'pending',
         functionName: 'fn',
       );
-      await platform.start(
-        'code',
-        externalFunctions: ['fn'],
-      );
+      await platform.start('code', externalFunctions: ['fn']);
 
-      expect(
-        () => platform.run('code'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.run('code'), throwsA(isA<StateError>()));
     });
 
     test('resume() while idle throws StateError', () {
-      expect(
-        () => platform.resume(null),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.resume(null), throwsA(isA<StateError>()));
     });
 
     test('resumeWithError() while idle throws StateError', () {
-      expect(
-        () => platform.resumeWithError('err'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.resumeWithError('err'), throwsA(isA<StateError>()));
     });
 
     test('run() after disposed throws StateError', () async {
       await platform.dispose();
 
-      expect(
-        () => platform.run('code'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.run('code'), throwsA(isA<StateError>()));
     });
 
-    test(
-      'start() after disposed throws StateError',
-      () async {
-        await platform.dispose();
+    test('start() after disposed throws StateError', () async {
+      await platform.dispose();
 
-        expect(
-          () => platform.start('code'),
-          throwsA(isA<StateError>()),
-        );
-      },
-    );
+      expect(() => platform.start('code'), throwsA(isA<StateError>()));
+    });
 
-    test(
-      'resume() after disposed throws StateError',
-      () async {
-        await platform.dispose();
-        // Also not active, but disposed check comes first.
-        expect(
-          () => platform.resume(null),
-          throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
-              contains('disposed'),
-            ),
+    test('resume() after disposed throws StateError', () async {
+      await platform.dispose();
+      // Also not active, but disposed check comes first.
+      expect(
+        () => platform.resume(null),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('disposed'),
           ),
-        );
-      },
-    );
+        ),
+      );
+    });
   });
 
   group('limits encoding', () {
     test('null limits passes null to bindings', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('code');
 
@@ -548,25 +473,16 @@ void main() {
     });
 
     test('partial limits encodes JSON subset', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
-      await platform.run(
-        'code',
-        limits: const MontyLimits(memoryBytes: 1024),
-      );
+      await platform.run('code', limits: const MontyLimits(memoryBytes: 1024));
 
       final decoded = json.decode(fake.lastLimitsJson!) as Map<String, dynamic>;
       expect(decoded, {'memory_bytes': 1024});
     });
 
     test('full limits encodes all fields', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run(
         'code',
@@ -615,10 +531,7 @@ void main() {
         usage: usage,
       );
 
-      await platform.start(
-        'code',
-        externalFunctions: ['fn_a', 'fn_b'],
-      );
+      await platform.start('code', externalFunctions: ['fn_a', 'fn_b']);
 
       final decoded = json.decode(fake.lastExtFnsJson!) as List<dynamic>;
       expect(decoded, ['fn_a', 'fn_b']);
@@ -627,10 +540,7 @@ void main() {
 
   group('lazy initialization', () {
     test('first call triggers init', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('code');
 
@@ -638,10 +548,7 @@ void main() {
     });
 
     test('subsequent calls skip init', () async {
-      fake.runResult = const CoreRunResult(
-        ok: true,
-        usage: usage,
-      );
+      fake.runResult = const CoreRunResult(ok: true, usage: usage);
 
       await platform.run('first');
       await platform.run('second');
@@ -652,9 +559,7 @@ void main() {
 
   group('unknown progress state', () {
     test('throws StateError', () async {
-      fake.progressResult = const CoreProgressResult(
-        state: 'bogus',
-      );
+      fake.progressResult = const CoreProgressResult(state: 'bogus');
 
       await expectLater(
         () => platform.start('code'),
@@ -685,10 +590,7 @@ void main() {
       expect(platform.isActive, isTrue);
 
       // A second concurrent run() should fail with StateError.
-      expect(
-        () => platform.run('second'),
-        throwsA(isA<StateError>()),
-      );
+      expect(() => platform.run('second'), throwsA(isA<StateError>()));
 
       // Release the gate so the first run completes.
       gate.complete();
@@ -698,10 +600,7 @@ void main() {
     });
 
     test('run() returns to idle after error', () async {
-      fake.runResult = const CoreRunResult(
-        ok: false,
-        error: 'boom',
-      );
+      fake.runResult = const CoreRunResult(ok: false, error: 'boom');
 
       await expectLater(
         () => platform.run('code'),
@@ -710,22 +609,24 @@ void main() {
       expect(platform.isIdle, isTrue);
     });
 
-    test('start() marks active before await — concurrent start() throws',
-        () async {
-      fake.progressResult = const CoreProgressResult(
-        state: 'complete',
-        usage: zeroUsage,
-      );
+    test(
+      'start() marks active before await — concurrent start() throws',
+      () async {
+        fake.progressResult = const CoreProgressResult(
+          state: 'complete',
+          usage: zeroUsage,
+        );
 
-      // start() should mark active synchronously.
-      final first = platform.start('first');
-      // Can't easily test concurrency here since fake is synchronous,
-      // but we verify the state IS active before start returns.
-      // The real proof is the run() test above with the gate.
-      final result = await first;
-      expect(result, isA<MontyComplete>());
-      expect(platform.isIdle, isTrue);
-    });
+        // start() should mark active synchronously.
+        final first = platform.start('first');
+        // Can't easily test concurrency here since fake is synchronous,
+        // but we verify the state IS active before start returns.
+        // The real proof is the run() test above with the gate.
+        final result = await first;
+        expect(result, isA<MontyComplete>());
+        expect(platform.isIdle, isTrue);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -775,22 +676,19 @@ void main() {
     });
   });
 
-  group('static cancel API', () {
+  group('static cancel API (MontyCancelRegistry)', () {
     tearDown(() {
       // Reset static state after each test.
-      BaseMontyPlatform.registerNativeCancel(
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (_) => false,
         isCancelledById: (_) => null,
         ensureInitialized: ([_]) {},
       );
-      // Clean up any web registry entries by unregistering.
-      // (We can't access _webRegistry directly, but tests below manage
-      // their own entries.)
     });
 
     test('registerNativeCancel stores callbacks and cancelById uses them', () {
       var cancelledId = -1;
-      BaseMontyPlatform.registerNativeCancel(
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (id) {
           cancelledId = id;
           return true;
@@ -798,56 +696,55 @@ void main() {
         isCancelledById: (_) => false,
         ensureInitialized: ([_]) {},
       );
-      final result = BaseMontyPlatform.cancelById(99);
+      final result = MontyCancelRegistry.cancelById(99);
       expect(result, isTrue);
       expect(cancelledId, 99);
     });
 
     test('webRegister/webUnregister manage web registry', () {
       final webFake = _FakeCoreBindings();
-      final webId = BaseMontyPlatform.webRegister(webFake);
+      final webId = MontyCancelRegistry.webRegister(webFake);
       expect(webId, greaterThan(0));
 
-      // Verify registered via isHandleAlive (web path checks _webRegistry).
       // Reset native so isHandleAlive falls through to web registry.
-      BaseMontyPlatform.registerNativeCancel(
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (_) => false,
         isCancelledById: (_) => null,
         ensureInitialized: ([_]) {},
       );
 
-      BaseMontyPlatform.webUnregister(webId);
+      MontyCancelRegistry.webUnregister(webId);
     });
 
     test('webRegister returns incrementing IDs', () {
-      final id1 = BaseMontyPlatform.webRegister(_FakeCoreBindings());
-      final id2 = BaseMontyPlatform.webRegister(_FakeCoreBindings());
+      final id1 = MontyCancelRegistry.webRegister(_FakeCoreBindings());
+      final id2 = MontyCancelRegistry.webRegister(_FakeCoreBindings());
       expect(id2, greaterThan(id1));
-      BaseMontyPlatform.webUnregister(id1);
-      BaseMontyPlatform.webUnregister(id2);
+      MontyCancelRegistry.webUnregister(id1);
+      MontyCancelRegistry.webUnregister(id2);
     });
 
     test('ensureInitialized invokes registered callback', () {
       var called = false;
-      BaseMontyPlatform.registerNativeCancel(
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (_) => false,
         isCancelledById: (_) => null,
         ensureInitialized: ([_]) {
           called = true;
         },
       );
-      BaseMontyPlatform.ensureInitialized();
+      MontyCancelRegistry.ensureInitialized();
       expect(called, isTrue);
     });
 
     test('isHandleAlive delegates to native callback', () {
-      BaseMontyPlatform.registerNativeCancel(
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (_) => false,
         isCancelledById: (id) => id == 42 ? false : null,
         ensureInitialized: ([_]) {},
       );
-      expect(BaseMontyPlatform.isHandleAlive(42), isTrue);
-      expect(BaseMontyPlatform.isHandleAlive(999), isFalse);
+      expect(MontyCancelRegistry.isHandleAlive(42), isTrue);
+      expect(MontyCancelRegistry.isHandleAlive(999), isFalse);
     });
   });
 
@@ -890,10 +787,7 @@ void main() {
       // Now make resume() throw.
       fake.throwOnResume = Exception('FFI crash');
 
-      await expectLater(
-        () => platform.resume(42),
-        throwsA(isA<Exception>()),
-      );
+      await expectLater(() => platform.resume(42), throwsA(isA<Exception>()));
       expect(
         platform.isIdle,
         isTrue,

--- a/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
+++ b/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
@@ -43,62 +43,68 @@ void main() {
       );
     });
 
-    test('Python ZeroDivisionError maps to MontyException (not sealed)',
-        () async {
-      final bindings = _FakeCoreBindings();
-      final platform = _TestPlatform(bindings: bindings);
+    test(
+      'Python ZeroDivisionError maps to MontyException (not sealed)',
+      () async {
+        final bindings = _FakeCoreBindings();
+        final platform = _TestPlatform(bindings: bindings);
 
-      bindings.nextRunResult = const CoreRunResult(
-        ok: false,
-        error: 'division by zero',
-        excType: 'ZeroDivisionError',
-      );
+        bindings.nextRunResult = const CoreRunResult(
+          ok: false,
+          error: 'division by zero',
+          excType: 'ZeroDivisionError',
+        );
 
-      await expectLater(
-        platform.run('code'),
-        throwsA(
-          isA<MontyException>().having(
-            (e) => e.excType,
-            'excType',
-            'ZeroDivisionError',
+        await expectLater(
+          platform.run('code'),
+          throwsA(
+            isA<MontyException>().having(
+              (e) => e.excType,
+              'excType',
+              'ZeroDivisionError',
+            ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
 
-    test('progress error with KeyboardInterrupt maps to MontyCancelledError',
-        () async {
-      final bindings = _FakeCoreBindings();
-      final platform = _TestPlatform(bindings: bindings);
+    test(
+      'progress error with KeyboardInterrupt maps to MontyCancelledError',
+      () async {
+        final bindings = _FakeCoreBindings();
+        final platform = _TestPlatform(bindings: bindings);
 
-      bindings.nextStartResult = const CoreProgressResult(
-        state: 'error',
-        error: 'Execution cancelled',
-        excType: 'KeyboardInterrupt',
-      );
+        bindings.nextStartResult = const CoreProgressResult(
+          state: 'error',
+          error: 'Execution cancelled',
+          excType: 'KeyboardInterrupt',
+        );
 
-      await expectLater(
-        platform.start('code'),
-        throwsA(isA<MontyCancelledError>()),
-      );
-    });
+        await expectLater(
+          platform.start('code'),
+          throwsA(isA<MontyCancelledError>()),
+        );
+      },
+    );
 
-    test('progress error with MemoryLimitExceeded maps to MontyResourceError',
-        () async {
-      final bindings = _FakeCoreBindings();
-      final platform = _TestPlatform(bindings: bindings);
+    test(
+      'progress error with MemoryLimitExceeded maps to MontyResourceError',
+      () async {
+        final bindings = _FakeCoreBindings();
+        final platform = _TestPlatform(bindings: bindings);
 
-      bindings.nextStartResult = const CoreProgressResult(
-        state: 'error',
-        error: 'Memory limit exceeded',
-        excType: 'MemoryLimitExceeded',
-      );
+        bindings.nextStartResult = const CoreProgressResult(
+          state: 'error',
+          error: 'Memory limit exceeded',
+          excType: 'MemoryLimitExceeded',
+        );
 
-      await expectLater(
-        platform.start('code'),
-        throwsA(isA<MontyResourceError>()),
-      );
-    });
+        await expectLater(
+          platform.start('code'),
+          throwsA(isA<MontyResourceError>()),
+        );
+      },
+    );
   });
 
   group('exhaustive switch compiles', () {
@@ -128,8 +134,10 @@ void main() {
     });
 
     test('MontyScriptError preserves excType', () {
-      const error =
-          MontyScriptError('division by zero', excType: 'ZeroDivisionError');
+      const error = MontyScriptError(
+        'division by zero',
+        excType: 'ZeroDivisionError',
+      );
       expect(error.excType, 'ZeroDivisionError');
       expect(error.message, 'division by zero');
     });
@@ -158,10 +166,7 @@ void main() {
 
     test('MontyCrashError default message', () {
       const e = MontyCrashError();
-      expect(
-        e.toString(),
-        'MontyCrashError: Interpreter crashed unexpectedly',
-      );
+      expect(e.toString(), 'MontyCrashError: Interpreter crashed unexpectedly');
     });
 
     test('MontyDisposedError default message', () {
@@ -181,16 +186,16 @@ void main() {
   group('MontyCancelToken', () {
     tearDown(() {
       // Reset native callbacks.
-      BaseMontyPlatform.registerNativeCancel(
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (_) => false,
         isCancelledById: (_) => null,
         ensureInitialized: ([_]) {},
       );
     });
 
-    test('cancel delegates to BaseMontyPlatform.cancelById', () {
+    test('cancel delegates to MontyCancelRegistry.cancelById', () {
       var cancelledId = -1;
-      BaseMontyPlatform.registerNativeCancel(
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (id) {
           cancelledId = id;
           return true;
@@ -204,8 +209,8 @@ void main() {
       expect(cancelledId, 42);
     });
 
-    test('isAlive delegates to BaseMontyPlatform.isHandleAlive', () {
-      BaseMontyPlatform.registerNativeCancel(
+    test('isAlive delegates to MontyCancelRegistry.isHandleAlive', () {
+      MontyCancelRegistry.registerNativeCancel(
         cancelById: (_) => false,
         isCancelledById: (id) => id == 7 ? false : null,
         ensureInitialized: ([_]) {},

--- a/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_core_bindings.dart
@@ -10,7 +10,7 @@ import 'package:dart_monty_wasm/src/wasm_bindings.dart';
 /// Provides synthetic [MontyResourceUsage] with Dart-side wall-clock
 /// timing since the WASM bridge does not expose `ResourceTracker`.
 ///
-/// Registers in [BaseMontyPlatform.webRegister] at init for cross-session
+/// Registers in [MontyCancelRegistry.webRegister] at init for cross-session
 /// `cancelById` support on web.
 ///
 /// ```dart
@@ -32,7 +32,7 @@ class WasmCoreBindings implements MontyCoreBindings {
   Future<bool> init() async {
     if (_sessionId != null) return true;
     _sessionId = await _bindings.createSession();
-    _handleId = BaseMontyPlatform.webRegister(this);
+    _handleId = MontyCancelRegistry.webRegister(this);
     return true;
   }
 
@@ -164,7 +164,7 @@ class WasmCoreBindings implements MontyCoreBindings {
     // Worker is terminated — unregister and clear state so init() can
     // spawn a new one without leaking the handle ID in the platform registry.
     if (_handleId != null) {
-      BaseMontyPlatform.webUnregister(_handleId!);
+      MontyCancelRegistry.webUnregister(_handleId!);
       _handleId = null;
     }
     _sessionId = null;
@@ -173,7 +173,7 @@ class WasmCoreBindings implements MontyCoreBindings {
   @override
   Future<void> dispose() async {
     if (_handleId != null) {
-      BaseMontyPlatform.webUnregister(_handleId!);
+      MontyCancelRegistry.webUnregister(_handleId!);
       _handleId = null;
     }
     if (_sessionId != null) {
@@ -187,10 +187,10 @@ class WasmCoreBindings implements MontyCoreBindings {
   // ---------------------------------------------------------------------------
 
   static MontyResourceUsage _makeUsage(int elapsedMs) => MontyResourceUsage(
-        memoryBytesUsed: 0,
-        timeElapsedMs: elapsedMs,
-        stackDepthUsed: 0,
-      );
+    memoryBytesUsed: 0,
+    timeElapsedMs: elapsedMs,
+    stackDepthUsed: 0,
+  );
 
   CoreRunResult _translateRunResult(WasmRunResult result, int elapsedMs) {
     if (result.ok) {


### PR DESCRIPTION
## Summary
- Extract static cancel/web registry methods from `BaseMontyPlatform` into dedicated `MontyCancelRegistry` class
- Leave `@Deprecated` forwarding stubs on `BaseMontyPlatform` for backward compatibility
- Migrate all first-party consumers to use `MontyCancelRegistry` directly

## Changes
- **New `monty_cancel_registry.dart`**: `abstract final class MontyCancelRegistry` with `cancelById`, `isHandleAlive`, `webRegister`, `webUnregister`, `registerNativeCancel`, `ensureInitialized`
- **`BaseMontyPlatform`**: 6 static methods replaced with `@Deprecated` forwards
- **`MontyCancelToken`**: calls `MontyCancelRegistry` instead of `BaseMontyPlatform`
- **`WasmCoreBindings`**: `webRegister`/`webUnregister` calls migrated
- **`NativeBindingsFfi`**: `registerNativeCancel` call migrated
- **Tests**: all static cancel API references updated
- **Barrel**: `monty_cancel_registry.dart` added to exports

## Test plan
- [x] `dart analyze --fatal-infos` zero issues (platform_interface + bridge)
- [x] 347 platform_interface tests pass
- [x] 100 bridge tests pass
- [x] `dart format` clean
- [x] Deprecated forwards ensure third-party consumers are not broken