### PR TITLE
chore(release): fix pub.dev scores (+50 points)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.9.2
+
+- Align all dependency lower bounds with actual API usage (fixes pub.dev
+  downgrade tests across ffi, wasm, native, web)
+- Update `dart_monty_ffi` constraint to `^0.8.3`
+- Update `dart_monty_wasm` constraint to `^0.8.4`
+
 ## 0.9.1
 
 > **Pre-1.0 stability notice**: dart_monty is under active development. APIs may

--- a/packages/dart_monty_bridge/CHANGELOG.md
+++ b/packages/dart_monty_bridge/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.1
+
+- Add `example/example.dart` demonstrating plugin creation and registry setup
+
 ## 0.4.0
 
 ### Breaking

--- a/packages/dart_monty_bridge/example/example.dart
+++ b/packages/dart_monty_bridge/example/example.dart
@@ -1,0 +1,89 @@
+// ignore_for_file: avoid_print, document_ignores
+
+import 'package:dart_monty_bridge/dart_monty_bridge.dart';
+
+/// A plugin that provides calculator host functions to Python scripts.
+///
+/// Demonstrates the core bridge concepts:
+/// - Extending [MontyPlugin] with a namespace
+/// - Defining [HostFunction]s with typed parameter schemas
+/// - Async handlers that receive validated arguments
+class CalculatorPlugin extends MontyPlugin {
+  @override
+  String get namespace => 'calc';
+
+  @override
+  String? get systemPromptContext =>
+      'The calc plugin provides basic arithmetic operations.';
+
+  @override
+  List<HostFunction> get functions => [
+    const HostFunction(
+      schema: HostFunctionSchema(
+        name: 'calc_add',
+        description: 'Adds two numbers and returns the result.',
+        params: [
+          HostParam(
+            name: 'a',
+            type: HostParamType.number,
+            description: 'First operand',
+          ),
+          HostParam(
+            name: 'b',
+            type: HostParamType.number,
+            description: 'Second operand',
+          ),
+        ],
+      ),
+      handler: _add,
+    ),
+    const HostFunction(
+      schema: HostFunctionSchema(
+        name: 'calc_factorial',
+        description: 'Computes the factorial of a non-negative integer.',
+        params: [
+          HostParam(
+            name: 'n',
+            type: HostParamType.integer,
+            description: 'Non-negative integer',
+          ),
+        ],
+      ),
+      handler: _factorial,
+    ),
+  ];
+}
+
+Future<Object?> _add(Map<String, Object?> args) async {
+  final a = args['a']! as num;
+  final b = args['b']! as num;
+  return a + b;
+}
+
+Future<Object?> _factorial(Map<String, Object?> args) async {
+  final n = args['n']! as int;
+  if (n < 0) throw ArgumentError.value(n, 'n', 'must be >= 0');
+  var result = 1;
+  for (var i = 2; i <= n; i++) {
+    result *= i;
+  }
+  return result;
+}
+
+void main() {
+  // Create a registry and register plugins.
+  final registry = PluginRegistry()..register(CalculatorPlugin());
+
+  // Generate a system prompt describing all available host functions.
+  // This is typically sent to an LLM so it knows which tools it can call.
+  final prompt = registry.generateSystemPrompt();
+  print('=== System Prompt ===\n$prompt');
+
+  // Inspect registered functions and their JSON schemas.
+  print('\n=== Registered Functions ===');
+  for (final plugin in registry.plugins) {
+    for (final fn in plugin.functions) {
+      print('${fn.schema.name}: ${fn.schema.toJsonSchema()}');
+    }
+  }
+}

--- a/packages/dart_monty_bridge/pubspec.yaml
+++ b/packages/dart_monty_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_bridge
 description: High-level bridge layer for dart_monty. Host functions, event loop, plugin system.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_ffi/CHANGELOG.md
+++ b/packages/dart_monty_ffi/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.3
+
+- Update `dart_monty_platform_interface` constraint to `^0.8.0` (fixes pub.dev
+  downgrade test — `MontyCancelRegistry` and `monty_backend_spi.dart` require
+  PI 0.8.0+)
+
 ## 0.8.2
 
 - Make `bindings` parameter optional on `MontyFfi()` — defaults to `NativeBindingsFfi()`

--- a/packages/dart_monty_ffi/pubspec.yaml
+++ b/packages/dart_monty_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_ffi
 description: Native FFI backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.2
+version: 0.8.3
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   code_assets: ^1.0.0
-  dart_monty_platform_interface: ^0.7.0
+  dart_monty_platform_interface: ^0.8.0
   ffi: ^2.1.3
   hooks: ^1.0.2
 

--- a/packages/dart_monty_native/CHANGELOG.md
+++ b/packages/dart_monty_native/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.4
+
+- Update `dart_monty_platform_interface` constraint to `^0.8.0`
+- Update `dart_monty_ffi` constraint to `^0.8.3`
+
 ## 0.7.3
 
 - Update `dart_monty_ffi` dependency constraint to `^0.8.1`

--- a/packages/dart_monty_native/pubspec.yaml
+++ b/packages/dart_monty_native/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_native
 description: Native plugin for dart_monty (replaces dart_monty_desktop). Pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.3
+version: 0.7.4
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,8 +15,8 @@ environment:
   flutter: '>=3.10.0'
 
 dependencies:
-  dart_monty_ffi: ^0.8.1
-  dart_monty_platform_interface: ^0.7.0
+  dart_monty_ffi: ^0.8.3
+  dart_monty_platform_interface: ^0.8.0
   flutter:
     sdk: flutter
 

--- a/packages/dart_monty_wasm/CHANGELOG.md
+++ b/packages/dart_monty_wasm/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.4
+
+- Update `dart_monty_platform_interface` constraint to `^0.8.0` (fixes pub.dev
+  downgrade test — `MontyCancelRegistry` and `monty_backend_spi.dart` require
+  PI 0.8.0+)
+
 ## 0.8.3
 
 - Implement `MontyFutureCapable` on `MontyWasm` — WASM backend now supports

--- a/packages/dart_monty_wasm/pubspec.yaml
+++ b/packages/dart_monty_wasm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_wasm
 description: WASM backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.3
+version: 0.8.4
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -14,7 +14,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  dart_monty_platform_interface: ^0.7.0
+  dart_monty_platform_interface: ^0.8.0
 
 dev_dependencies:
   test: ^1.25.0

--- a/packages/dart_monty_web/CHANGELOG.md
+++ b/packages/dart_monty_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.4
+
+- Update `dart_monty_platform_interface` constraint to `^0.8.0`
+- Update `dart_monty_wasm` constraint to `^0.8.4`
+
 ## 0.7.3
 
 - Update `dart_monty_wasm` dependency constraint to `^0.8.1`

--- a/packages/dart_monty_web/pubspec.yaml
+++ b/packages/dart_monty_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_web
 description: Flutter web plugin for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.3
+version: 0.7.4
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,8 +15,8 @@ environment:
   flutter: '>=3.19.0'
 
 dependencies:
-  dart_monty_platform_interface: ^0.7.0
-  dart_monty_wasm: ^0.8.1
+  dart_monty_platform_interface: ^0.8.0
+  dart_monty_wasm: ^0.8.4
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.9.1
+version: 0.9.2
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -14,9 +14,9 @@ environment:
   sdk: ^3.10.0
 
 dependencies:
-  dart_monty_ffi: ^0.8.2
+  dart_monty_ffi: ^0.8.3
   dart_monty_platform_interface: ^0.8.0
-  dart_monty_wasm: ^0.8.3
+  dart_monty_wasm: ^0.8.4
 
 dev_dependencies:
   test: ^1.25.0


### PR DESCRIPTION
## Summary

Fix pub.dev scoring issues across the dart_monty ecosystem. Addresses #227.

**Root causes:**
- `ffi` and `wasm` depend on `platform_interface: ^0.7.0` but use `MontyCancelRegistry` (PI 0.8.0+) — pub.dev downgrade test fails (-20 each)
- `bridge` missing `example/example.dart` (-10)

## Changes

### Phase 1: Constraint alignment

Bump `dart_monty_platform_interface` constraint from `^0.7.0` to `^0.8.0` in ffi, wasm, native, and web. Update inter-package constraints for clean publish chain.

| Package | Old → New | Key Change |
|---------|-----------|------------|
| `ffi` | 0.8.2 → **0.8.3** | PI `^0.7.0` → `^0.8.0` |
| `wasm` | 0.8.3 → **0.8.4** | PI `^0.7.0` → `^0.8.0` |
| `native` | 0.7.3 → **0.7.4** | PI `^0.8.0`, ffi `^0.8.3` |
| `web` | 0.7.3 → **0.7.4** | PI `^0.8.0`, wasm `^0.8.4` |
| `dart_monty` | 0.9.1 → **0.9.2** | ffi `^0.8.3`, wasm `^0.8.4` |

### Phase 2: Bridge example

Add `example/example.dart` showing `MontyPlugin`, `HostFunction`, `PluginRegistry`, and schema generation. Uses only bridge's regular dependencies (not `dart_monty_ffi` which is dev-only).

- `bridge` 0.4.0 → **0.4.1**

## Expected score improvements

| Package | Before | After | Delta |
|---------|--------|-------|-------|
| `ffi` | 140 | **160** | +20 |
| `wasm` | 140 | **160** | +20 |
| `bridge` | 150 | **160** | +10 |

## Publish order (after merge)

```
1. ffi-v0.8.3, wasm-v0.8.4        # tier 1
2. native-v0.7.4, web-v0.7.4      # tier 2 (depend on tier 1)
3. bridge-v0.4.1                   # independent
4. v0.9.2                          # root (depends on tier 1)
```

## Test plan

- [x] `python3 tool/analyze_packages.py` — all 8 packages pass
- [x] platform_interface: 347 tests pass
- [x] ffi: 169 tests pass
- [x] wasm: 117 tests pass
- [x] bridge: 246 tests pass
- [x] All pre-commit hooks pass
- [x] Plan reviewed 3x by Gemini (WARNING → PASS → adversarial FAIL fixed)

Closes #227