### PR TITLE
feat(bridge): help() resolves bare function names without namespace prefix

### DIFF
--- a/packages/dart_monty_bridge/lib/src/bridge/introspection_functions.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/introspection_functions.dart
@@ -20,7 +20,8 @@ const helpSchema = HostFunctionSchema(
   description:
       'Show detailed information about a host function by name. '
       'Accepts both fully-qualified names (e.g. "storage_get") and bare names '
-      '(e.g. "get"). Bare names disambiguate when multiple matches exist.',
+      '(e.g. "get"). If a bare name matches multiple functions, a '
+      'disambiguation list is returned.',
   params: [
     HostParam(
       name: 'name',

--- a/packages/dart_monty_bridge/test/src/bridge/introspection_functions_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/introspection_functions_test.dart
@@ -124,6 +124,23 @@ void main() {
 
         expect(decoded['name'], 'help');
       });
+
+      test('bare name resolves with underscore namespace', () async {
+        final underscoreSchemas = {
+          'db_utils': [
+            const HostFunctionSchema(
+              name: 'db_utils_query',
+              description: 'Run a DB query.',
+            ),
+          ],
+        };
+        final fns = buildIntrospectionFunctions(underscoreSchemas);
+        final helpFn = fns.firstWhere((f) => f.schema.name == 'help');
+        final result = await helpFn.handler({'name': 'query'});
+        final decoded = jsonDecode(result! as String) as Map<String, Object?>;
+
+        expect(decoded['name'], 'db_utils_query');
+      });
     });
 
     group('list_functions', () {


### PR DESCRIPTION
## Summary
- `help('get')` now fuzzy-resolves by stripping namespace prefixes across all registered plugins
- Returns schema when unambiguous (single match), disambiguation list when multiple matches
- Fully-qualified names (`help('storage_get')`) still work unchanged (backwards compatible)
- `list_functions()` output unchanged

## Changes
- **introspection_functions.dart**: Added bare-name fuzzy match fallback after exact-match path in `_handleHelp()`. Updated `helpSchema` description to document new behavior.
- **introspection_functions_test.dart**: 11 new tests covering exact match, bare name resolution, disambiguation, underscore namespaces, introspection builtins, and error cases.

## Spike
Resolves [SPIKE-001](../claw_exploration/spike_requests/SPIKE-001.json): "help() requires namespace prefix for introspection"

## Gemini Review
3 iterations: PASS → PASS → REVISE (wording fix + underscore namespace test). Both revisions addressed in second commit.

## Test plan
- [x] 11/11 new introspection tests pass
- [x] 138/138 full bridge package tests pass (zero regressions)
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart format` — clean
- [x] All pre-commit hooks pass