### PR TITLE
chore: bump all package versions for pub.dev release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.8.1
+
+- Fix CI release workflow: add WASM build step, remove broken AOT compilation
+- Align all package versions and dependency constraints for clean pub.dev release
+- Add `dart_monty_bridge` publish workflow
+- Update release documentation in CLAUDE.md and CONTRIBUTING.md
+
 ## 0.8.0
 
 - **dart_monty_mcp** (0.1.0) — new MCP server package: 5 built-in tools, host function/plugin system, session persistence, 68 unit tests, docs

--- a/packages/dart_monty_bridge/CHANGELOG.md
+++ b/packages/dart_monty_bridge/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.1
+
+- Remove `dependency_overrides` for clean pub.dev publishing
+- Switch `struct_log` from git dependency to `^0.1.0` hosted
+
 ## 0.3.0
 
 - **BREAKING**: Remove deprecated `HostFunctionRegistry` class and barrel export.

--- a/packages/dart_monty_bridge/pubspec.yaml
+++ b/packages/dart_monty_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_bridge
 description: High-level bridge layer for dart_monty. Host functions, event loop, plugin system.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_ffi/CHANGELOG.md
+++ b/packages/dart_monty_ffi/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.1
+
+- Align version with pub.dev (0.8.0 was not successfully published)
+- Update platform_interface dependency constraint to `^0.7.0`
+
 ## 0.8.0
 
 - **BREAKING**: Migrate from `DynamicLibrary.open()` to `@Native` annotations with Dart native build hooks

--- a/packages/dart_monty_ffi/pubspec.yaml
+++ b/packages/dart_monty_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_ffi
 description: Native FFI backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_native/CHANGELOG.md
+++ b/packages/dart_monty_native/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3
+
+- Update `dart_monty_ffi` dependency constraint to `^0.8.1`
+
 ## 0.7.2
 
 - Update `dart_monty_ffi` dependency constraint to `^0.8.0`

--- a/packages/dart_monty_native/pubspec.yaml
+++ b/packages/dart_monty_native/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_native
 description: Native plugin for dart_monty (replaces dart_monty_desktop). Pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.2
+version: 0.7.3
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,7 +15,7 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  dart_monty_ffi: ^0.8.0
+  dart_monty_ffi: ^0.8.1
   dart_monty_platform_interface: ^0.7.0
   flutter:
     sdk: flutter

--- a/packages/dart_monty_platform_interface/CHANGELOG.md
+++ b/packages/dart_monty_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.2
+
+- Extract `monty_backend_spi.dart` SPI sub-library for backend implementers
+- Deprecate `MontyPlatform.instance` singleton (kept as fallback, removal in 1.0)
+- Align version with dependency constraints across all packages
+
 ## 0.7.1
 
 - Deprecate `MontyPlatform.instance` singleton getter/setter (kept as fallback; will be removed in 1.0)

--- a/packages/dart_monty_platform_interface/pubspec.yaml
+++ b/packages/dart_monty_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_platform_interface
 description: Platform interface for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_wasm/CHANGELOG.md
+++ b/packages/dart_monty_wasm/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+- Align version and dependency constraints for clean pub.dev release
+
 ## 0.8.0
 
 - **BREAKING**: Replace NAPI-RS runtime with direct C-ABI calls to 28 exported Rust functions via `wasm32-wasip1`

--- a/packages/dart_monty_wasm/pubspec.yaml
+++ b/packages/dart_monty_wasm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_wasm
 description: WASM backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_web/CHANGELOG.md
+++ b/packages/dart_monty_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.3
+
+- Update `dart_monty_wasm` dependency constraint to `^0.8.1`
+
 ## 0.7.2
 
 - Update `dart_monty_wasm` dependency constraint to `^0.8.0`

--- a/packages/dart_monty_web/pubspec.yaml
+++ b/packages/dart_monty_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_web
 description: Flutter web plugin for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.2
+version: 0.7.3
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -16,7 +16,7 @@ environment:
 
 dependencies:
   dart_monty_platform_interface: ^0.7.0
-  dart_monty_wasm: ^0.8.0
+  dart_monty_wasm: ^0.8.1
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,9 +15,9 @@ environment:
   flutter: '>=3.19.0'
 
 dependencies:
-  dart_monty_native: ^0.7.0
-  dart_monty_platform_interface: ^0.7.0
-  dart_monty_web: ^0.7.0
+  dart_monty_native: ^0.7.3
+  dart_monty_platform_interface: ^0.7.2
+  dart_monty_web: ^0.7.3
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
## Summary
- Bump all 7 published packages to new patch versions for clean pub.dev release
- Update dependency constraints to match new versions
- Update CHANGELOGs for each package

## Version bumps

| Package | Old | New |
|---------|-----|-----|
| `dart_monty_platform_interface` | 0.7.1 | 0.7.2 |
| `dart_monty_ffi` | 0.8.0 | 0.8.1 |
| `dart_monty_wasm` | 0.8.0 | 0.8.1 |
| `dart_monty_bridge` | 0.3.0 | 0.3.1 |
| `dart_monty_web` | 0.7.2 | 0.7.3 |
| `dart_monty_native` | 0.7.2 | 0.7.3 |
| `dart_monty` | 0.8.0 | 0.8.1 |

## Post-merge: tag and publish in order

```bash
git tag platform_interface-v0.7.2 && git push origin platform_interface-v0.7.2
# wait...
git tag ffi-v0.8.1 wasm-v0.8.1 bridge-v0.3.1 && git push origin ffi-v0.8.1 wasm-v0.8.1 bridge-v0.3.1
# wait...
git tag web-v0.7.3 native-v0.7.3 && git push origin web-v0.7.3 native-v0.7.3
# wait...
git tag v0.8.1 && git push origin v0.8.1
```

## Test plan
- [x] All pubspec versions match CHANGELOG headings
- [x] Dependency constraints reference new versions
- [x] platform_interface tests pass
- [ ] Push tags in dependency order after merge