### PR TITLE
feat(bridge): add ChildSpawnContext for per-child filesystem isolation

### DIFF
--- a/packages/dart_monty_bridge/lib/src/bridge/monty_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/monty_plugin.dart
@@ -2,6 +2,26 @@ import 'package:dart_monty_bridge/src/bridge/host_function.dart';
 import 'package:dart_monty_bridge/src/bridge/monty_bridge.dart';
 import 'package:meta/meta.dart';
 
+/// Context passed to [MontyPlugin.createChildInstance] when a child sandbox
+/// is spawned.
+///
+/// Carries the child's unique [childId] and an optional [workingDirectory]
+/// that the consumer can use for per-child filesystem isolation.
+class ChildSpawnContext {
+  /// Creates a [ChildSpawnContext].
+  const ChildSpawnContext({required this.childId, this.workingDirectory});
+
+  /// Unique identifier for this child within the parent `SandboxPlugin`.
+  final int childId;
+
+  /// Per-child working directory path, or `null` if the parent did not
+  /// configure `SandboxPlugin.sandboxBaseDir`.
+  ///
+  /// This is a computed path string only — actual directory creation is the
+  /// consumer's responsibility (e.g., in `FsPlugin.createChildInstance`).
+  final String? workingDirectory;
+}
+
 /// Extension point for providing host functions to a [MontyBridge].
 ///
 /// Each plugin declares a unique [namespace], a set of [functions], and
@@ -34,5 +54,10 @@ abstract class MontyPlugin {
   ///
   /// The returned instance must be independent — it will be registered on a
   /// separate [MontyBridge] and disposed with the child.
-  MontyPlugin? createChildInstance() => null;
+  ///
+  /// [context] carries the child's ID and optional per-child working
+  /// directory. Plugins that need filesystem isolation (e.g., `FsPlugin`)
+  /// can use [ChildSpawnContext.workingDirectory] to create a private
+  /// directory for the child.
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) => null;
 }

--- a/packages/dart_monty_bridge/lib/src/plugins/json_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/json_plugin.dart
@@ -101,7 +101,7 @@ class JsonPlugin extends MontyPlugin {
   ];
 
   @override
-  MontyPlugin? createChildInstance() => JsonPlugin(
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) => JsonPlugin(
     logger: LogManager.instance.getLogger('JsonPlugin.child'),
     maxInputSize: _maxInputSize,
   );

--- a/packages/dart_monty_bridge/lib/src/plugins/message_bus_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/message_bus_plugin.dart
@@ -238,10 +238,11 @@ class MessageBusPlugin extends MontyPlugin {
   ];
 
   @override
-  MontyPlugin? createChildInstance() => MessageBusPlugin(
-    bus: _bus,
-    logger: LogManager.instance.getLogger('MessageBusPlugin.child'),
-  );
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) =>
+      MessageBusPlugin(
+        bus: _bus,
+        logger: LogManager.instance.getLogger('MessageBusPlugin.child'),
+      );
 
   @override
   Future<void> onDispose() async {

--- a/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:dart_monty_bridge/dart_monty_bridge.dart';
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
+import 'package:path/path.dart' as p;
 import 'package:struct_log/struct_log.dart';
 
 /// Exception thrown when a child sandbox fails, is cancelled, or is disposed.
@@ -37,8 +38,14 @@ typedef MontyPlatformFactory = Future<MontyPlatform> Function();
 
 /// Factory that creates and configures a [PluginRegistry] for child bridges.
 ///
+/// Receives the [ChildSpawnContext] for the child being spawned, allowing
+/// the factory to configure per-child resources (e.g., filesystem roots).
+///
 /// Return `null` to give children only introspection builtins (no plugins).
-typedef ChildPluginRegistryFactory = Future<PluginRegistry?> Function();
+typedef ChildPluginRegistryFactory =
+    Future<PluginRegistry?> Function(
+      ChildSpawnContext context,
+    );
 
 /// Tracks a spawned child interpreter.
 class _ChildHandle {
@@ -98,6 +105,7 @@ class SandboxPlugin extends MontyPlugin {
     this.maxDepth = 3,
     this.currentDepth = 0,
     this.childLimits,
+    this.sandboxBaseDir,
     Logger? logger,
   }) : log = logger ?? LogManager.instance.getLogger('SandboxPlugin');
 
@@ -126,6 +134,14 @@ class SandboxPlugin extends MontyPlugin {
 
   /// Resource limits applied to child interpreters.
   final MontyLimits? childLimits;
+
+  /// Base directory for per-child sandbox working directories.
+  ///
+  /// When non-null, each child receives a [ChildSpawnContext] with
+  /// `workingDirectory` set to `$sandboxBaseDir/.sandboxes/child_$id`.
+  /// The directory is **not** created by this plugin — consumers (e.g.,
+  /// `FsPlugin.createChildInstance`) are responsible for creation.
+  final String? sandboxBaseDir;
 
   /// Logger for this plugin instance.
   final Logger log;
@@ -292,9 +308,7 @@ class SandboxPlugin extends MontyPlugin {
         'Spawn rejected: depth limit',
         attributes: {'currentDepth': currentDepth, 'maxDepth': maxDepth},
       );
-      throw StateError(
-        'Maximum sandbox recursion depth ($maxDepth) exceeded.',
-      );
+      throw StateError('Maximum sandbox recursion depth ($maxDepth) exceeded.');
     }
     final aliveCount = _children.values.where((c) => c.isAlive).length;
     if (aliveCount >= maxChildren) {
@@ -318,6 +332,15 @@ class SandboxPlugin extends MontyPlugin {
         stackDepth: childLimits?.stackDepth,
       );
     }
+
+    // Allocate ID early so ChildSpawnContext is available for plugin wiring.
+    final id = _nextId++;
+    final spawnContext = ChildSpawnContext(
+      childId: id,
+      workingDirectory: sandboxBaseDir != null
+          ? p.join(sandboxBaseDir!, '.sandboxes', 'child_$id')
+          : null,
+    );
 
     // Create child platform, bridge, and wire plugins.
     // All phases are inside a single cleanup scope so that any failure
@@ -352,7 +375,7 @@ class SandboxPlugin extends MontyPlugin {
       if (registryFactory != null) {
         // Explicit factory takes precedence.
         try {
-          childRegistry = await registryFactory();
+          childRegistry = await registryFactory(spawnContext);
         } on Object catch (e, st) {
           log.error(
             'Child plugin factory failed',
@@ -365,7 +388,7 @@ class SandboxPlugin extends MontyPlugin {
       } else if (parentPlugins.isNotEmpty) {
         // Auto-inherit from parent plugins via createChildInstance().
         try {
-          childRegistry = _buildInheritedRegistry();
+          childRegistry = _buildInheritedRegistry(spawnContext);
         } on Object catch (e, st) {
           log.error(
             'Child plugin inheritance failed',
@@ -391,10 +414,7 @@ class SandboxPlugin extends MontyPlugin {
             'Child plugin attachment failed',
             error: e,
             stackTrace: st,
-            attributes: {
-              'phase': 'attachTo',
-              'pluginCount': pluginCount,
-            },
+            attributes: {'phase': 'attachTo', 'pluginCount': pluginCount},
           );
           rethrow;
         }
@@ -406,7 +426,6 @@ class SandboxPlugin extends MontyPlugin {
       rethrow;
     }
 
-    final id = _nextId++;
     final completer = Completer<Object?>();
     completer.future.ignore();
 
@@ -504,12 +523,12 @@ class SandboxPlugin extends MontyPlugin {
   }
 
   /// Builds a child registry from parent plugins that opt into inheritance.
-  PluginRegistry? _buildInheritedRegistry() {
+  PluginRegistry? _buildInheritedRegistry(ChildSpawnContext context) {
     final childPlugins = <MontyPlugin>[];
     for (final plugin in parentPlugins) {
       // Skip SandboxPlugin itself -- children get their own via depth control.
       if (plugin is SandboxPlugin) continue;
-      final child = plugin.createChildInstance();
+      final child = plugin.createChildInstance(context: context);
       if (child == null) continue;
       // Guard: returning `this` would cause the parent plugin to be disposed
       // when the child finishes, and returning a SandboxPlugin would bypass

--- a/packages/dart_monty_bridge/lib/src/plugins/template_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/template_plugin.dart
@@ -62,10 +62,11 @@ class DinjaTemplatePlugin extends MontyPlugin {
   ];
 
   @override
-  MontyPlugin? createChildInstance() => DinjaTemplatePlugin(
-    logger: LogManager.instance.getLogger('DinjaTemplatePlugin.child'),
-    maxInputSize: _maxInputSize,
-  );
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) =>
+      DinjaTemplatePlugin(
+        logger: LogManager.instance.getLogger('DinjaTemplatePlugin.child'),
+        maxInputSize: _maxInputSize,
+      );
 
   Future<Object?> _handleRender(Map<String, Object?> args) async {
     final templateStr = args['template']! as String;

--- a/packages/dart_monty_bridge/pubspec.yaml
+++ b/packages/dart_monty_bridge/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   dart_monty_platform_interface: ^0.7.0
   dinja: ^1.0.0
   meta: ^1.11.0
+  path: ^1.8.0
   struct_log: ^0.1.0
 
 dev_dependencies:

--- a/packages/dart_monty_bridge/test/integration/sandbox_plugin_inheritance_test.dart
+++ b/packages/dart_monty_bridge/test/integration/sandbox_plugin_inheritance_test.dart
@@ -9,11 +9,7 @@ import 'package:test/test.dart';
 /// Wraps a single Python expression in async-def/await for futures-mode
 /// child bridges. Backslash-n are literal (for embedding in spawn code=).
 String _asyncChild(String expr) {
-  return [
-    'async def w():',
-    '    return await $expr',
-    'await w()',
-  ].join(r'\n');
+  return ['async def w():', '    return await $expr', 'await w()'].join(r'\n');
 }
 
 /// Integration tests for SandboxPlugin child inheritance with real FFI.
@@ -36,10 +32,7 @@ void main() {
   MontyPlatform createPlatform() => MontyFfi(bindings: bindings);
 
   /// Executes [code] on a bridge and returns the final value or throws.
-  Future<Object?> run(
-    DefaultMontyBridge bridge,
-    String code,
-  ) async {
+  Future<Object?> run(DefaultMontyBridge bridge, String code) async {
     Object? result;
     String? error;
     await for (final event in bridge.execute(code)) {
@@ -125,10 +118,7 @@ void main() {
         );
       await registry.attachTo(bridge);
 
-      final result = await run(
-        bridge,
-        'greeter_hello(name="parent")',
-      );
+      final result = await run(bridge, 'greeter_hello(name="parent")');
 
       expect(result, 'Hello, parent!');
       bridge.dispose();
@@ -164,9 +154,7 @@ void main() {
       final bridge = createBridge();
       final registry = PluginRegistry()
         ..register(
-          SandboxPlugin(
-            platformFactory: () async => createPlatform(),
-          ),
+          SandboxPlugin(platformFactory: () async => createPlatform()),
         );
       await registry.attachTo(bridge);
 
@@ -241,7 +229,7 @@ void main() {
           SandboxPlugin(
             platformFactory: () async => createPlatform(),
             parentPlugins: [greeter],
-            childPluginRegistryFactory: () async {
+            childPluginRegistryFactory: (_) async {
               // Empty registry — no parent inheritance.
               return PluginRegistry();
             },
@@ -265,6 +253,79 @@ void main() {
       expect(result, 'error_caught');
       bridge.dispose();
     });
+  });
+  // ---------------------------------------------------------------------------
+  // ChildSpawnContext threading
+  // ---------------------------------------------------------------------------
+
+  group('ChildSpawnContext threading', () {
+    test(
+      'child receives context with working directory via real FFI',
+      () async {
+        ChildSpawnContext? capturedContext;
+        final contextPlugin = _ContextCapturingPlugin(
+          onContext: (ctx) => capturedContext = ctx,
+        );
+        final bridge = createBridge();
+        final registry = PluginRegistry()
+          ..register(contextPlugin)
+          ..register(
+            SandboxPlugin(
+              platformFactory: () async => createPlatform(),
+              sandboxBaseDir: '/tmp/sandbox_test',
+              parentPlugins: [contextPlugin],
+            ),
+          );
+        await registry.attachTo(bridge);
+
+        final result = await run(
+          bridge,
+          'h = ${spawn("2 + 2")}\n'
+          'sandbox_await(handle=h)',
+        );
+
+        expect(result, 4);
+        expect(capturedContext, isNotNull);
+        expect(capturedContext!.childId, 0);
+        expect(
+          capturedContext!.workingDirectory,
+          contains('.sandboxes/child_0'),
+        );
+        bridge.dispose();
+      },
+    );
+
+    test(
+      'context has null workingDirectory when sandboxBaseDir unset',
+      () async {
+        ChildSpawnContext? capturedContext;
+        final contextPlugin = _ContextCapturingPlugin(
+          onContext: (ctx) => capturedContext = ctx,
+        );
+        final bridge = createBridge();
+        final registry = PluginRegistry()
+          ..register(contextPlugin)
+          ..register(
+            SandboxPlugin(
+              platformFactory: () async => createPlatform(),
+              parentPlugins: [contextPlugin],
+            ),
+          );
+        await registry.attachTo(bridge);
+
+        final result = await run(
+          bridge,
+          'h = ${spawn("1 + 1")}\n'
+          'sandbox_await(handle=h)',
+        );
+
+        expect(result, 2);
+        expect(capturedContext, isNotNull);
+        expect(capturedContext!.childId, 0);
+        expect(capturedContext!.workingDirectory, isNull);
+        bridge.dispose();
+      },
+    );
   });
 }
 
@@ -299,7 +360,8 @@ class _GreeterPlugin extends MontyPlugin {
   ];
 
   @override
-  MontyPlugin? createChildInstance() => _GreeterPlugin();
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) =>
+      _GreeterPlugin();
 }
 
 /// Plugin that provides a counter. Each instance has its own count.
@@ -331,5 +393,28 @@ class _CounterPlugin extends MontyPlugin {
   ];
 
   @override
-  MontyPlugin? createChildInstance() => _CounterPlugin();
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) =>
+      _CounterPlugin();
+}
+
+/// Plugin that captures the [ChildSpawnContext] for test assertions.
+class _ContextCapturingPlugin extends MontyPlugin {
+  _ContextCapturingPlugin({required this.onContext});
+
+  final void Function(ChildSpawnContext) onContext;
+
+  @override
+  String get namespace => 'ctx_capture';
+
+  @override
+  String? get systemPromptContext => null;
+
+  @override
+  List<HostFunction> get functions => [];
+
+  @override
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) {
+    if (context != null) onContext(context);
+    return null;
+  }
 }

--- a/packages/dart_monty_bridge/test/integration/sandbox_plugin_reg_failure_test.dart
+++ b/packages/dart_monty_bridge/test/integration/sandbox_plugin_reg_failure_test.dart
@@ -54,7 +54,7 @@ void main() {
         ..register(
           SandboxPlugin(
             platformFactory: () async => createPlatform(),
-            childPluginRegistryFactory: () async {
+            childPluginRegistryFactory: (_) async {
               throw StateError('factory boom');
             },
             logger: logger,
@@ -84,7 +84,7 @@ void main() {
         ..register(
           SandboxPlugin(
             platformFactory: () async => createPlatform(),
-            childPluginRegistryFactory: () async {
+            childPluginRegistryFactory: (_) async {
               final childRegistry = PluginRegistry()
                 ..register(_IntegrationBoomPlugin());
               return childRegistry;

--- a/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/monty_plugin_test.dart
@@ -93,6 +93,16 @@ void main() {
       expect(plugin.createChildInstance(), isNull);
     });
 
+    test('createChildInstance accepts optional context', () {
+      final plugin = _TestPlugin(namespace: 'ns', functions: []);
+      const context = ChildSpawnContext(
+        childId: 42,
+        workingDirectory: '/tmp/child_42',
+      );
+
+      expect(plugin.createChildInstance(context: context), isNull);
+    });
+
     test('onDispose default implementation is a no-op', () async {
       final plugin = _TestPlugin(
         namespace: 'ns',

--- a/packages/dart_monty_bridge/test/src/plugins/sandbox_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/plugins/sandbox_plugin_test.dart
@@ -738,10 +738,7 @@ void main() {
         await await_({'handle': handle! as int});
         await free({'handle': handle as int});
 
-        expect(
-          () => free({'handle': handle}),
-          throwsA(isA<ArgumentError>()),
-        );
+        expect(() => free({'handle': handle}), throwsA(isA<ArgumentError>()));
       });
     });
 
@@ -871,11 +868,7 @@ void main() {
           throwsA(
             isA<ChildSandboxException>()
                 .having((e) => e.exception, 'exception', isNull)
-                .having(
-                  (e) => e.message,
-                  'message',
-                  contains('infra boom'),
-                ),
+                .having((e) => e.message, 'message', contains('infra boom')),
           ),
         );
       });
@@ -939,7 +932,7 @@ void main() {
       test('child gets plugins from factory', () async {
         final plugin = SandboxPlugin(
           platformFactory: () async => _completingMock(),
-          childPluginRegistryFactory: () async {
+          childPluginRegistryFactory: (_) async {
             final registry = PluginRegistry()
               ..register(
                 _TestPlugin(
@@ -973,7 +966,7 @@ void main() {
           final plugin = SandboxPlugin(
             platformFactory: () async => _completingMock(),
             parentPlugins: [parentPlugin],
-            childPluginRegistryFactory: () async {
+            childPluginRegistryFactory: (_) async {
               factoryCalled = true;
               // Explicit factory returns empty registry —
               // no parent inheritance.
@@ -1079,34 +1072,133 @@ void main() {
           );
           final spawn = _findHandler(plugin, 'sandbox_spawn');
 
-          await expectLater(
-            spawn({'code': '42'}),
-            throwsStateError,
-          );
+          await expectLater(spawn({'code': '42'}), throwsStateError);
         },
       );
 
+      test('spawn cleans up platform on factory failure', () async {
+        late MockMontyPlatform createdMock;
+        final plugin = SandboxPlugin(
+          platformFactory: () async {
+            return createdMock = _completingMock();
+          },
+          childPluginRegistryFactory: (_) async {
+            throw StateError('factory boom');
+          },
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+
+        await expectLater(spawn({'code': '42'}), throwsStateError);
+        expect(createdMock.isDisposed, isTrue);
+      });
+    });
+
+    group('ChildSpawnContext threading', () {
       test(
-        'spawn cleans up platform on factory failure',
+        'context flows to createChildInstance with correct childId',
         () async {
-          late MockMontyPlatform createdMock;
+          ChildSpawnContext? capturedContext;
           final plugin = SandboxPlugin(
-            platformFactory: () async {
-              return createdMock = _completingMock();
-            },
-            childPluginRegistryFactory: () async {
-              throw StateError('factory boom');
-            },
+            platformFactory: () async => _completingMock(),
+            parentPlugins: [
+              _ContextCapturingPlugin(
+                onContext: (ctx) => capturedContext = ctx,
+              ),
+            ],
           );
           final spawn = _findHandler(plugin, 'sandbox_spawn');
+          final await_ = _findHandler(plugin, 'sandbox_await');
 
-          await expectLater(
-            spawn({'code': '42'}),
-            throwsStateError,
-          );
-          expect(createdMock.isDisposed, isTrue);
+          final handle = await spawn({'code': '42'});
+          await await_({'handle': handle! as int});
+
+          expect(capturedContext, isNotNull);
+          expect(capturedContext!.childId, 0);
         },
       );
+
+      test('null sandboxBaseDir gives null workingDirectory', () async {
+        ChildSpawnContext? capturedContext;
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _completingMock(),
+          parentPlugins: [
+            _ContextCapturingPlugin(onContext: (ctx) => capturedContext = ctx),
+          ],
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+
+        final handle = await spawn({'code': '42'});
+        await await_({'handle': handle! as int});
+
+        expect(capturedContext, isNotNull);
+        expect(capturedContext!.workingDirectory, isNull);
+      });
+
+      test('sandboxBaseDir produces correct workingDirectory', () async {
+        ChildSpawnContext? capturedContext;
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _completingMock(),
+          sandboxBaseDir: '/tmp/test',
+          parentPlugins: [
+            _ContextCapturingPlugin(onContext: (ctx) => capturedContext = ctx),
+          ],
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+
+        final handle = await spawn({'code': '42'});
+        await await_({'handle': handle! as int});
+
+        expect(capturedContext, isNotNull);
+        expect(
+          capturedContext!.workingDirectory,
+          '/tmp/test/.sandboxes/child_0',
+        );
+      });
+
+      test('sequential spawns get incrementing paths', () async {
+        final contexts = <ChildSpawnContext>[];
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _completingMock(),
+          sandboxBaseDir: '/data',
+          parentPlugins: [_ContextCapturingPlugin(onContext: contexts.add)],
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+
+        final h0 = (await spawn({'code': '1'}))! as int;
+        final h1 = (await spawn({'code': '2'}))! as int;
+        await await_({'handle': h0});
+        await await_({'handle': h1});
+
+        expect(contexts, hasLength(2));
+        expect(contexts[0].childId, 0);
+        expect(contexts[0].workingDirectory, '/data/.sandboxes/child_0');
+        expect(contexts[1].childId, 1);
+        expect(contexts[1].workingDirectory, '/data/.sandboxes/child_1');
+      });
+
+      test('factory receives ChildSpawnContext', () async {
+        ChildSpawnContext? factoryContext;
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _completingMock(),
+          sandboxBaseDir: '/base',
+          childPluginRegistryFactory: (ctx) async {
+            factoryContext = ctx;
+            return null;
+          },
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+
+        final handle = await spawn({'code': '42'});
+        await await_({'handle': handle! as int});
+
+        expect(factoryContext, isNotNull);
+        expect(factoryContext!.childId, 0);
+        expect(factoryContext!.workingDirectory, '/base/.sandboxes/child_0');
+      });
     });
 
     group('structured logging', () {
@@ -1322,7 +1414,7 @@ void main() {
       test('factory failure logs error with phase=factory', () async {
         final plugin = SandboxPlugin(
           platformFactory: () async => _completingMock(),
-          childPluginRegistryFactory: () async {
+          childPluginRegistryFactory: (_) async {
             throw StateError('factory boom');
           },
           logger: logger,
@@ -1363,7 +1455,7 @@ void main() {
       test('plugin attachment logs debug with plugin count', () async {
         final plugin = SandboxPlugin(
           platformFactory: () async => _completingMock(),
-          childPluginRegistryFactory: () async {
+          childPluginRegistryFactory: (_) async {
             final registry = PluginRegistry()
               ..register(
                 _TestPlugin(
@@ -1420,7 +1512,7 @@ void main() {
         () async {
           final plugin = SandboxPlugin(
             platformFactory: () async => _completingMock(),
-            childPluginRegistryFactory: () async {
+            childPluginRegistryFactory: (_) async {
               final registry = PluginRegistry()..register(_AttachBoomPlugin());
               return registry;
             },
@@ -1446,7 +1538,7 @@ void main() {
           platformFactory: () async {
             return createdMock = _completingMock();
           },
-          childPluginRegistryFactory: () async {
+          childPluginRegistryFactory: (_) async {
             throw StateError('factory boom');
           },
           logger: logger,
@@ -1538,7 +1630,7 @@ class _InheritablePlugin extends MontyPlugin {
   ];
 
   @override
-  MontyPlugin? createChildInstance() =>
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) =>
       _InheritablePlugin(namespace: namespace);
 }
 
@@ -1556,7 +1648,7 @@ class _ReturnsSandboxPlugin extends MontyPlugin {
   List<HostFunction> get functions => [];
 
   @override
-  MontyPlugin? createChildInstance() =>
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) =>
       SandboxPlugin(platformFactory: () async => MockMontyPlatform());
 }
 
@@ -1572,6 +1664,29 @@ class _TestPlugin extends MontyPlugin {
 
   @override
   final List<HostFunction> functions;
+}
+
+/// Plugin that captures the [ChildSpawnContext] passed to
+/// [MontyPlugin.createChildInstance].
+class _ContextCapturingPlugin extends MontyPlugin {
+  _ContextCapturingPlugin({required this.onContext});
+
+  final void Function(ChildSpawnContext) onContext;
+
+  @override
+  String get namespace => 'ctx_capture';
+
+  @override
+  final String? systemPromptContext = null;
+
+  @override
+  List<HostFunction> get functions => [];
+
+  @override
+  MontyPlugin? createChildInstance({ChildSpawnContext? context}) {
+    if (context != null) onContext(context);
+    return _TestPlugin(namespace: 'ctx_child', functions: []);
+  }
 }
 
 /// A [MontyPlatform] that completes normally but throws on [dispose].


### PR DESCRIPTION
## Summary
- Add `ChildSpawnContext` data class to carry per-child `childId` and `workingDirectory` through the spawn flow
- Update `MontyPlugin.createChildInstance` and `ChildPluginRegistryFactory` to accept context
- Add `sandboxBaseDir` param to `SandboxPlugin` — computes `$base/.sandboxes/child_$id` paths via `p.join` (no `dart:io`)
- Move `_nextId++` before plugin wiring so context is fully hydrated (caught by Gemini review)

## Changes
- **monty_plugin.dart**: `ChildSpawnContext` class, `createChildInstance({ChildSpawnContext? context})` signature
- **sandbox_plugin.dart**: Updated typedef, `sandboxBaseDir` field, context threading in `_handleSpawn` and `_buildInheritedRegistry`
- **json_plugin.dart, message_bus_plugin.dart, template_plugin.dart**: Override signatures updated
- **pubspec.yaml**: Added `path` dependency for safe path joining
- **sandbox_plugin_test.dart**: 5 new unit tests (context threading, null baseDir, path computation, sequential IDs, factory context)
- **sandbox_plugin_inheritance_test.dart**: 2 new FFI integration tests (context with working dir, null workingDirectory)
- **sandbox_plugin_reg_failure_test.dart**: Factory lambda signature updated

## Context
Phase 1 of per-child filesystem isolation (#211). This PR adds the generic mechanism to `dart_monty_bridge`; dart_claw consumes it in a follow-up PR to give each child sandbox a private writable directory with read-only access to the shared parent dir.

## Test plan
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart test --exclude-tags=integration` — 243/243 pass
- [x] Pre-commit hooks pass (format, analyze, platform_interface tests)
- [x] Gemini pre-review (plan) + post-review (diff) — all criteria PASS

Closes #211