### PR TITLE
fix(wasm): conditional import for VM test compatibility

### DIFF
--- a/packages/dart_monty_wasm/lib/dart_monty_wasm.dart
+++ b/packages/dart_monty_wasm/lib/dart_monty_wasm.dart
@@ -3,5 +3,6 @@ library;
 
 export 'src/monty_wasm.dart';
 export 'src/wasm_bindings.dart';
-export 'src/wasm_bindings_js.dart';
+export 'src/wasm_bindings_js_stub.dart'
+    if (dart.library.js_interop) 'src/wasm_bindings_js.dart';
 export 'src/wasm_core_bindings.dart';

--- a/packages/dart_monty_wasm/lib/src/monty_wasm.dart
+++ b/packages/dart_monty_wasm/lib/src/monty_wasm.dart
@@ -3,7 +3,8 @@ import 'dart:typed_data';
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
 import 'package:dart_monty_platform_interface/monty_backend_spi.dart';
 import 'package:dart_monty_wasm/src/wasm_bindings.dart';
-import 'package:dart_monty_wasm/src/wasm_bindings_js.dart';
+import 'package:dart_monty_wasm/src/wasm_bindings_js_stub.dart'
+    if (dart.library.js_interop) 'package:dart_monty_wasm/src/wasm_bindings_js.dart';
 import 'package:dart_monty_wasm/src/wasm_core_bindings.dart';
 
 /// Web WASM implementation of [MontyPlatform].

--- a/packages/dart_monty_wasm/lib/src/wasm_bindings_js_stub.dart
+++ b/packages/dart_monty_wasm/lib/src/wasm_bindings_js_stub.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+
+import 'package:dart_monty_wasm/src/wasm_bindings.dart';
+
+/// VM stub for [WasmBindingsJs].
+///
+/// On non-web platforms `dart:js_interop` is unavailable, so this stub
+/// provides the same class name so that the conditional import in
+/// `monty_wasm.dart` compiles. The constructor throws immediately — tests
+/// always inject a mock, so this path is never reached.
+class WasmBindingsJs extends WasmBindings {
+  /// Throws [UnsupportedError] — only available on web.
+  WasmBindingsJs() {
+    throw UnsupportedError(
+      'WasmBindingsJs requires dart:js_interop (web only)',
+    );
+  }
+
+  @override
+  Future<bool> init() => throw UnimplementedError();
+
+  @override
+  Future<int> createSession() => throw UnimplementedError();
+
+  @override
+  Future<void> disposeSession(int sessionId) => throw UnimplementedError();
+
+  @override
+  Future<WasmRunResult> run(
+    String code, {
+    String? limitsJson,
+    String? scriptName,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> start(
+    String code, {
+    String? extFnsJson,
+    String? limitsJson,
+    String? scriptName,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> resume(String valueJson) =>
+      throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> resumeWithError(String errorMessage) =>
+      throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> resumeAsFuture() => throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  ) => throw UnimplementedError();
+
+  @override
+  Future<Uint8List> snapshot() => throw UnimplementedError();
+
+  @override
+  Future<void> restore(Uint8List data) => throw UnimplementedError();
+
+  @override
+  Future<void> cancel() => throw UnimplementedError();
+
+  @override
+  Future<WasmDiscoverResult> discover() => throw UnimplementedError();
+
+  @override
+  Future<void> dispose() => throw UnimplementedError();
+}


### PR DESCRIPTION
## Summary
- Add VM stub for `WasmBindingsJs` with conditional import so `dart:js_interop` is not loaded on the Dart VM
- Fixes CI publish failure: `monty_wasm_test.dart` couldn't compile on VM after the zero-arg constructor change

## Changes
- **wasm_bindings_js_stub.dart**: New VM stub — constructor throws `UnsupportedError`, all methods throw `UnimplementedError`
- **monty_wasm.dart**: Conditional import — stub on VM, real JS bindings on web
- **dart_monty_wasm.dart**: Matching conditional export in barrel file

## Test plan
- [x] `dart test` passes locally (110 tests, 0 failures)
- [x] `dart analyze --fatal-infos` clean
- [x] `dart format` clean
- [x] Gemini 3.1 Pro review: all 5 criteria PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)