### PR TITLE
fix(sandbox): child bridges use useFutures: false (#212)

### DIFF
--- a/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
@@ -69,10 +69,13 @@ class _ChildHandle {
 
   Future<void> cancel() async {
     isAlive = false;
+    // Dispose plugins FIRST — this unblocks pending handler Futures
+    // (e.g., MessageBusPlugin completes waiters with StateError).
+    // The bridge/stream must still be alive to deliver the resulting errors.
+    if (registry != null) await registry!.disposeAll();
     await subscription.cancel();
     bridge.dispose();
     await platform.dispose();
-    if (registry != null) await registry!.disposeAll();
   }
 }
 
@@ -361,7 +364,11 @@ class SandboxPlugin extends MontyPlugin {
         );
         rethrow;
       }
-      bridge = DefaultMontyBridge(platform: platform, limits: limits);
+      bridge = DefaultMontyBridge(
+        platform: platform,
+        limits: limits,
+        useFutures: false,
+      );
       log.debug(
         'Child bridge created',
         attributes: {
@@ -462,10 +469,11 @@ class SandboxPlugin extends MontyPlugin {
         // Clean up child resources.
         // bridge and platform are guaranteed non-null here -- the try block
         // succeeded before the stream listener was created.
+        // Dispose plugins first to unblock any pending handler Futures.
         try {
+          if (childRegistry != null) await childRegistry.disposeAll();
           bridge!.dispose();
           await platform!.dispose();
-          if (childRegistry != null) await childRegistry.disposeAll();
         } on Object catch (e, st) {
           log.warning(
             'Child cleanup error (swallowed)',

--- a/packages/dart_monty_bridge/test/integration/message_bus_integration_test.dart
+++ b/packages/dart_monty_bridge/test/integration/message_bus_integration_test.dart
@@ -71,11 +71,8 @@ void main() {
     final bridge = await createBridgeWithMessageBus();
 
     // Child blocks on msg_recv until the parent sends, then returns the value.
-    final childCode = [
-      'async def w():',
-      r'    return await msg_recv(name=\"inbox\")',
-      'await w()',
-    ].join(r'\n');
+    // useFutures: false on child bridges (#212) — direct call, no await.
+    const childCode = r'msg_recv(name=\"inbox\")';
 
     final result = await run(
       bridge,
@@ -99,15 +96,12 @@ void main() {
     // and replies with a rich result — demonstrating first-class Dart
     // objects (maps, lists, ints, strings, bools) flowing both directions,
     // unlike print() which only returns flat strings.
-    const sendLine =
-        r'    await msg_send(name=\"result\", message={\"total\": total, \"count\": len(items), \"source\": task[\"meta\"][\"origin\"], \"passed\": total > 10})';
+    // useFutures: false on child bridges (#212) — direct calls, no await.
     final childCode = [
-      'async def w():',
-      r'    task = await msg_recv(name=\"work\")',
-      r'    items = task[\"items\"]',
-      '    total = items[0] + items[1] + items[2]',
-      sendLine,
-      'await w()',
+      r'task = msg_recv(name=\"work\")',
+      r'items = task[\"items\"]',
+      'total = items[0] + items[1] + items[2]',
+      r'msg_send(name=\"result\", message={\"total\": total, \"count\": len(items), \"source\": task[\"meta\"][\"origin\"], \"passed\": total > 10})',
     ].join(r'\n');
 
     final result = await run(
@@ -137,18 +131,13 @@ void main() {
 
     // Each worker receives a value on its input channel, doubles it, and
     // sends the result on its output channel.
+    // useFutures: false on child bridges (#212) — direct calls, no await.
     String workerCode(String inCh, String outCh) {
-      final recvLine = '    task = await msg_recv(name=\\"$inCh\\")';
-      const doubleLine = r'    doubled = task[\"value\"] * 2';
+      final recvLine = 'task = msg_recv(name=\\"$inCh\\")';
+      const doubleLine = r'doubled = task[\"value\"] * 2';
       final sendLine =
-          '    await msg_send(name=\\"$outCh\\", message={\\"doubled\\": doubled})';
-      return [
-        'async def w():',
-        recvLine,
-        doubleLine,
-        sendLine,
-        'await w()',
-      ].join(r'\n');
+          'msg_send(name=\\"$outCh\\", message={\\"doubled\\": doubled})';
+      return [recvLine, doubleLine, sendLine].join(r'\n');
     }
 
     final result = await run(

--- a/packages/dart_monty_bridge/test/integration/sandbox_plugin_inheritance_test.dart
+++ b/packages/dart_monty_bridge/test/integration/sandbox_plugin_inheritance_test.dart
@@ -6,11 +6,9 @@ import 'package:dart_monty_ffi/dart_monty_ffi.dart';
 import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
 import 'package:test/test.dart';
 
-/// Wraps a single Python expression in async-def/await for futures-mode
-/// child bridges. Backslash-n are literal (for embedding in spawn code=).
-String _asyncChild(String expr) {
-  return ['async def w():', '    return await $expr', 'await w()'].join(r'\n');
-}
+/// Child bridges use useFutures: false (#212), so host function calls
+/// return resolved values directly — no async def/await needed.
+String _syncChild(String expr) => expr;
 
 /// Integration tests for SandboxPlugin child inheritance with real FFI.
 ///
@@ -50,8 +48,8 @@ void main() {
   String spawn(String childCode) => 'sandbox_spawn(code="$childCode")';
 
   // Parent bridge uses useFutures: false for simpler test code.
-  // Child bridges (created by SandboxPlugin) use useFutures: true by default,
-  // so child code calling host functions must use async def + await.
+  // Child bridges (created by SandboxPlugin) also use useFutures: false
+  // (see #212 — prevents unawaited Future leaking as Python coroutine).
   DefaultMontyBridge createBridge() =>
       DefaultMontyBridge(platform: createPlatform(), useFutures: false);
 
@@ -137,9 +135,8 @@ void main() {
         );
       await registry.attachTo(bridge);
 
-      // Child bridge uses futures by default — child code must use
-      // async def + await for host function calls.
-      final cc = _asyncChild(r'greeter_hello(name=\"child\")');
+      // Child bridge uses useFutures: false (#212) — direct calls.
+      final cc = _syncChild(r'greeter_hello(name=\"child\")');
       final result = await run(
         bridge,
         'h = ${spawn(cc)}\n'
@@ -159,7 +156,7 @@ void main() {
       await registry.attachTo(bridge);
 
       // Child calls greeter_hello — not available (no inheritance).
-      final cc = _asyncChild(r'greeter_hello(name=\"test\")');
+      final cc = _syncChild(r'greeter_hello(name=\"test\")');
       final result = await run(
         bridge,
         'h = ${spawn(cc)}\n'
@@ -189,11 +186,10 @@ void main() {
       await registry.attachTo(bridge);
 
       // Each child increments its own counter independently.
+      // useFutures: false — direct calls, no async/await needed.
       final cc = [
-        'async def w():',
-        '    await counter_increment()',
-        '    return await counter_get()',
-        'await w()',
+        'counter_increment()',
+        'counter_get()',
       ].join(r'\n');
       final result = await run(
         bridge,
@@ -238,7 +234,7 @@ void main() {
       await registry.attachTo(bridge);
 
       // Child should NOT have greeter_hello (factory overrides).
-      final cc = _asyncChild(r'greeter_hello(name=\"test\")');
+      final cc = _syncChild(r'greeter_hello(name=\"test\")');
       final result = await run(
         bridge,
         'h = ${spawn(cc)}\n'


### PR DESCRIPTION
## Summary
- Fix child sandbox bridges leaking unawaited Dart Futures as Python coroutine objects
- Fix disposal ordering in `_ChildHandle.cancel()` to prevent orphaned Futures on cancel

## Changes
- **SandboxPlugin._handleSpawn()**: Create child bridges with `useFutures: false` — host function calls block synchronously and return resolved values, not awaitables
- **_ChildHandle.cancel()**: Reorder disposal — plugins first (unblocks pending handler Futures like `msg_recv` Completers), then subscription/bridge/platform
- **Tests**: Remove `async def`/`await` wrappers from child Python code in integration tests (no longer needed with sync dispatch)

## Root cause
`DefaultMontyBridge` defaults to `useFutures: true`, which stores host function Futures in `_pendingFutures` and returns coroutine handles to Python. Child sandboxes run procedural scripts that never `await` these handles, so `MontyResolveFutures` is never emitted and the Future leaks as a coroutine object. This only manifested with slow models (120b) where `msg_recv` returned pending Futures rather than immediately-resolved `Future.value()`.

## Test plan
- [x] 260/260 tests pass (237 unit + 23 integration)
- [x] `dart analyze --fatal-infos` — zero issues
- [x] Pre-commit hooks pass (format, analyze, secrets, platform_interface tests)
- [x] Integration tests verify msg_recv, msg_send, fan-out/gather all work with sync dispatch

Fixes #212, fixes #214