### PR TITLE
feat(registry): add extraFunctions param to PluginRegistry.attachTo

### DIFF
--- a/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 
+import 'package:dart_monty_bridge/src/bridge/host_function.dart';
 import 'package:dart_monty_bridge/src/bridge/host_function_schema.dart';
 import 'package:dart_monty_bridge/src/bridge/introspection_functions.dart';
 import 'package:dart_monty_bridge/src/bridge/monty_bridge.dart';
@@ -21,7 +22,7 @@ class PluginRegistry {
 
   static final RegExp _validNamespace = RegExp(r'^[a-z][a-z0-9_]*$');
   static const int _maxNamespaceLength = 32;
-  static const Set<String> _reservedNamespaces = {'introspection'};
+  static const Set<String> _reservedNamespaces = {'introspection', 'extra'};
 
   /// Registered plugins in insertion order (unmodifiable).
   List<MontyPlugin> get plugins => UnmodifiableListView(_plugins);
@@ -77,10 +78,16 @@ class PluginRegistry {
   /// Wires all plugins to [bridge], calls [MontyPlugin.onRegister] for each,
   /// and registers introspection builtins.
   ///
+  /// [extraFunctions] registers standalone host functions that are not part of
+  /// any plugin. They appear under the `'extra'` introspection category.
+  ///
   /// All plugins are wired even if some [MontyPlugin.onRegister] calls throw —
   /// errors are collected and thrown as a single [StateError] after all plugins
   /// have been attached.
-  Future<void> attachTo(MontyBridge bridge) async {
+  Future<void> attachTo(
+    MontyBridge bridge, {
+    List<HostFunction>? extraFunctions,
+  }) async {
     // Get registry's own logger from the bridge.
     _log = bridge.logger.child('registry');
 
@@ -98,6 +105,20 @@ class PluginRegistry {
         schemas.add(fn.schema);
       }
       schemasByCategory[plugin.namespace] = schemas;
+    }
+
+    // Register standalone functions under the 'extra' category.
+    if (extraFunctions != null && extraFunctions.isNotEmpty) {
+      final extraSchemas = <HostFunctionSchema>[];
+      for (final fn in extraFunctions) {
+        bridge.register(fn);
+        extraSchemas.add(fn.schema);
+      }
+      schemasByCategory['extra'] = extraSchemas;
+      _log.debug(
+        'Registered extra functions',
+        attributes: {'count': extraFunctions.length},
+      );
     }
 
     // Store registration order for reverse-order disposal.

--- a/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/plugin_registry_test.dart
@@ -176,6 +176,19 @@ void main() {
           ),
         );
       });
+
+      test('rejects reserved namespace "extra"', () {
+        expect(
+          () => registry.register(_TestPlugin(namespace: 'extra')),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('reserved'),
+            ),
+          ),
+        );
+      });
     });
 
     group('function prefix enforcement', () {
@@ -318,6 +331,34 @@ void main() {
         await registry.attachTo(bridge);
 
         expect(order, ['first', 'second']);
+      });
+
+      test('registers extraFunctions onto bridge', () async {
+        final bridge = _MockBridge();
+        registry.register(
+          _TestPlugin(namespace: 'ns', functions: [_fn('ns_one')]),
+        );
+
+        await registry.attachTo(
+          bridge,
+          extraFunctions: [_fn('standalone_op')],
+        );
+
+        expect(bridge.registeredNames, contains('ns_one'));
+        expect(bridge.registeredNames, contains('standalone_op'));
+        expect(bridge.registeredNames, contains('list_functions'));
+      });
+
+      test('extraFunctions with null or empty list is a no-op', () async {
+        final bridge = _MockBridge();
+        registry.register(
+          _TestPlugin(namespace: 'ns', functions: [_fn('ns_one')]),
+        );
+
+        await registry.attachTo(bridge, extraFunctions: []);
+
+        expect(bridge.registeredNames, contains('ns_one'));
+        expect(bridge.registeredNames, isNot(contains('standalone_op')));
       });
 
       test('attaches all plugins even if onRegister throws', () async {


### PR DESCRIPTION
## Summary
- Add optional `List<HostFunction>? extraFunctions` parameter to `PluginRegistry.attachTo()`
- Extra functions are registered under the reserved `'extra'` introspection category
- Required for soliplex to migrate from its local PluginRegistry to dart_monty_bridge's

## Changes
- **plugin_registry.dart**: Add `'extra'` to `_reservedNamespaces`, new `extraFunctions` param on `attachTo()`, registers extras and includes in introspection output
- **plugin_registry_test.dart**: Tests for `extraFunctions` registration and `'extra'` namespace reservation

## Test plan
- [x] 31/31 plugin_registry tests pass
- [x] `dart analyze --fatal-infos` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)