### PR TITLE
feat(bridge): add invokeHostFunction for Dart-side tool dispatch

### DIFF
--- a/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
@@ -134,6 +134,30 @@ class DefaultMontyBridge implements MontyBridge {
     _isDisposed = true;
   }
 
+  @override
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    CallRole role = const ToolCall(),
+  }) {
+    if (_isDisposed) throw StateError('Bridge has been disposed');
+    final fn = _functions[name];
+    if (fn == null) {
+      throw ArgumentError('Unknown host function: $name');
+    }
+
+    // Route through mapAndValidate for type coercion (e.g., string→int).
+    // Construct a MontyPending with kwargs only (Dart callers use named args).
+    final pending = MontyPending(
+      functionName: name,
+      arguments: const [],
+      kwargs: args,
+    );
+    final validatedArgs = fn.schema.mapAndValidate(pending);
+
+    return _invokeWithMiddleware(fn, name, validatedArgs, role);
+  }
+
   Future<void> _run(
     String code,
     StreamController<BridgeEvent> controller,

--- a/packages/dart_monty_bridge/lib/src/bridge/monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/monty_bridge.dart
@@ -23,6 +23,19 @@ abstract class MontyBridge {
   /// override in implementations that support middleware.
   void use(BridgeMiddleware middleware) {}
 
+  /// Invokes a registered host function by name, routing through middleware.
+  ///
+  /// Use this to call host functions from Dart infrastructure code
+  /// (e.g., orchestration loops) rather than from Python. Arguments are
+  /// validated through [HostFunctionSchema.mapAndValidate] before dispatch.
+  ///
+  /// Throws [ArgumentError] if [name] is not registered.
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    CallRole role = const ToolCall(),
+  });
+
   /// Executes [code] and returns a stream of lifecycle events.
   ///
   /// Events follow the bridge lifecycle:

--- a/packages/dart_monty_bridge/test/src/bridge/default_monty_bridge_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/default_monty_bridge_test.dart
@@ -237,9 +237,7 @@ void main() {
         );
 
       mock
-        ..enqueueProgress(
-          const MontyPending(functionName: 'fn', arguments: []),
-        )
+        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
           const MontyComplete(result: MontyResult(usage: _usage)),
         );
@@ -267,9 +265,7 @@ void main() {
         );
 
       mock
-        ..enqueueProgress(
-          const MontyPending(functionName: 'fn', arguments: []),
-        )
+        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
           const MontyComplete(result: MontyResult(usage: _usage)),
         );
@@ -351,9 +347,7 @@ void main() {
         );
 
       mock
-        ..enqueueProgress(
-          const MontyPending(functionName: 'fn', arguments: []),
-        )
+        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
           const MontyComplete(result: MontyResult(usage: _usage)),
         );
@@ -449,9 +443,7 @@ void main() {
         );
 
       syncMock
-        ..enqueueProgress(
-          const MontyPending(functionName: 'fn', arguments: []),
-        )
+        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
           const MontyComplete(result: MontyResult(usage: _usage)),
         );
@@ -479,9 +471,7 @@ void main() {
         );
 
       syncMock
-        ..enqueueProgress(
-          const MontyPending(functionName: 'fn', arguments: []),
-        )
+        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
           const MontyComplete(result: MontyResult(usage: _usage)),
         );
@@ -504,9 +494,7 @@ void main() {
       );
 
       mock
-        ..enqueueProgress(
-          const MontyPending(functionName: 'fn', arguments: []),
-        )
+        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
           const MontyComplete(result: MontyResult(usage: _usage)),
         );
@@ -517,10 +505,7 @@ void main() {
 
     test('use() after dispose throws StateError', () {
       bridge.dispose();
-      expect(
-        () => bridge.use(_LoggingMiddleware('x', [])),
-        throwsStateError,
-      );
+      expect(() => bridge.use(_LoggingMiddleware('x', [])), throwsStateError);
     });
 
     test('middleware works on futures path', () async {
@@ -579,6 +564,116 @@ void main() {
 
       await bridge.execute('fn()').toList();
       expect(captured, isA<ToolCall>());
+    });
+  });
+
+  group('invokeHostFunction', () {
+    test(
+      'routes through middleware with correct name, args, and role',
+      () async {
+        String? capturedName;
+        Map<String, Object?>? capturedArgs;
+        CallRole? capturedRole;
+
+        bridge
+          ..use(
+            _CapturingMiddleware(
+              onCall: (name, args, role) {
+                capturedName = name;
+                capturedArgs = args;
+                capturedRole = role;
+              },
+            ),
+          )
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'greet',
+                description: '',
+                params: [HostParam(name: 'who', type: HostParamType.string)],
+              ),
+              handler: (args) async => 'hello ${args['who']}',
+            ),
+          );
+
+        final result = await bridge.invokeHostFunction('greet', {
+          'who': 'world',
+        });
+
+        expect(result, 'hello world');
+        expect(capturedName, 'greet');
+        expect(capturedArgs, {'who': 'world'});
+        expect(capturedRole, isA<ToolCall>());
+      },
+    );
+
+    test('unknown function throws ArgumentError', () {
+      expect(() => bridge.invokeHostFunction('nope', {}), throwsArgumentError);
+    });
+
+    test('propagates InfraCall role to middleware', () async {
+      CallRole? capturedRole;
+
+      bridge
+        ..use(_RoleCapturingMiddleware((role) => capturedRole = role))
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'fn', description: ''),
+            handler: (_) async => null,
+          ),
+        );
+
+      await bridge.invokeHostFunction('fn', {}, role: const InfraCall());
+
+      expect(capturedRole, isA<InfraCall>());
+    });
+
+    test('validates arguments via mapAndValidate', () {
+      bridge.register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'need_name',
+            description: '',
+            params: [HostParam(name: 'name', type: HostParamType.string)],
+          ),
+          handler: (_) async => null,
+        ),
+      );
+
+      expect(
+        () => bridge.invokeHostFunction('need_name', {}),
+        throwsFormatException,
+      );
+    });
+
+    test('coerces string to int for integer param', () async {
+      Map<String, Object?>? capturedArgs;
+
+      bridge.register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'add',
+            description: '',
+            params: [HostParam(name: 'n', type: HostParamType.integer)],
+          ),
+          handler: (args) async {
+            capturedArgs = args;
+            return args['n'];
+          },
+        ),
+      );
+
+      final result = await bridge.invokeHostFunction('add', {'n': '42'});
+
+      expect(result, 42);
+      expect(capturedArgs!['n'], isA<int>());
+      expect(capturedArgs!['n'], 42);
+    });
+
+    test('disposed bridge throws StateError', () {
+      bridge.dispose();
+
+      expect(() => bridge.invokeHostFunction('fn', {}), throwsStateError);
     });
   });
 }
@@ -646,6 +741,24 @@ class _ThrowingMiddleware extends BridgeMiddleware {
     CallRole role,
     ToolHandler next,
   ) => throw StateError('Access denied');
+}
+
+class _CapturingMiddleware extends BridgeMiddleware {
+  _CapturingMiddleware({required this.onCall});
+
+  final void Function(String name, Map<String, Object?> args, CallRole role)
+  onCall;
+
+  @override
+  Future<Object?> handle(
+    String name,
+    Map<String, Object?> args,
+    CallRole role,
+    ToolHandler next,
+  ) {
+    onCall(name, args, role);
+    return next(name, args);
+  }
 }
 
 /// A minimal [MontyPlatform] that throws a [MontyException] from [start].

--- a/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
@@ -124,5 +124,12 @@ class _NoOpBridge implements MontyBridge {
   Stream<BridgeEvent> execute(String code) => const Stream.empty();
 
   @override
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    CallRole role = const ToolCall(),
+  }) => throw UnimplementedError();
+
+  @override
   void dispose() {}
 }

--- a/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
@@ -331,10 +331,7 @@ void main() {
             ),
           )
           ..register(
-            _LifecyclePlugin(
-              namespace: 'bbb',
-              functions: [_fn('bbb_x')],
-            ),
+            _LifecyclePlugin(namespace: 'bbb', functions: [_fn('bbb_x')]),
           );
 
         await expectLater(
@@ -613,6 +610,13 @@ class _MockBridge implements MontyBridge {
 
   @override
   Stream<BridgeEvent> execute(String code) => const Stream.empty();
+
+  @override
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    CallRole role = const ToolCall(),
+  }) => throw UnimplementedError();
 
   @override
   void dispose() {}


### PR DESCRIPTION
## Summary
- Adds `invokeHostFunction(name, args, {role})` to `MontyBridge` interface and `DefaultMontyBridge`
- Enables Dart infrastructure code (e.g., orchestration loops) to call registered host functions through the middleware chain without going through the Python runtime
- Routes through `mapAndValidate` for type coercion, then `_invokeWithMiddleware` for the full middleware onion

## Changes
- **monty_bridge.dart**: New abstract method on `MontyBridge` interface
- **default_monty_bridge.dart**: Implementation with disposed/unknown-function guards + mapAndValidate + middleware dispatch
- **Tests**: 6 new tests (middleware routing, role propagation, argument validation, type coercion, error cases)
- **Mock updates**: `_NoOpBridge` and `_MockBridge` stubs updated for new interface method

## Test plan
- [x] 212 unit tests pass (5 integration skipped — requires native library)
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart format` — clean
- [x] Pre-commit hooks pass (format, analyze, platform_interface tests)
- [x] Additive only — no existing behavior modified
- [x] `EventLoopBridge` inherits automatically (extends DefaultMontyBridge)

## Context
Part of Option C (Dart-native orchestration engine) — see `claw_exploration/option_c_dart_orchestrator_design.md`. dart_claw PR (feat/dart-orchestrator) depends on this.