### PR TITLE
chore(release): bump versions for 0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 0.10.0
+
+### Changed
+
+- Upgrade Monty interpreter from 0.0.7 to 0.0.8 (via `dart_monty_native` 0.8.0)
+- Upstream monty 0.0.8 adds: full `math` module, PEP 448 unpacking, `re` module,
+  dict view/set operators, compiler stack-depth fixes
+
+### Fixed
+
+- ForIter stack corruption (#225) in nested for-loops with try/except — fixed by
+  upstream compiler stack-depth tracking (#246, #268)
+
 ## 0.9.2
 
 - Align all dependency lower bounds with actual API usage (fixes pub.dev

--- a/packages/dart_monty_bridge/CHANGELOG.md
+++ b/packages/dart_monty_bridge/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.5.0
+
+### Added
+
+- `SandboxPlugin`: child system prompt injection via `ChildSystemPromptBuilder`
+  callback — infrastructure can set identity/workspace context per child (#231)
+- `PluginRegistry.attachTo`: accept `extraFunctions` for standalone host
+  functions outside any plugin namespace (#222)
+
+### Fixed
+
+- `JsonPlugin`: standardize parameter names — `text`/`value` → `data` for
+  consistency across `json_loads`, `json_dumps`, `json_get` (#229)
+
 ## 0.4.1
 
 - Add `example/example.dart` demonstrating plugin creation and registry setup

--- a/packages/dart_monty_bridge/pubspec.yaml
+++ b/packages/dart_monty_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_bridge
 description: High-level bridge layer for dart_monty. Host functions, event loop, plugin system.
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_native/CHANGELOG.md
+++ b/packages/dart_monty_native/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.8.0
+
+### Changed
+
+- Upgrade Monty Rust crate from 0.0.7 to 0.0.8 — includes compiler
+  stack-depth fixes (#246, #268), full math module, PEP 448 unpacking,
+  NameLookup auto-detection, `re` module, dict views, and more
+- Adapt FFI handle layer for PrintWriter by-value API change
+
+### Fixed
+
+- ForIter stack corruption in nested for-loops with try/except
+  (3+ loops, try in 2+, 4+ items in 3rd loop) — dart_monty#225
+
 ## 0.7.4
 
 - Update `dart_monty_platform_interface` constraint to `^0.8.0`

--- a/packages/dart_monty_native/pubspec.yaml
+++ b/packages/dart_monty_native/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_native
 description: Native plugin for dart_monty (replaces dart_monty_desktop). Pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.7.4
+version: 0.8.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.9.2
+version: 0.10.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues


### PR DESCRIPTION
## Release 0.10.0

### Packages being released

| Package | Version | Changes |
|---------|---------|---------|
| `dart_monty` | 0.9.2 → **0.10.0** | Depends on updated native + bridge |
| `dart_monty_bridge` | 0.4.1 → **0.5.0** | Child system prompt injection, JSON param fix, extraFunctions |
| `dart_monty_native` | 0.7.4 → **0.8.0** | Monty 0.0.7 → 0.0.8, PrintWriter API, ForIter #225 fix |

### Highlights

- **Monty interpreter 0.0.8**: full `math` module (~50 functions), PEP 448 generalised unpacking, `re` module, dict view/set operators, compiler stack-depth fixes
- **ForIter #225 fix**: nested for-loops with try/except no longer crash (3+ loops, try in 2+, 4+ items)
- **SandboxPlugin**: child system prompt injection via `ChildSystemPromptBuilder`
- **JsonPlugin**: parameter name standardization (`text`/`value` → `data`)

### Release order (after merge)

```bash
# 1. bridge (no new deps)
git tag bridge-v0.5.0 && git push origin bridge-v0.5.0

# 2. native (no new deps)  
git tag native-v0.8.0 && git push origin native-v0.8.0

# 3. root dart_monty + GitHub Release (native binaries)
git tag v0.10.0 && git push origin v0.10.0
```

### Pre-release checklist
- [x] CI green on main
- [x] CHANGELOGs updated (Unreleased → version headings)
- [x] Version bumps in pubspec.yaml
- [x] `dart pub publish --dry-run` passes for bridge and root
- [x] PyMarkdown lint passes