### PR TITLE
fix(ci): replace deprecated macos-13 runner, fix release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,10 @@ jobs:
             label: linux-arm64
             target: aarch64-unknown-linux-gnu
             cross: true
-          - os: macos-13
+          - os: macos-14
             ext: dylib
             label: macos-x64
+            target: x86_64-apple-darwin
           - os: macos-14
             ext: dylib
             label: macos-arm64


### PR DESCRIPTION
## Summary
- Replace deprecated `macos-13` runner with `macos-14` + cross-compile target `x86_64-apple-darwin` for macos-x64 builds

## Context
`v0.8.1` release had two issues:
1. `macos-13` runner no longer available (failed with "configuration not supported")
2. `pub-dev` environment doesn't allow `v*` tags (separate fix in GitHub Settings)

## Test plan
- [ ] Re-tag v0.8.1 after merge + environment fix to verify full release