### PR TITLE
refactor(bridge): plugin consolidation + pub.dev publishing

### DIFF
--- a/packages/dart_monty_bridge/pubspec.yaml
+++ b/packages/dart_monty_bridge/pubspec.yaml
@@ -20,7 +20,3 @@ dependencies:
 dev_dependencies:
   test: ^1.25.0
   very_good_analysis: ^10.0.0
-
-dependency_overrides:
-  dart_monty_platform_interface:
-    path: ../dart_monty_platform_interface


### PR DESCRIPTION
## Summary
- Remove deprecated `HostFunctionRegistry` (zero consumers) and barrel export
- Harden `PluginRegistry.disposeAll()` and `attachTo()` — collect errors instead of stopping on first failure
- Prepare `dart_monty_bridge` for pub.dev publishing (LICENSE, README, hosted struct_log dep, remove dependency_overrides)
- Fix `dart_monty_wasm` pubspec version mismatch (0.7.0 → 0.8.0)

## Changes
- **dart_monty_bridge**: Delete `host_function_registry.dart`, harden error collection, add LICENSE/README, replace git dep with `struct_log: ^0.1.0`, remove `dependency_overrides`. Bump 0.2.2 → 0.3.0. **Published to pub.dev.**
- **dart_monty_wasm**: Bump pubspec 0.7.0 → 0.8.0 to match CHANGELOG

## Test plan
- [x] 107 bridge tests pass (3 new: dispose/attach error collection)
- [x] `dart analyze --fatal-infos` clean on bridge
- [x] `dart pub publish --dry-run` passes with 0 warnings
- [x] Published to pub.dev as 0.3.0