### PR TITLE
chore: remove stale wasi-worker-browser.mjs references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,9 @@ cd example/web && dart pub get
 dart compile js bin/main.dart -o web/main.dart.js
 cp ../../packages/dart_monty_wasm/assets/dart_monty_bridge.js web/
 cp ../../packages/dart_monty_wasm/assets/dart_monty_worker.js web/
-cp ../../packages/dart_monty_wasm/assets/wasi-worker-browser.mjs web/
 cp ../../packages/dart_monty_wasm/assets/*.wasm web/
 
-# Serve with COOP/COEP headers (required for SharedArrayBuffer)
+# Serve with COOP/COEP headers
 python3 -c "
 import http.server, functools
 class H(http.server.SimpleHTTPRequestHandler):

--- a/example/flutter_web/web/.gitignore
+++ b/example/flutter_web/web/.gitignore
@@ -2,7 +2,6 @@
 dart_monty_bridge.js
 dart_monty_worker.js
 monty.wasm32-wasi.wasm
-wasi-worker-browser.mjs
 
 # Ladder fixtures — symlink or copy from test/fixtures/python_ladder/ at dev time
 fixtures

--- a/example/web-showcase/run.sh
+++ b/example/web-showcase/run.sh
@@ -31,7 +31,6 @@ echo ""
 echo "--- Copying WASM assets ---"
 cp "$WASM_PKG/assets/dart_monty_bridge.js" "$WEB_DIR/"
 cp "$WASM_PKG/assets/dart_monty_worker.js" "$WEB_DIR/"
-cp "$WASM_PKG/assets/wasi-worker-browser.mjs" "$WEB_DIR/"
 cp "$WASM_PKG/assets/"*.wasm "$WEB_DIR/"
 
 # Copy coi-serviceworker from the existing web example
@@ -58,7 +57,6 @@ cleanup() {
   # Clean up copied files
   rm -f "$WEB_DIR/dart_monty_bridge.js" \
         "$WEB_DIR/dart_monty_worker.js" \
-        "$WEB_DIR/wasi-worker-browser.mjs" \
         "$WEB_DIR/"*.wasm \
         "$WEB_DIR/showcase.dart.js" \
         "$WEB_DIR/showcase.dart.js.deps" \

--- a/example/web/run.sh
+++ b/example/web/run.sh
@@ -32,7 +32,6 @@ echo ""
 echo "--- Copying assets ---"
 cp "$WASM_PKG/assets/dart_monty_bridge.js" "$WEB_DIR/"
 cp "$WASM_PKG/assets/dart_monty_worker.js" "$WEB_DIR/"
-cp "$WASM_PKG/assets/wasi-worker-browser.mjs" "$WEB_DIR/"
 cp "$WASM_PKG/assets/"*.wasm "$WEB_DIR/"
 echo "  Assets copied."
 
@@ -65,7 +64,6 @@ cleanup() {
   # Clean up copied files
   rm -f "$WEB_DIR/dart_monty_bridge.js" \
         "$WEB_DIR/dart_monty_worker.js" \
-        "$WEB_DIR/wasi-worker-browser.mjs" \
         "$WEB_DIR/"*.wasm \
         "$WEB_DIR/main.dart.js" \
         "$WEB_DIR/main.dart.js.deps" \

--- a/spike/web_test/.gitignore
+++ b/spike/web_test/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 .dart_tool/
 web/monty_bundle.js
 web/monty_worker.js
-web/wasi-worker-browser.mjs
 web/monty.wasm32-wasi.wasm
 web/main.dart.js
 web/main.dart.js.deps

--- a/tool/run_wasm_cancel_benchmark.sh
+++ b/tool/run_wasm_cancel_benchmark.sh
@@ -22,7 +22,6 @@ fi
 echo "Copying assets to $INTEG_WEB..."
 cp "$PKG/assets/dart_monty_bridge.js" "$INTEG_WEB/"
 cp "$PKG/assets/dart_monty_worker.js" "$INTEG_WEB/"
-cp "$PKG/assets/wasi-worker-browser.mjs" "$INTEG_WEB/"
 cp "$PKG/assets/"*.wasm "$INTEG_WEB/"
 
 # --- Compile benchmark to JS ---
@@ -40,7 +39,6 @@ cleanup() {
   fi
   rm -f "$INTEG_WEB/dart_monty_bridge.js" \
         "$INTEG_WEB/dart_monty_worker.js" \
-        "$INTEG_WEB/wasi-worker-browser.mjs" \
         "$INTEG_WEB/"*.wasm \
         "$INTEG_WEB/cancel_benchmark.dart.js" \
         "$INTEG_WEB/cancel_benchmark.dart.js.deps" \

--- a/tool/test_cross_path_parity.sh
+++ b/tool/test_cross_path_parity.sh
@@ -50,11 +50,6 @@ npx esbuild web/monty_worker_src.js \
   --platform=browser --external:'*.wasm' \
   --log-level=warning
 
-sed -i.bak 's|new URL("@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs"|new URL("./wasi-worker-browser.mjs"|g' \
-  web/monty_worker.js && rm -f web/monty_worker.js.bak
-
-cp node_modules/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs web/ 2>/dev/null || true
-
 npx esbuild web/monty_glue.js \
   --bundle --format=iife \
   --outfile=web/monty_bundle.js \
@@ -252,7 +247,6 @@ if [ -d "$WASM_PKG/js" ]; then
   WASM_INTEG="$WASM_PKG/test/integration/web"
   cp "$WASM_PKG/assets/dart_monty_bridge.js" "$WASM_INTEG/"
   cp "$WASM_PKG/assets/dart_monty_worker.js" "$WASM_INTEG/"
-  cp "$WASM_PKG/assets/wasi-worker-browser.mjs" "$WASM_INTEG/"
   cp "$WASM_PKG/assets/"*.wasm "$WASM_INTEG/"
 
   cd "$WASM_PKG"
@@ -314,7 +308,6 @@ http.server.HTTPServer(('127.0.0.1', $SERVE_PORT), handler).serve_forever()
   # Clean up copied assets
   rm -f "$WASM_INTEG/dart_monty_bridge.js" \
         "$WASM_INTEG/dart_monty_worker.js" \
-        "$WASM_INTEG/wasi-worker-browser.mjs" \
         "$WASM_INTEG/"*.wasm \
         "$WASM_INTEG/ladder_runner.dart.js" \
         "$WASM_INTEG/ladder_runner.dart.js.deps" \

--- a/tool/test_python_ladder.sh
+++ b/tool/test_python_ladder.sh
@@ -150,11 +150,6 @@ npx esbuild web/monty_worker_src.js \
   --external:'*.wasm' \
   --log-level=warning
 
-# Patch bare specifier for sub-worker URL
-sed -i.bak 's|new URL("@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs"|new URL("./wasi-worker-browser.mjs"|g' \
-  web/monty_worker.js && rm -f web/monty_worker.js.bak
-
-cp node_modules/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs web/ 2>/dev/null || true
 cp node_modules/@pydantic/monty-wasm32-wasi/monty.wasm32-wasi.wasm web/ 2>/dev/null || true
 
 echo "  esbuild: bundle glue"

--- a/tool/test_web_spike.sh
+++ b/tool/test_web_spike.sh
@@ -33,13 +33,6 @@ npx esbuild web/monty_worker_src.js \
   --external:'*.wasm' \
   --log-level=info
 
-# Patch bare specifier for sub-worker URL (esbuild can't resolve new URL() imports)
-sed -i.bak 's|new URL("@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs"|new URL("./wasi-worker-browser.mjs"|g' \
-  web/monty_worker.js && rm -f web/monty_worker.js.bak
-
-# Copy WASI sub-worker to web/ (needed at runtime by the Worker)
-cp node_modules/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs web/ 2>/dev/null || true
-
 echo "--- esbuild: bundle glue (IIFE for main thread) ---"
 npx esbuild web/monty_glue.js \
   --bundle \


### PR DESCRIPTION
## Summary
- Remove all 14 stale `wasi-worker-browser.mjs` references across 9 files
- NAPI-RS was replaced by direct C-ABI in PR #121; only WASM asset is now `dart_monty_native.wasm`

## Changes
- **tool scripts**: Remove `sed` patches, `cp` commands, and `rm` cleanup for `wasi-worker-browser.mjs`
- **example scripts**: Remove asset copy and cleanup lines
- **gitignores**: Remove `wasi-worker-browser.mjs` entries
- **CONTRIBUTING.md**: Remove stale `cp` instruction

Closes #140

## Test plan
- [x] `grep -r 'wasi-worker-browser' .` returns zero matches
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)