### PR TITLE
chore: release 0.9.0 — pure Dart + WASM fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **`Monty()` convenience class** — auto-selects native (FFI) or web (WASM) backend via `dart.library.ffi` / `dart.library.js_interop`
 - **Zero-arg constructors** — `MontyFfi()`, `MontyNative()`, `MontyWasm()` now default to production bindings
 - **`Monty.withPlatform()`** — explicit backend injection for testing or custom bindings
+- **Fix**: WASM bindings use static method API matching JS bridge (was broken since Worker pool refactor)
 - SDK constraint raised to `^3.10.0`
 
 ## 0.8.1

--- a/packages/dart_monty_wasm/CHANGELOG.md
+++ b/packages/dart_monty_wasm/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 0.9.0
+## 0.8.2
 
+- **Fix**: `WasmBindingsJs` now uses static method bindings matching the JS bridge API (was broken: tried to call `new DartMontyBridge()` which doesn't exist)
 - Make `bindings` parameter optional on `MontyWasm()` — defaults to `WasmBindingsJs()`
-- No API changes for existing callers using explicit bindings
+- Add `_ensureInit()` to guarantee default Worker session exists before any operation
 
 ## 0.8.1
 

--- a/packages/dart_monty_wasm/pubspec.yaml
+++ b/packages/dart_monty_wasm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_wasm
 description: WASM backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   dart_monty_ffi: ^0.8.1
   dart_monty_platform_interface: ^0.7.2
-  dart_monty_wasm: ^0.7.1
+  dart_monty_wasm: ^0.8.2
 
 dev_dependencies:
   test: ^1.25.0


### PR DESCRIPTION
## Summary
- Bump `dart_monty_wasm` to 0.8.2 (static bindings fix)
- Update root `dart_monty` dep to `dart_monty_wasm: ^0.8.2`
- Update changelogs for 0.9.0 release

## Release plan (after merge)
1. Tag `wasm-v0.8.2` → publishes `dart_monty_wasm` 0.8.2 to pub.dev
2. Tag `v0.9.0` → publishes `dart_monty` 0.9.0 to pub.dev

## Test plan
- [x] All pre-commit hooks pass
- [x] Version and changelog alignment verified