### PR TITLE
chore: align all package versions for release

### DIFF
--- a/packages/dart_monty_mcp/LICENSE
+++ b/packages/dart_monty_mcp/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 runyaga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/dart_monty_mcp/pubspec.yaml
+++ b/packages/dart_monty_mcp/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_mcp
 description: MCP server exposing the Monty Python interpreter as tools.
-version: 0.1.0
+version: 0.1.1
 publish_to: none
 repository: https://github.com/runyaga/dart_monty
 

--- a/packages/dart_monty_native/CHANGELOG.md
+++ b/packages/dart_monty_native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+
+- Update `dart_monty_ffi` dependency constraint to `^0.8.0`
+
 ## 0.7.1
 
 - Suppress `MontyPlatform.instance` deprecation in `registerWith()` (federated plugin registration requires the singleton)

--- a/packages/dart_monty_native/pubspec.yaml
+++ b/packages/dart_monty_native/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_native
 description: Native plugin for dart_monty (replaces dart_monty_desktop). Pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,7 +15,7 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  dart_monty_ffi: ^0.7.0
+  dart_monty_ffi: ^0.8.0
   dart_monty_platform_interface: ^0.7.0
   flutter:
     sdk: flutter

--- a/packages/dart_monty_web/CHANGELOG.md
+++ b/packages/dart_monty_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+
+- Update `dart_monty_wasm` dependency constraint to `^0.8.0`
+
 ## 0.7.1
 
 - Suppress `MontyPlatform.instance` deprecation in `registerWith()` (federated plugin registration requires the singleton)

--- a/packages/dart_monty_web/pubspec.yaml
+++ b/packages/dart_monty_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_web
 description: Flutter web plugin for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
   dart_monty_platform_interface: ^0.7.0
-  dart_monty_wasm: ^0.7.0
+  dart_monty_wasm: ^0.8.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/monty_cli/LICENSE
+++ b/packages/monty_cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 runyaga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/monty_cli/pubspec.yaml
+++ b/packages/monty_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: monty_cli
 description: Standalone CLI for dart_monty — run, eval, and REPL for the Monty sandboxed Python interpreter.
-version: 0.1.0
+version: 0.1.1
 publish_to: none
 repository: https://github.com/runyaga/dart_monty
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.7.0
+version: 0.8.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues


### PR DESCRIPTION
## Summary
- Align all pubspec versions with their CHANGELOGs
- Fix dependency constraints that referenced old versions
- Add missing LICENSE files

## Changes
| Package | Old | New | Change |
|---------|-----|-----|--------|
| **root dart_monty** | 0.7.0 | 0.8.0 | Match CHANGELOG |
| **dart_monty_native** | 0.7.1 | 0.7.2 | ffi constraint `^0.7.0` → `^0.8.0` |
| **dart_monty_web** | 0.7.1 | 0.7.2 | wasm constraint `^0.7.0` → `^0.8.0` |
| **dart_monty_mcp** | 0.1.0 | 0.1.1 | Match CHANGELOG, add LICENSE |
| **monty_cli** | 0.1.0 | 0.1.1 | Match CHANGELOG, add LICENSE |

## Already aligned (no changes)
- dart_monty_platform_interface: 0.7.1
- dart_monty_ffi: 0.8.0
- dart_monty_wasm: 0.8.0
- dart_monty_bridge: 0.3.0

## Test plan
- [x] All pubspec versions match CHANGELOG top entries (verified via script)
- [x] 347 platform_interface tests pass
- [ ] CI validates Flutter packages