### PR TITLE
fix(bridge): surface child isolate errors as tool failures

### DIFF
--- a/packages/dart_monty_bridge/lib/src/plugins/isolate_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/isolate_plugin.dart
@@ -261,6 +261,7 @@ class IsolatePlugin extends MontyPlugin {
 
     final id = _nextId++;
     final completer = Completer<Object?>();
+    completer.future.ignore();
 
     // Execute child and listen for completion.
     final stream = bridge.execute(code);
@@ -295,12 +296,14 @@ class IsolatePlugin extends MontyPlugin {
           // child result.
         }
 
-        if (errorMessage != null) {
-          completer.completeError(
-            StateError('Child $id failed: $errorMessage'),
-          );
-        } else {
-          completer.complete(childValue);
+        if (!completer.isCompleted) {
+          if (errorMessage != null) {
+            completer.completeError(
+              Exception('Child $id failed: $errorMessage'),
+            );
+          } else {
+            completer.complete(childValue);
+          }
         }
       },
       onError: (Object error) {
@@ -367,9 +370,9 @@ class IsolatePlugin extends MontyPlugin {
 
     await child.cancel();
     if (!child.completer.isCompleted) {
-      child.completer.completeError(StateError('Child $handle was cancelled.'));
-      // Suppress unhandled async error if nobody awaits this child.
-      child.completer.future.ignore();
+      child.completer.completeError(
+        Exception('Child $handle was cancelled.'),
+      );
     }
 
     return null;
@@ -418,10 +421,8 @@ class IsolatePlugin extends MontyPlugin {
       await child.cancel();
       if (!child.completer.isCompleted) {
         child.completer.completeError(
-          StateError('Child ${entry.key} disposed with parent.'),
+          Exception('Child ${entry.key} disposed with parent.'),
         );
-        // Suppress unhandled async error if nobody awaits this child.
-        child.completer.future.ignore();
       }
     }
     _children.clear();

--- a/packages/dart_monty_bridge/test/src/plugins/isolate_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/plugins/isolate_plugin_test.dart
@@ -211,9 +211,9 @@ void main() {
         expect(
           () => await_({'handle': handle! as int}),
           throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'toString()',
               contains('NameError'),
             ),
           ),
@@ -266,7 +266,7 @@ void main() {
           () => awaitAll({
             'handles': <Object?>[h0, h1],
           }),
-          throwsA(isA<StateError>()),
+          throwsA(isA<Exception>()),
         );
       });
 
@@ -384,9 +384,9 @@ void main() {
         expect(
           () => await_({'handle': handle as int}),
           throwsA(
-            isA<StateError>().having(
-              (e) => e.message,
-              'message',
+            isA<Exception>().having(
+              (e) => e.toString(),
+              'toString()',
               contains('cancelled'),
             ),
           ),
@@ -564,7 +564,7 @@ void main() {
         // Await will throw because the child failed.
         await expectLater(
           () => await_({'handle': handle! as int}),
-          throwsA(isA<StateError>()),
+          throwsA(isA<Exception>()),
         );
 
         final output = await getOutput({'handle': handle! as int});


### PR DESCRIPTION
## Summary
- Child isolate errors (SyntaxError, TimeoutError) crashed the parent process as unhandled async exceptions instead of surfacing as catchable tool failures

## Changes
- **isolate_plugin.dart**: `completer.future.ignore()` at creation prevents unhandled errors when child fails before being awaited
- **isolate_plugin.dart**: `if (!completer.isCompleted)` guard in `onDone` prevents double-complete race with `onError`
- **isolate_plugin.dart**: `StateError` → `Exception` for cleaner Python error messages (no "Bad state:" prefix)
- **isolate_plugin_test.dart**: Updated 4 assertions for `Exception` type

Closes #131

## Test plan
- [x] 107/107 bridge tests pass
- [x] `dart analyze --fatal-infos` clean
- [x] Gemini 3.1 Pro review: SHIP (3 iterations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)