### PR TITLE
feat(bridge): add sandbox_gather for output attribution

### DIFF
--- a/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
@@ -140,7 +140,8 @@ class SandboxPlugin extends MontyPlugin {
   @override
   String? get systemPromptContext =>
       'Spawn Python scripts in sandboxed interpreter instances. '
-      'Each child has its own state. Use for parallel computation.';
+      'Each child has its own state. Use for parallel computation. '
+      'Use sandbox_gather for attributed results with handle and output.';
 
   @override
   List<HostFunction> get functions => [
@@ -265,6 +266,22 @@ class SandboxPlugin extends MontyPlugin {
         ],
       ),
       handler: _handleGetOutput,
+    ),
+    HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'sandbox_gather',
+        description:
+            'Wait for multiple children and return attributed results. '
+            'Each element is a dict with handle, value, and output keys.',
+        params: [
+          HostParam(
+            name: 'handles',
+            type: HostParamType.list,
+            description: 'List of handles from sandbox_spawn.',
+          ),
+        ],
+      ),
+      handler: _handleGather,
     ),
   ];
 
@@ -598,6 +615,33 @@ class SandboxPlugin extends MontyPlugin {
       );
     }
     return child.printOutput;
+  }
+
+  Future<Object?> _handleGather(Map<String, Object?> args) async {
+    final raw = args['handles']! as List<Object?>;
+    final handles = raw.cast<num>().map((n) => n.toInt()).toList();
+
+    final futures = <Future<Object?>>[];
+    for (final handle in handles) {
+      final child = _children[handle];
+      if (child == null) {
+        throw ArgumentError.value(handle, 'handle', 'Unknown child handle.');
+      }
+      futures.add(child.completer.future);
+    }
+
+    final values = await Future.wait(futures);
+
+    final results = <Map<String, Object?>>[];
+    for (var i = 0; i < handles.length; i++) {
+      results.add({
+        'handle': handles[i],
+        'value': values[i],
+        'output': _children[handles[i]]!.printOutput,
+      });
+    }
+
+    return results;
   }
 
   @override

--- a/packages/dart_monty_bridge/test/integration/sandbox_gather_test.dart
+++ b/packages/dart_monty_bridge/test/integration/sandbox_gather_test.dart
@@ -1,0 +1,236 @@
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty_bridge/dart_monty_bridge.dart';
+import 'package:dart_monty_ffi/dart_monty_ffi.dart';
+import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:test/test.dart';
+
+/// Integration tests for sandbox_gather output attribution with real FFI.
+///
+/// Run with:
+/// ```bash
+/// cd native && cargo build --release && cd ..
+/// cd packages/dart_monty_bridge
+/// DYLD_LIBRARY_PATH=../../native/target/release \
+///   dart test --tags=integration --run-skipped \
+///   test/integration/sandbox_gather_test.dart
+/// ```
+void main() {
+  late NativeBindingsFfi bindings;
+
+  setUpAll(() {
+    bindings = NativeBindingsFfi();
+  });
+
+  MontyPlatform createPlatform() => MontyFfi(bindings: bindings);
+
+  DefaultMontyBridge createBridge() =>
+      DefaultMontyBridge(platform: createPlatform(), useFutures: false);
+
+  group('sandbox_gather with real FFI', () {
+    test(
+      'attributes print output and return value to correct worker',
+      () async {
+        final bridge = createBridge();
+        final registry = PluginRegistry()
+          ..register(
+            SandboxPlugin(platformFactory: () async => createPlatform()),
+          );
+        await registry.attachTo(bridge);
+
+        final plugin = registry.plugins.whereType<SandboxPlugin>().first;
+        final spawn = plugin.functions
+            .firstWhere((f) => f.schema.name == 'sandbox_spawn')
+            .handler;
+        final gather = plugin.functions
+            .firstWhere((f) => f.schema.name == 'sandbox_gather')
+            .handler;
+
+        // Spawn 3 workers with distinct print output and return values.
+        final h0 = (await spawn({'code': 'print("worker-A")\n42'}))! as int;
+        final h1 = (await spawn({'code': 'print("worker-B")\n99'}))! as int;
+        final h2 = (await spawn({'code': 'print("worker-C")\n7'}))! as int;
+
+        final results =
+            (await gather({
+                  'handles': [h0, h1, h2],
+                }))!
+                as List<Object?>;
+
+        expect(results, hasLength(3));
+
+        final r0 = results[0]! as Map<String, Object?>;
+        final r1 = results[1]! as Map<String, Object?>;
+        final r2 = results[2]! as Map<String, Object?>;
+
+        // Each result is attributed to the correct handle.
+        expect(r0['handle'], h0);
+        expect(r1['handle'], h1);
+        expect(r2['handle'], h2);
+
+        // Return values match.
+        expect(r0['value'], 42);
+        expect(r1['value'], 99);
+        expect(r2['value'], 7);
+
+        // Print output is attributed correctly.
+        expect(r0['output'], contains('worker-A'));
+        expect(r1['output'], contains('worker-B'));
+        expect(r2['output'], contains('worker-C'));
+
+        bridge.dispose();
+      },
+    );
+
+    test('gather preserves requested handle order', () async {
+      final bridge = createBridge();
+      final registry = PluginRegistry()
+        ..register(
+          SandboxPlugin(platformFactory: () async => createPlatform()),
+        );
+      await registry.attachTo(bridge);
+
+      final plugin = registry.plugins.whereType<SandboxPlugin>().first;
+      final spawn = plugin.functions
+          .firstWhere((f) => f.schema.name == 'sandbox_spawn')
+          .handler;
+      final gather = plugin.functions
+          .firstWhere((f) => f.schema.name == 'sandbox_gather')
+          .handler;
+
+      final h0 = (await spawn({'code': '10'}))! as int;
+      final h1 = (await spawn({'code': '20'}))! as int;
+
+      // Request in reverse order.
+      final results =
+          (await gather({
+                'handles': [h1, h0],
+              }))!
+              as List<Object?>;
+
+      expect((results[0]! as Map)['handle'], h1);
+      expect((results[0]! as Map)['value'], 20);
+      expect((results[1]! as Map)['handle'], h0);
+      expect((results[1]! as Map)['value'], 10);
+
+      bridge.dispose();
+    });
+
+    test('gather with silent worker returns null output', () async {
+      final bridge = createBridge();
+      final registry = PluginRegistry()
+        ..register(
+          SandboxPlugin(platformFactory: () async => createPlatform()),
+        );
+      await registry.attachTo(bridge);
+
+      final plugin = registry.plugins.whereType<SandboxPlugin>().first;
+      final spawn = plugin.functions
+          .firstWhere((f) => f.schema.name == 'sandbox_spawn')
+          .handler;
+      final gather = plugin.functions
+          .firstWhere((f) => f.schema.name == 'sandbox_gather')
+          .handler;
+
+      // One worker prints, the other does not.
+      final hLoud = (await spawn({'code': 'print("hello")\n1'}))! as int;
+      final hSilent = (await spawn({'code': '2'}))! as int;
+
+      final results =
+          (await gather({
+                'handles': [hLoud, hSilent],
+              }))!
+              as List<Object?>;
+
+      final rLoud = results[0]! as Map<String, Object?>;
+      final rSilent = results[1]! as Map<String, Object?>;
+
+      expect(rLoud['output'], contains('hello'));
+      expect(rSilent['output'], isNull);
+
+      bridge.dispose();
+    });
+
+    test('gather propagates child failure as ChildSandboxException', () async {
+      final bridge = createBridge();
+      final registry = PluginRegistry()
+        ..register(
+          SandboxPlugin(platformFactory: () async => createPlatform()),
+        );
+      await registry.attachTo(bridge);
+
+      final plugin = registry.plugins.whereType<SandboxPlugin>().first;
+      final spawn = plugin.functions
+          .firstWhere((f) => f.schema.name == 'sandbox_spawn')
+          .handler;
+      final gather = plugin.functions
+          .firstWhere((f) => f.schema.name == 'sandbox_gather')
+          .handler;
+
+      final hGood = (await spawn({'code': '1'}))! as int;
+      final hBad = (await spawn({'code': 'undefined_variable_xyz'}))! as int;
+
+      expect(
+        () => gather({
+          'handles': [hGood, hBad],
+        }),
+        throwsA(
+          isA<ChildSandboxException>().having(
+            (e) => e.message,
+            'message',
+            contains('NameError'),
+          ),
+        ),
+      );
+
+      bridge.dispose();
+    });
+
+    test(
+      'gather results are machine-parseable for downstream tooling',
+      () async {
+        final bridge = createBridge();
+        final registry = PluginRegistry()
+          ..register(
+            SandboxPlugin(platformFactory: () async => createPlatform()),
+          );
+        await registry.attachTo(bridge);
+
+        final plugin = registry.plugins.whereType<SandboxPlugin>().first;
+        final spawn = plugin.functions
+            .firstWhere((f) => f.schema.name == 'sandbox_spawn')
+            .handler;
+        final gather = plugin.functions
+            .firstWhere((f) => f.schema.name == 'sandbox_gather')
+            .handler;
+
+        final h0 =
+            (await spawn({'code': 'print("line1")\nprint("line2")\n100'}))!
+                as int;
+        final h1 = (await spawn({'code': 'print("only")\n200'}))! as int;
+
+        final results =
+            (await gather({
+                  'handles': [h0, h1],
+                }))!
+                as List<Object?>;
+
+        // Verify every result has exactly the expected keys.
+        for (final raw in results) {
+          final r = raw! as Map<String, Object?>;
+          expect(r.keys, containsAll(['handle', 'value', 'output']));
+          expect(r['handle'], isA<int>());
+        }
+
+        // Verify multiline output is captured intact.
+        final r0 = results[0]! as Map<String, Object?>;
+        final output = r0['output']! as String;
+        expect(output, contains('line1'));
+        expect(output, contains('line2'));
+
+        bridge.dispose();
+      },
+    );
+  });
+}

--- a/packages/dart_monty_bridge/test/src/plugins/sandbox_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/plugins/sandbox_plugin_test.dart
@@ -88,11 +88,11 @@ void main() {
         expect(plugin.systemPromptContext, contains('sandboxed'));
       });
 
-      test('provides 7 host functions', () {
+      test('provides 8 host functions', () {
         final plugin = SandboxPlugin(
           platformFactory: () async => MockMontyPlatform(),
         );
-        expect(plugin.functions, hasLength(7));
+        expect(plugin.functions, hasLength(8));
       });
 
       test('all function names start with sandbox_', () {
@@ -518,6 +518,156 @@ void main() {
         final getOutput = _findHandler(plugin, 'sandbox_get_output');
 
         expect(() => getOutput({'handle': 999}), throwsA(isA<ArgumentError>()));
+      });
+    });
+
+    group('sandbox_gather', () {
+      test(
+        'returns attributed results with handle, value, and output',
+        () async {
+          var callCount = 0;
+          final plugin = SandboxPlugin(
+            platformFactory: () async {
+              callCount++;
+              return _completingMockWithResult(
+                value: callCount,
+                printOutput: 'output_$callCount\n',
+              );
+            },
+          );
+          final spawn = _findHandler(plugin, 'sandbox_spawn');
+          final gather = _findHandler(plugin, 'sandbox_gather');
+
+          final h0 = (await spawn({'code': 'a'}))! as int;
+          final h1 = (await spawn({'code': 'b'}))! as int;
+
+          final result =
+              (await gather({
+                    'handles': [h0, h1],
+                  }))!
+                  as List<Object?>;
+
+          expect(result, hasLength(2));
+          final r0 = result[0]! as Map<String, Object?>;
+          final r1 = result[1]! as Map<String, Object?>;
+
+          expect(r0['handle'], h0);
+          expect(r0['value'], isNotNull);
+          expect(r0['output'], isNotNull);
+          expect(r1['handle'], h1);
+          expect(r1['value'], isNotNull);
+          expect(r1['output'], isNotNull);
+        },
+      );
+
+      test('preserves handle order', () async {
+        var callCount = 0;
+        final plugin = SandboxPlugin(
+          platformFactory: () async {
+            callCount++;
+            return _completingMockWithResult(value: callCount * 10);
+          },
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final gather = _findHandler(plugin, 'sandbox_gather');
+
+        final h0 = (await spawn({'code': 'a'}))! as int;
+        final h1 = (await spawn({'code': 'b'}))! as int;
+        final h2 = (await spawn({'code': 'c'}))! as int;
+
+        // Request in reverse order.
+        final result =
+            (await gather({
+                  'handles': [h2, h0, h1],
+                }))!
+                as List<Object?>;
+
+        expect(result, hasLength(3));
+        expect((result[0]! as Map)['handle'], h2);
+        expect((result[1]! as Map)['handle'], h0);
+        expect((result[2]! as Map)['handle'], h1);
+      });
+
+      test('handles null printOutput (child with no print)', () async {
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _completingMockWithResult(value: 42),
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final gather = _findHandler(plugin, 'sandbox_gather');
+
+        final h0 = (await spawn({'code': 'a'}))! as int;
+
+        final result =
+            (await gather({
+                  'handles': [h0],
+                }))!
+                as List<Object?>;
+
+        expect(result, hasLength(1));
+        final r0 = result[0]! as Map<String, Object?>;
+        expect(r0['handle'], h0);
+        expect(r0['value'], 42);
+        expect(r0['output'], isNull);
+      });
+
+      test('throws ChildSandboxException if any child fails', () async {
+        var callCount = 0;
+        final plugin = SandboxPlugin(
+          platformFactory: () async {
+            callCount++;
+            if (callCount == 2) return _failingMock('child failed');
+            return _completingMockWithResult(value: callCount);
+          },
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final gather = _findHandler(plugin, 'sandbox_gather');
+
+        final h0 = (await spawn({'code': 'a'}))! as int;
+        final h1 = (await spawn({'code': 'b'}))! as int;
+
+        expect(
+          () => gather({
+            'handles': [h0, h1],
+          }),
+          throwsA(isA<ChildSandboxException>()),
+        );
+      });
+
+      test('throws ArgumentError for unknown handle', () async {
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _completingMock(),
+        );
+        final gather = _findHandler(plugin, 'sandbox_gather');
+
+        expect(
+          () => gather({
+            'handles': [999],
+          }),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+
+      test('works with single handle', () async {
+        final plugin = SandboxPlugin(
+          platformFactory: () async =>
+              _completingMockWithResult(value: 'solo', printOutput: 'hi\n'),
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final gather = _findHandler(plugin, 'sandbox_gather');
+
+        final h0 = (await spawn({'code': 'a'}))! as int;
+
+        final result =
+            (await gather({
+                  'handles': [h0],
+                }))!
+                as List<Object?>;
+
+        expect(result, hasLength(1));
+        final r0 = result[0]! as Map<String, Object?>;
+        expect(r0['handle'], h0);
+        expect(r0['value'], 'solo');
+        expect(r0['output'], 'hi\n');
       });
     });
 


### PR DESCRIPTION
## Summary
- Add `sandbox_gather` host function to SandboxPlugin that awaits multiple children and returns attributed results — each element is a dict with `handle`, `value`, and `output` keys
- Purely additive: `sandbox_await_all` is untouched, no existing seeds break
- Resolves SPIKE-014 (parallel worker output attribution flagged during E17 v2 migration)

## Changes
- **sandbox_plugin.dart**: New `sandbox_gather` HostFunction + `_handleGather` handler, updated `systemPromptContext`
- **sandbox_plugin_test.dart**: 6 unit tests (attributed results, handle order, null output, child failure, unknown handle, single handle), function count 7→8
- **sandbox_gather_test.dart**: 5 FFI integration tests (output attribution, order preservation, silent worker, error propagation, machine-parseability)

## Test plan
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart format .` — clean
- [x] `dart test test/src/plugins/sandbox_plugin_test.dart` — 75/75 pass
- [x] `DYLD_LIBRARY_PATH=../../native/target/release dart test --tags=integration --run-skipped test/integration/sandbox_gather_test.dart` — 5/5 pass
- [x] All pre-commit hooks pass