### PR TITLE
docs(site): redesign GitHub Pages landing page

### DIFF
--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>dart_monty — Sandboxed Python for Dart</title>
+  <title>dart_monty — Sandboxed Python for Dart & Flutter</title>
   <meta name="description" content="Pure Dart bindings for the Monty sandboxed Python interpreter. Run Python from Dart — native, web, mobile. Same code, every platform.">
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
@@ -696,7 +696,7 @@
   <div class="hero-bg"></div>
   <div class="hero-content">
     <h1>dart_monty</h1>
-    <p class="tagline">Sandboxed Python for Dart.<br>Same code. <em>Every platform.</em></p>
+    <p class="tagline">Sandboxed Python for Dart & Flutter.<br>Same code. <em>Every platform.</em></p>
     <div class="hero-actions">
       <a class="btn-primary" href="#demos">Try Live Demos</a>
       <a class="btn-secondary" href="#architecture">Explore Architecture</a>
@@ -755,7 +755,7 @@
       <h3>LLMs generate Python. Your app should execute it.</h3>
       <p>
         When an LLM writes code to answer a question, transform data, or call a tool&mdash;it writes Python.
-        dart_monty lets your Dart app execute that code directly, in-process, without a server round-trip.
+        dart_monty lets your Dart and Flutter apps execute that code directly, in-process, without a server round-trip.
         The LLM writes 35 lines of glue. <a href="https://github.com/pydantic/monty">Monty</a> runs it. Your host functions provide the domain logic.
         The agent loop closes locally.
       </p>
@@ -805,7 +805,7 @@
      ═══════════════════════════════════════════════════════════════ -->
 <section id="about" class="fade-in">
   <div class="section-label">The What</div>
-  <div class="section-title">A Rust Python interpreter. In your Dart app. Everywhere.</div>
+  <div class="section-title">A Rust Python interpreter. In your Dart and Flutter apps. Everywhere.</div>
   <p class="section-subtitle">
     dart_monty wraps <a href="https://github.com/pydantic/monty"><strong>Monty</strong></a>&mdash;Pydantic's
     tree-walking Python interpreter written in Rust&mdash;in pure Dart bindings.


### PR DESCRIPTION
## Summary
- Replace minimal 136-line index.html with full 1,534-line editorial showcase
- Add Mermaid.js architecture diagrams (package graph, execution paths, state machine, error hierarchy, plugin system, FFI boundary, SPI contract, evolution timeline)
- Walk through all 11 Python ladder tiers with visual tier cards
- Feature deep dives with alternating text/code layout (panic safety, cancellation, plugins, iterative execution)
- Interactive demo cards linking to existing WASM demos (executor, ladder, visualizer, MCP, Flutter)
- Scroll-triggered fade-in animations, responsive nav with active section tracking
- SubGenius, Devo, and Talking Heads references woven throughout as section epigraphs

## Changes
- **example/web/web/index.html**: Complete rewrite — modern dark theme, Space Grotesk + IBM Plex Mono typography, Mermaid.js from CDN, responsive layout
- **No build changes**: Same `pages.yaml` workflow, same `__BUILD_DATE__` stamp, same demo page links

## Test plan
- [x] Opens correctly in browser (local file)
- [x] Mermaid diagrams render with network access
- [x] All demo links point to existing pages
- [x] `__BUILD_DATE__` placeholder preserved for CI stamping
- [x] Responsive layout at mobile widths
- [ ] Verify Pages deployment renders correctly after merge