### PR TITLE
feat(bridge): add BridgeMiddleware with sealed CallRole (#199)

### DIFF
--- a/packages/dart_monty_bridge/analysis_options.yaml
+++ b/packages/dart_monty_bridge/analysis_options.yaml
@@ -8,3 +8,6 @@ linter:
     # False positive: subscriptions stored in _ChildHandle are cancelled
     # in onDispose/cancel but the analyzer can't track across indirection.
     cancel_subscriptions: false
+    # BridgeMiddleware is intentionally a single-method abstract class —
+    # it's an interface for subclassing, not a standalone function.
+    one_member_abstracts: false

--- a/packages/dart_monty_bridge/lib/dart_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/dart_monty_bridge.dart
@@ -5,6 +5,7 @@
 library;
 
 export 'src/bridge/bridge_event.dart';
+export 'src/bridge/bridge_middleware.dart';
 export 'src/bridge/default_monty_bridge.dart';
 export 'src/bridge/event_loop_bridge.dart';
 export 'src/bridge/host_function.dart';

--- a/packages/dart_monty_bridge/lib/src/bridge/bridge_middleware.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/bridge_middleware.dart
@@ -1,0 +1,43 @@
+/// Role of a tool call passing through the middleware chain.
+///
+/// Sealed so every `switch` is exhaustive — adding a new role subtype
+/// is a compile-time breaking change that forces middleware updates.
+sealed class CallRole {
+  /// Creates a [CallRole].
+  const CallRole();
+}
+
+/// Infrastructure: orchestration loop, planning, routing.
+///
+/// Middleware should observe but not enforce policy on these calls.
+class InfraCall extends CallRole {
+  /// Creates an [InfraCall].
+  const InfraCall();
+}
+
+/// Agent-initiated tool action — subject to the full middleware chain.
+class ToolCall extends CallRole {
+  /// Creates a [ToolCall].
+  const ToolCall();
+}
+
+/// Signature for the next handler in the middleware chain.
+typedef ToolHandler =
+    Future<Object?> Function(
+      String name,
+      Map<String, Object?> args,
+    );
+
+/// Intercepts every tool call through a bridge.
+///
+/// Register via `use()` on the bridge. First registered = outermost in the
+/// onion chain. Call `next` to proceed, or throw/return to short-circuit.
+abstract class BridgeMiddleware {
+  /// Wraps a tool call. Inspect [role] to decide whether to enforce policy.
+  Future<Object?> handle(
+    String name,
+    Map<String, Object?> args,
+    CallRole role,
+    ToolHandler next,
+  );
+}

--- a/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:dart_monty_bridge/src/bridge/bridge_event.dart';
+import 'package:dart_monty_bridge/src/bridge/bridge_middleware.dart';
 import 'package:dart_monty_bridge/src/bridge/host_function.dart';
 import 'package:dart_monty_bridge/src/bridge/host_function_schema.dart';
 import 'package:dart_monty_bridge/src/bridge/monty_bridge.dart';
@@ -31,6 +32,7 @@ print = _cw
 const _preambleLineCount = 5;
 
 const _consoleWriteFn = '__console_write__';
+const _roleKwarg = '__role__';
 
 /// Tracks an in-flight host function future awaiting resolution.
 class _PendingFuture {
@@ -73,6 +75,7 @@ class DefaultMontyBridge implements MontyBridge {
   final Logger log;
 
   final Map<String, HostFunction> _functions = {};
+  final List<BridgeMiddleware> _middleware = [];
   final Map<int, _PendingFuture> _pendingFutures = {};
   int _idCounter = 0;
   bool _isExecuting = false;
@@ -87,6 +90,12 @@ class DefaultMontyBridge implements MontyBridge {
   @override
   List<HostFunctionSchema> get schemas =>
       _functions.values.map((f) => f.schema).toList(growable: false);
+
+  @override
+  void use(BridgeMiddleware middleware) {
+    if (_isDisposed) throw StateError('Bridge has been disposed');
+    _middleware.add(middleware);
+  }
 
   @override
   void register(HostFunction function) {
@@ -244,14 +253,20 @@ class DefaultMontyBridge implements MontyBridge {
       return _platform.resume(null);
     }
 
-    // Registered host function — emit tool call events.
+    // Registered host function — extract role, strip reserved kwargs, dispatch.
     final fn = _functions[name];
     if (fn != null) {
+      final (cleanedPending, role) = _extractRole(pending);
       log.trace('Host function call', attributes: {'name': name});
       if (futuresCapable) {
-        return _dispatchToolCallAsFuture(fn, pending, controller);
+        return _dispatchToolCallAsFuture(
+          fn,
+          cleanedPending,
+          controller,
+          role: role,
+        );
       }
-      return _dispatchToolCall(fn, pending, controller);
+      return _dispatchToolCall(fn, cleanedPending, controller, role: role);
     }
 
     // Unknown function — raise error in Python.
@@ -259,11 +274,62 @@ class DefaultMontyBridge implements MontyBridge {
     return _platform.resumeWithError('Unknown function: $name');
   }
 
+  /// Extracts `__role__` from [pending] kwargs and returns a cleaned
+  /// [MontyPending] (without the reserved kwarg) plus the [CallRole].
+  ///
+  /// Defaults to [ToolCall] when no `__role__` kwarg is present.
+  (MontyPending, CallRole) _extractRole(MontyPending pending) {
+    final kwargs = pending.kwargs;
+    if (kwargs == null || !kwargs.containsKey(_roleKwarg)) {
+      return (pending, const ToolCall());
+    }
+
+    final roleValue = kwargs[_roleKwarg];
+    final role = switch (roleValue) {
+      'infra' => const InfraCall(),
+      _ => const ToolCall(),
+    };
+
+    // Reconstruct pending without the reserved kwarg.
+    final cleaned = Map<String, Object?>.of(kwargs)..remove(_roleKwarg);
+    final cleanedPending = MontyPending(
+      functionName: pending.functionName,
+      arguments: pending.arguments,
+      kwargs: cleaned.isEmpty ? null : cleaned,
+      callId: pending.callId,
+      methodCall: pending.methodCall,
+    );
+
+    return (cleanedPending, role);
+  }
+
+  /// Invokes [fn] through the middleware chain with the given [role].
+  ///
+  /// Fast path: when no middleware is registered, calls the handler directly.
+  Future<Object?> _invokeWithMiddleware(
+    HostFunction fn,
+    String name,
+    Map<String, Object?> args,
+    CallRole role,
+  ) {
+    if (_middleware.isEmpty) return fn.handler(args);
+
+    // Build onion chain: first registered = outermost.
+    var handler = (String _, Map<String, Object?> a) => fn.handler(a);
+    for (final mw in _middleware.reversed) {
+      final next = handler;
+      handler = (n, a) => mw.handle(n, a, role, next);
+    }
+
+    return handler(name, args);
+  }
+
   Future<MontyProgress> _dispatchToolCall(
     HostFunction fn,
     MontyPending pending,
-    StreamController<BridgeEvent> controller,
-  ) async {
+    StreamController<BridgeEvent> controller, {
+    required CallRole role,
+  }) async {
     final callId = _nextId;
     final stepName = pending.functionName;
 
@@ -290,9 +356,9 @@ class DefaultMontyBridge implements MontyBridge {
       ..add(BridgeToolCallArgs(callId: callId, delta: jsonEncode(args)))
       ..add(BridgeToolCallEnd(callId: callId));
 
-    // Execute handler.
+    // Execute handler through middleware chain.
     try {
-      final result = await fn.handler(args);
+      final result = await _invokeWithMiddleware(fn, stepName, args, role);
       controller
         ..add(
           BridgeToolCallResult(
@@ -321,8 +387,9 @@ class DefaultMontyBridge implements MontyBridge {
   Future<MontyProgress> _dispatchToolCallAsFuture(
     HostFunction fn,
     MontyPending pending,
-    StreamController<BridgeEvent> controller,
-  ) async {
+    StreamController<BridgeEvent> controller, {
+    required CallRole role,
+  }) async {
     final callId = _nextId;
     final stepName = pending.functionName;
 
@@ -354,7 +421,7 @@ class DefaultMontyBridge implements MontyBridge {
     // state with a leaked FFI handle.
     final Future<Object?> handlerFuture;
     try {
-      handlerFuture = fn.handler(args);
+      handlerFuture = _invokeWithMiddleware(fn, stepName, args, role);
     } on Object catch (e, st) {
       log.error(
         'Host handler threw synchronously',

--- a/packages/dart_monty_bridge/lib/src/bridge/monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/monty_bridge.dart
@@ -1,4 +1,5 @@
 import 'package:dart_monty_bridge/src/bridge/bridge_event.dart';
+import 'package:dart_monty_bridge/src/bridge/bridge_middleware.dart';
 import 'package:dart_monty_bridge/src/bridge/host_function.dart';
 import 'package:dart_monty_bridge/src/bridge/host_function_schema.dart';
 
@@ -15,6 +16,12 @@ abstract class MontyBridge {
 
   /// Unregisters a host function by name.
   void unregister(String name);
+
+  /// Registers a [BridgeMiddleware] to intercept tool calls.
+  ///
+  /// First registered = outermost in the onion chain. No-op by default;
+  /// override in implementations that support middleware.
+  void use(BridgeMiddleware middleware) {}
 
   /// Executes [code] and returns a stream of lifecycle events.
   ///

--- a/packages/dart_monty_bridge/test/src/bridge/default_monty_bridge_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/default_monty_bridge_test.dart
@@ -194,6 +194,368 @@ void main() {
       },
     );
   });
+
+  group('BridgeMiddleware', () {
+    test('use() registers middleware called on tool dispatch', () async {
+      final log = <String>[];
+
+      bridge
+        ..use(_LoggingMiddleware('mw1', log))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'greet', description: ''),
+            handler: (_) async => 'hello',
+          ),
+        );
+
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'greet', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('greet()').toList();
+      expect(log, ['mw1:before:greet', 'mw1:after:greet']);
+    });
+
+    test('onion chain order: first registered = outermost', () async {
+      final log = <String>[];
+
+      bridge
+        ..use(_LoggingMiddleware('outer', log))
+        ..use(_LoggingMiddleware('inner', log))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'fn', description: ''),
+            handler: (_) async {
+              log.add('handler');
+              return null;
+            },
+          ),
+        );
+
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'fn', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('fn()').toList();
+      expect(log, [
+        'outer:before:fn',
+        'inner:before:fn',
+        'handler',
+        'inner:after:fn',
+        'outer:after:fn',
+      ]);
+    });
+
+    test('middleware receives ToolCall role by default', () async {
+      CallRole? captured;
+
+      bridge
+        ..use(_RoleCapturingMiddleware((role) => captured = role))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'fn', description: ''),
+            handler: (_) async => null,
+          ),
+        );
+
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'fn', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('fn()').toList();
+      expect(captured, isA<ToolCall>());
+    });
+
+    test('__role__=infra kwarg sets InfraCall role', () async {
+      CallRole? captured;
+
+      bridge
+        ..use(_RoleCapturingMiddleware((role) => captured = role))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'fn', description: ''),
+            handler: (_) async => null,
+          ),
+        );
+
+      mock
+        ..enqueueProgress(
+          const MontyPending(
+            functionName: 'fn',
+            arguments: [],
+            kwargs: {'__role__': 'infra'},
+          ),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('fn(__role__="infra")').toList();
+      expect(captured, isA<InfraCall>());
+    });
+
+    test('__role__ kwarg is stripped before mapAndValidate', () async {
+      Map<String, Object?>? capturedArgs;
+
+      bridge.register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'fn',
+            description: '',
+            params: [HostParam(name: 'x', type: HostParamType.integer)],
+          ),
+          handler: (args) async {
+            capturedArgs = args;
+            return null;
+          },
+        ),
+      );
+
+      mock
+        ..enqueueProgress(
+          const MontyPending(
+            functionName: 'fn',
+            arguments: [],
+            kwargs: {'x': 42, '__role__': 'infra'},
+          ),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('fn(x=42, __role__="infra")').toList();
+      expect(capturedArgs, {'x': 42});
+    });
+
+    test('middleware can short-circuit by not calling next', () async {
+      // Use sync dispatch (useFutures: false) so BridgeToolCallResult is
+      // emitted immediately in _dispatchToolCall, not deferred.
+      final syncMock = MockMontyPlatform();
+      final syncBridge = DefaultMontyBridge(
+        platform: syncMock,
+        useFutures: false,
+      );
+      addTearDown(syncBridge.dispose);
+
+      syncBridge
+        ..use(_BlockingMiddleware('blocked'))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'fn', description: ''),
+            handler: (_) async => fail('should not be called'),
+          ),
+        );
+
+      syncMock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'fn', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      final events = await syncBridge.execute('fn()').toList();
+      final result = events.whereType<BridgeToolCallResult>().first;
+      expect(result.result, 'blocked');
+    });
+
+    test('middleware can throw to reject a call', () async {
+      final syncMock = MockMontyPlatform();
+      final syncBridge = DefaultMontyBridge(
+        platform: syncMock,
+        useFutures: false,
+      );
+      addTearDown(syncBridge.dispose);
+
+      syncBridge
+        ..use(_ThrowingMiddleware())
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'fn', description: ''),
+            handler: (_) async => fail('should not be called'),
+          ),
+        );
+
+      syncMock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'fn', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      final events = await syncBridge.execute('fn()').toList();
+      final result = events.whereType<BridgeToolCallResult>().first;
+      expect(result.result, contains('Access denied'));
+    });
+
+    test('no middleware = fast path (handler called directly)', () async {
+      var called = false;
+      bridge.register(
+        HostFunction(
+          schema: const HostFunctionSchema(name: 'fn', description: ''),
+          handler: (_) async {
+            called = true;
+            return 'ok';
+          },
+        ),
+      );
+
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'fn', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('fn()').toList();
+      expect(called, isTrue);
+    });
+
+    test('use() after dispose throws StateError', () {
+      bridge.dispose();
+      expect(
+        () => bridge.use(_LoggingMiddleware('x', [])),
+        throwsStateError,
+      );
+    });
+
+    test('middleware works on futures path', () async {
+      final log = <String>[];
+
+      bridge
+        ..use(_LoggingMiddleware('mw', log))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'async_fn', description: ''),
+            handler: (_) async => 'result',
+          ),
+        );
+
+      // Futures path: Pending -> resumeAsFuture -> ResolveFutures -> Complete
+      mock
+        ..enqueueProgress(
+          const MontyPending(
+            functionName: 'async_fn',
+            arguments: [],
+            callId: 1,
+          ),
+        )
+        ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('await async_fn()').toList();
+      expect(log, ['mw:before:async_fn', 'mw:after:async_fn']);
+    });
+
+    test('unknown __role__ value defaults to ToolCall', () async {
+      CallRole? captured;
+
+      bridge
+        ..use(_RoleCapturingMiddleware((role) => captured = role))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'fn', description: ''),
+            handler: (_) async => null,
+          ),
+        );
+
+      mock
+        ..enqueueProgress(
+          const MontyPending(
+            functionName: 'fn',
+            arguments: [],
+            kwargs: {'__role__': 'unknown_value'},
+          ),
+        )
+        ..enqueueProgress(
+          const MontyComplete(result: MontyResult(usage: _usage)),
+        );
+
+      await bridge.execute('fn()').toList();
+      expect(captured, isA<ToolCall>());
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test middleware implementations
+// ---------------------------------------------------------------------------
+
+class _LoggingMiddleware extends BridgeMiddleware {
+  _LoggingMiddleware(this.tag, this.log);
+
+  final String tag;
+  final List<String> log;
+
+  @override
+  Future<Object?> handle(
+    String name,
+    Map<String, Object?> args,
+    CallRole role,
+    ToolHandler next,
+  ) async {
+    log.add('$tag:before:$name');
+    final result = await next(name, args);
+    log.add('$tag:after:$name');
+    return result;
+  }
+}
+
+class _RoleCapturingMiddleware extends BridgeMiddleware {
+  _RoleCapturingMiddleware(this.onRole);
+
+  final void Function(CallRole) onRole;
+
+  @override
+  Future<Object?> handle(
+    String name,
+    Map<String, Object?> args,
+    CallRole role,
+    ToolHandler next,
+  ) {
+    onRole(role);
+    return next(name, args);
+  }
+}
+
+class _BlockingMiddleware extends BridgeMiddleware {
+  _BlockingMiddleware(this.returnValue);
+
+  final Object? returnValue;
+
+  @override
+  Future<Object?> handle(
+    String name,
+    Map<String, Object?> args,
+    CallRole role,
+    ToolHandler next,
+  ) async => returnValue;
+}
+
+class _ThrowingMiddleware extends BridgeMiddleware {
+  @override
+  Future<Object?> handle(
+    String name,
+    Map<String, Object?> args,
+    CallRole role,
+    ToolHandler next,
+  ) => throw StateError('Access denied');
 }
 
 /// A minimal [MontyPlatform] that throws a [MontyException] from [start].

--- a/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
@@ -112,6 +112,9 @@ class _NoOpBridge implements MontyBridge {
   List<HostFunctionSchema> get schemas => [];
 
   @override
+  void use(BridgeMiddleware middleware) {}
+
+  @override
   void register(HostFunction function) {}
 
   @override

--- a/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
@@ -601,6 +601,9 @@ class _MockBridge implements MontyBridge {
   List<HostFunctionSchema> get schemas => [];
 
   @override
+  void use(BridgeMiddleware middleware) {}
+
+  @override
   void register(HostFunction function) {
     registeredNames.add(function.schema.name);
   }


### PR DESCRIPTION
## Summary
- Introduces `BridgeMiddleware` — onion-style interceptor chain at the tool dispatch chokepoint
- Sealed `CallRole` hierarchy (`InfraCall`, `ToolCall`) enables selective policy enforcement
- `__role__` reserved kwarg extracted from `MontyPending.kwargs` and stripped before `mapAndValidate`
- Both sync and async/futures dispatch paths wired through the middleware chain
- Fast path: zero overhead when no middleware is registered

## Changes
- **bridge_middleware.dart** (new): `sealed CallRole`, `ToolHandler` typedef, `abstract BridgeMiddleware`
- **monty_bridge.dart**: Added `use(BridgeMiddleware)` with no-op default
- **default_monty_bridge.dart**: `use()` override, `_extractRole()`, `_invokeWithMiddleware()`, wired into both `_dispatchToolCall` and `_dispatchToolCallAsFuture`
- **dart_monty_bridge.dart**: Barrel export for bridge_middleware.dart
- **analysis_options.yaml**: Disabled `one_member_abstracts` (BridgeMiddleware is intentionally single-method interface)
- **Test mocks**: Added `use()` override to mock bridge classes

## Intentionally deferred (follow-up PRs)
These were discussed during design review and scoped out — none have consumers yet:
- `orchestratorId`/`requestId` on CallRole subclasses (tracing — additive, non-breaking)
- `createChildInstance`/`systemPromptFragment`/`dispose` on BridgeMiddleware (lifecycle hooks — no consumer exists)
- Child bridge propagation for SandboxPlugin (no one registers middleware + spawns children yet)
- `__role__` spoofing defense (untrusted code doesn't execute yet)
- Role field on `BridgeToolCallStart` event (event schema change — separate concern)

## Test plan
- [x] 11 new middleware tests: registration, onion chain ordering, role extraction (ToolCall default, InfraCall via kwarg, unknown defaults to ToolCall), kwarg stripping, short-circuit, throw rejection, fast path, lifecycle, futures path
- [x] All 159 unit tests pass (rebased on main after PR #201 merge)
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart format` — clean

Closes #199