### PR TITLE
fix(sandbox): add watchdog timer to prevent concurrency slot leak

### DIFF
--- a/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/plugins/sandbox_plugin.dart
@@ -73,10 +73,14 @@ class _ChildHandle {
   final PluginRegistry? registry;
   bool isAlive = true;
 
+  /// Wall-clock watchdog timer that force-cancels stuck children.
+  Timer? watchdog;
+
   /// Captured print output from the child (set on completion).
   String? printOutput;
 
   Future<void> cancel() async {
+    watchdog?.cancel();
     isAlive = false;
     // Dispose plugins FIRST — this unblocks pending handler Futures
     // (e.g., MessageBusPlugin completes waiters with StateError).
@@ -500,6 +504,7 @@ class SandboxPlugin extends MontyPlugin {
       onDone: () async {
         final child = _children[id];
         if (child == null) return;
+        child.watchdog?.cancel();
         child
           ..isAlive = false
           ..printOutput = childPrintOutput;
@@ -545,7 +550,9 @@ class SandboxPlugin extends MontyPlugin {
       },
       onError: (Object error, StackTrace stackTrace) {
         final child = _children[id];
-        if (child != null) child.isAlive = false;
+        if (child == null || !child.isAlive) return;
+        child.watchdog?.cancel();
+        child.isAlive = false;
         logger.error(
           'Child stream error',
           error: error,
@@ -557,13 +564,41 @@ class SandboxPlugin extends MontyPlugin {
       },
     );
 
-    _children[id] = _ChildHandle(
+    final child = _ChildHandle(
       bridge: bridge,
       platform: platform,
       completer: completer,
       subscription: subscription,
       registry: childRegistry,
     );
+    _children[id] = child;
+
+    // Start wall-clock watchdog timer to force-cancel stuck children.
+    // The Rust interpreter enforces CPU-time limits, but host function
+    // deadlocks (where the interpreter is suspended and Dart code blocks)
+    // are invisible to the interpreter timeout. This watchdog covers that gap.
+    final effectiveTimeout = limits?.timeoutMs;
+    if (effectiveTimeout != null) {
+      child.watchdog = Timer(
+        Duration(milliseconds: effectiveTimeout),
+        () async {
+          if (!child.isAlive || completer.isCompleted) return;
+          logger.warning(
+            'Child watchdog timeout — force-cancelling',
+            attributes: {'childId': id, 'timeoutMs': effectiveTimeout},
+          );
+          await child.cancel();
+          if (!completer.isCompleted) {
+            completer.completeError(
+              ChildSandboxException(
+                childId: id,
+                message: 'watchdog timeout after ${effectiveTimeout}ms',
+              ),
+            );
+          }
+        },
+      );
+    }
 
     return id;
   }

--- a/packages/dart_monty_bridge/test/src/plugins/sandbox_plugin_test.dart
+++ b/packages/dart_monty_bridge/test/src/plugins/sandbox_plugin_test.dart
@@ -841,6 +841,197 @@ void main() {
       });
     });
 
+    group('watchdog timer', () {
+      test('reaps stuck child after timeout', () async {
+        final plugin = SandboxPlugin(
+          platformFactory: () async =>
+              _SlowMockPlatform(Completer<MontyProgress>().future),
+          childLimits: const MontyLimits(timeoutMs: 50),
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+        final handle = await spawn({'code': 'stuck'});
+
+        await expectLater(
+          await_({'handle': handle! as int}),
+          throwsA(
+            isA<ChildSandboxException>().having(
+              (e) => e.message,
+              'message',
+              contains('watchdog timeout'),
+            ),
+          ),
+        );
+
+        await plugin.onDispose();
+      });
+
+      test('does not fire on normal completion', () async {
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _completingMockWithResult(value: 42),
+          childLimits: const MontyLimits(timeoutMs: 5000),
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+        final handle = await spawn({'code': '42'});
+
+        final result = await await_({'handle': handle! as int});
+        expect(result, 42);
+
+        await plugin.onDispose();
+      });
+
+      test('no watchdog when timeout is null', () async {
+        final completers = <Completer<MontyProgress>>[];
+        final plugin = SandboxPlugin(
+          platformFactory: () async {
+            final c = Completer<MontyProgress>();
+            completers.add(c);
+            return _SlowMockPlatform(c.future);
+          },
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final isAlive = _findHandler(plugin, 'sandbox_is_alive');
+        final handle = await spawn({'code': 'stuck'});
+
+        // Wait longer than any reasonable default watchdog.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final alive = await isAlive({'handle': handle! as int});
+        expect(alive, isTrue);
+
+        for (final c in completers) {
+          c.complete(
+            const MontyComplete(result: MontyResult(usage: _usage)),
+          );
+        }
+        await plugin.onDispose();
+      });
+
+      test(
+        'explicit cancel before watchdog does not double-complete',
+        () async {
+          final plugin = SandboxPlugin(
+            platformFactory: () async =>
+                _SlowMockPlatform(Completer<MontyProgress>().future),
+            childLimits: const MontyLimits(timeoutMs: 5000),
+          );
+          final spawn = _findHandler(plugin, 'sandbox_spawn');
+          final cancel = _findHandler(plugin, 'sandbox_cancel');
+          final await_ = _findHandler(plugin, 'sandbox_await');
+          final handle = await spawn({'code': 'stuck'});
+
+          await cancel({'handle': handle! as int});
+
+          await expectLater(
+            await_({'handle': handle}),
+            throwsA(
+              isA<ChildSandboxException>().having(
+                (e) => e.message,
+                'message',
+                'cancelled',
+              ),
+            ),
+          );
+
+          await plugin.onDispose();
+        },
+      );
+
+      test('slot recovered after watchdog reap', () async {
+        final plugin = SandboxPlugin(
+          platformFactory: () async =>
+              _SlowMockPlatform(Completer<MontyProgress>().future),
+          maxChildren: 1,
+          childLimits: const MontyLimits(timeoutMs: 50),
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+        final h0 = await spawn({'code': 'stuck'});
+
+        // Slot is occupied — second spawn must fail.
+        expect(
+          () => spawn({'code': 'b'}),
+          throwsA(isA<StateError>()),
+        );
+
+        // Wait for watchdog to reap the stuck child.
+        try {
+          await await_({'handle': h0! as int});
+        } on ChildSandboxException {
+          // Expected.
+        }
+
+        // Slot is now free.
+        final h1 = await spawn({'code': 'c'});
+        expect(h1, isA<int>());
+
+        await plugin.onDispose();
+      });
+
+      test('child error before timeout cancels watchdog', () async {
+        final plugin = SandboxPlugin(
+          platformFactory: () async => _failingMock('NameError: x'),
+          childLimits: const MontyLimits(timeoutMs: 5000),
+        );
+        final spawn = _findHandler(plugin, 'sandbox_spawn');
+        final await_ = _findHandler(plugin, 'sandbox_await');
+        final handle = await spawn({'code': 'x'});
+
+        await expectLater(
+          await_({'handle': handle! as int}),
+          throwsA(
+            isA<ChildSandboxException>().having(
+              (e) => e.message,
+              'message',
+              contains('NameError'),
+            ),
+          ),
+        );
+
+        await plugin.onDispose();
+      });
+
+      test('warning logged on watchdog reap', () async {
+        final sink = MemorySink();
+        final previousLevel = LogManager.instance.minimumLevel;
+        LogManager.instance
+          ..addSink(sink)
+          ..minimumLevel = LogLevel.trace;
+        final logger = LogManager.instance.getLogger('SandboxPlugin.test');
+
+        try {
+          final plugin = SandboxPlugin(
+            platformFactory: () async =>
+                _SlowMockPlatform(Completer<MontyProgress>().future),
+            childLimits: const MontyLimits(timeoutMs: 50),
+          )..logger = StructLogBridgeLogger(logger, LogManager.instance);
+          final spawn = _findHandler(plugin, 'sandbox_spawn');
+          final await_ = _findHandler(plugin, 'sandbox_await');
+          final handle = await spawn({'code': 'stuck'});
+
+          try {
+            await await_({'handle': handle! as int});
+          } on ChildSandboxException {
+            // Expected.
+          }
+
+          final warnRecord = sink.records.firstWhere(
+            (r) => r.message.contains('watchdog timeout'),
+          );
+          expect(warnRecord.level, LogLevel.warning);
+          expect(warnRecord.attributes['childId'], 0);
+          expect(warnRecord.attributes['timeoutMs'], 50);
+
+          await plugin.onDispose();
+        } finally {
+          LogManager.instance
+            ..removeSink(sink)
+            ..minimumLevel = previousLevel;
+        }
+      });
+    });
+
     group('ChildSandboxException', () {
       test('toString includes childId and message', () {
         const e = ChildSandboxException(childId: 3, message: 'boom');


### PR DESCRIPTION
## Summary
- Add per-child wall-clock watchdog `Timer` that force-cancels stuck children after their `timeoutMs` expires
- Fixes concurrency slot leak when a child's host function deadlocks in Dart (stream never completes, `isAlive` stays `true` forever)
- Add `isAlive` guard in `onError` callback to prevent double-dispose race between watchdog and stream error

## Changes
- **`_ChildHandle`**: New `Timer? watchdog` field, cancelled in `cancel()` before disposal
- **`_handleSpawn`**: Start watchdog timer after child handle stored when `limits?.timeoutMs` is set
- **`onDone` callback**: Cancel watchdog timer on normal completion
- **`onError` callback**: Cancel watchdog timer + `isAlive` guard to prevent double-dispose

## Test plan
- [x] 7 new unit tests in `watchdog timer` group (96 total, all pass)
- [x] Watchdog reaps stuck child after timeout
- [x] No interference with normal completion
- [x] No watchdog when timeout is null
- [x] Explicit cancel before watchdog — no double-complete
- [x] Concurrency slot recovery after watchdog reap
- [x] Child error before timeout cancels watchdog
- [x] Warning logged with childId and timeoutMs on watchdog reap
- [x] `dart analyze --fatal-infos` — zero issues
- [x] `dart format` — no changes
- [x] All pre-commit hooks pass
- [x] Gemini 3.1-pro architectural review: PASS on 5/5 criteria after fix iteration

Closes #215