### PR TITLE
chore(release): version bumps for pub.dev release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.9.1
+
+> **Pre-1.0 stability notice**: dart_monty is under active development. APIs may
+> change between minor versions. If you encounter issues, please
+> [open an issue](https://github.com/runyaga/dart_monty/issues).
+
+- Fix pub.dev analysis failure: update `dart_monty_ffi` constraint to `^0.8.2`
+  (0.8.1 had a required `bindings` parameter incompatible with zero-arg `MontyFfi()`)
+- Update `dart_monty_wasm` constraint to `^0.8.3`
+- Update `dart_monty_platform_interface` constraint to `^0.8.0`
+
 ## 0.9.0
 
 - **Pure Dart** — remove Flutter SDK dependency; all packages are pure Dart with compile-time conditional imports

--- a/packages/dart_monty_bridge/CHANGELOG.md
+++ b/packages/dart_monty_bridge/CHANGELOG.md
@@ -2,24 +2,44 @@
 
 ## 0.4.0
 
-- **BREAKING**: Remove `CompositePlugin` mixin and `PluginRef<T>`. Use
-  constructor injection instead for inter-plugin dependencies.
-- `PluginRegistry.attachTo()` calls `onRegister()` in registration order.
-- `PluginRegistry.disposeAll()` calls `onDispose()` in reverse registration
-  order.
-- **BREAKING**: Plugins no longer accept a `Logger` constructor parameter.
-  Logging is now injected automatically via `MontyPlugin.logger` (a
-  `BridgeLogger` field, default `NullBridgeLogger`) by `PluginRegistry`
+### Breaking
+
+- Remove `CompositePlugin` mixin and `PluginRef<T>`. Use constructor injection
+  for inter-plugin dependencies.
+- Rename `IsolatePlugin` to `SandboxPlugin` — the plugin creates isolated Monty
+  interpreter instances, not Dart isolates.
+- Plugins no longer accept a `Logger` constructor parameter. Logging is injected
+  automatically via `MontyPlugin.logger` (`BridgeLogger`) by `PluginRegistry`
   before `onRegister()`.
-- Add `BridgeLogger get logger` to `MontyBridge` abstract interface.
-- Add `StructLogBridgeLogger` — batteries-included adapter wrapping
-  struct_log's `Logger`/`LogManager` with hierarchical `.child()` scoping
-  and cascading `close()`.
-- `DefaultMontyBridge` defaults to `StructLogBridgeLogger.root(LogManager.instance)`.
-- `PluginRegistry` propagates `bridge.logger.child(plugin.namespace)` to
-  each plugin and uses `bridge.logger.child('registry')` internally.
-- `SandboxPlugin` child bridges receive `logger.child('child.$id')`.
 - Bump `dart_monty_platform_interface` to `^0.8.0`, `struct_log` to `^0.3.0`.
+
+### Added
+
+- `BridgeMiddleware` with sealed `CallRole` — intercept, modify, or block host
+  function calls with pre/post hooks and role-based security.
+- `JsonPlugin` — `json_parse`, `json_stringify`, `json_query` host functions.
+- `TemplatePlugin` — `template_render` host function with Mustache-style
+  templates.
+- `MessageBusPlugin` — `bus_send`/`bus_receive` for parent-child communication.
+- `invokeHostFunction()` on `MontyBridge` for Dart-side tool dispatch.
+- `sandbox_gather` host function for output attribution from child sandboxes.
+- `ChildSpawnContext` for per-child filesystem isolation in `SandboxPlugin`.
+- `extraFunctions` parameter on `PluginRegistry.attachTo()` for ad-hoc host
+  functions without a full plugin.
+- `BridgeLogger` abstract interface with `NullBridgeLogger` default.
+- `StructLogBridgeLogger` adapter with hierarchical `.child()` scoping and
+  cascading `close()`.
+- `PluginRegistry` propagates `bridge.logger.child(plugin.namespace)` to each
+  plugin and uses `bridge.logger.child('registry')` internally.
+- `SandboxPlugin` child bridges receive `logger.child('child.$id')`.
+- `help()` resolves bare function names without namespace prefix.
+- `SandboxPlugin.createChildInstance()` for plugin inheritance in child bridges.
+
+### Fixed
+
+- Child bridges use `useFutures: false` to prevent hangs.
+- Child isolate errors surface as tool failures instead of crashing parent.
+- Plugin registration failure logging with structured context.
 
 ## 0.3.1
 

--- a/packages/dart_monty_ffi/CHANGELOG.md
+++ b/packages/dart_monty_ffi/CHANGELOG.md
@@ -1,7 +1,7 @@
-## 0.9.0
+## 0.8.2
 
-- Make `bindings` parameter optional on `MontyFfi()` and `MontyNative()` — defaults to production implementations
-- No API changes for existing callers using explicit bindings
+- Make `bindings` parameter optional on `MontyFfi()` — defaults to `NativeBindingsFfi()`
+- Enables zero-arg `MontyFfi()` construction for the `dart_monty` convenience API
 
 ## 0.8.1
 

--- a/packages/dart_monty_ffi/pubspec.yaml
+++ b/packages/dart_monty_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_ffi
 description: Native FFI backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.1
+version: 0.8.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_wasm/CHANGELOG.md
+++ b/packages/dart_monty_wasm/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.8.3
+
+- Implement `MontyFutureCapable` on `MontyWasm` — WASM backend now supports
+  `resumeAsFuture()` and `resolveFutures()`
+- Fix `expectError` handling for iterative fixtures in WASM ladder runner
+- Fix async futures path wiring in WASM ladder runner
+
 ## 0.8.2
 
 - **Fix**: `WasmBindingsJs` now uses static method bindings matching the JS bridge API (was broken: tried to call `new DartMontyBridge()` which doesn't exist)

--- a/packages/dart_monty_wasm/pubspec.yaml
+++ b/packages/dart_monty_wasm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_wasm
 description: WASM backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.2
+version: 0.8.3
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.9.0
+version: 0.9.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -14,9 +14,9 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  dart_monty_ffi: ^0.8.1
-  dart_monty_platform_interface: ^0.7.2
-  dart_monty_wasm: ^0.8.2
+  dart_monty_ffi: ^0.8.2
+  dart_monty_platform_interface: ^0.8.0
+  dart_monty_wasm: ^0.8.3
 
 dev_dependencies:
   test: ^1.25.0


### PR DESCRIPTION
## Summary

Fix broken pub.dev analysis score for `dart_monty` and publish all pending package updates.

**Root cause**: `dart_monty` 0.9.0 calls `MontyFfi()` with no args, but the published `dart_monty_ffi` 0.8.1 has `{required NativeBindings bindings}`. The optional-bindings fix was on main but never published (version wasn't bumped).

## Package versions

| Package | pub.dev | New | Change |
|---------|---------|-----|--------|
| `platform_interface` | 0.7.2 | **0.8.0** | BridgeLogger, MontyCancelRegistry extraction |
| `ffi` | 0.8.1 | **0.8.2** | Optional bindings (THE FIX) |
| `wasm` | 0.8.2 | **0.8.3** | MontyFutureCapable, fixture fixes |
| `bridge` | 0.3.1 | **0.4.0** | Middleware, plugins, logging, SandboxPlugin |
| `dart_monty` | 0.9.0 | **0.9.1** | Constraint fix + pre-1.0 stability note |

## Publish order (after merge)

```
platform_interface-v0.8.0 → ffi-v0.8.2 / wasm-v0.8.3 / bridge-v0.4.0 → v0.9.1
```

## Test plan

- [x] `python3 tool/analyze_packages.py` — all packages pass
- [x] `dart pub publish --dry-run` — all 5 packages pass
- [x] platform_interface: 347 tests pass
- [x] ffi: 169 tests pass
- [x] wasm: 117 tests pass
- [x] bridge: 246 tests pass
- [x] All pre-commit hooks pass