### PR TITLE
chore(docs): remove dart_monty_mcp references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,6 @@
 
 ## 0.8.0
 
-- **dart_monty_mcp** (0.1.0) — new MCP server package: 5 built-in tools, host function/plugin system, session persistence, 68 unit tests, docs
 - **WASM direct C-ABI** — bypass NAPI-RS entirely: 28 direct Rust function calls via `wasm32-wasip1`, drops SharedArrayBuffer/COOP/COEP requirement, WASM binary 4.5 MB (was 256 MB overhead)
 - **CI** — lower patch coverage gate to 70% (issue #135 tracks raising to 95%)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ The `v<version>` tag triggers both pub.dev publish AND native/web binary release
 **Tag patterns:**
 - `platform_interface-v<ver>`, `ffi-v<ver>`, `wasm-v<ver>`, `bridge-v<ver>`, `web-v<ver>`, `native-v<ver>` → pub.dev only
 - `v<ver>` → pub.dev + GitHub Release (native binaries + web bundle)
-- `monty_cli` and `dart_monty_mcp` are NOT published to pub.dev
+- `monty_cli` is NOT published to pub.dev
 
 See `CONTRIBUTING.md` for the complete release process, including:
 - Pre-release checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,8 +148,8 @@ call the shared `_publish-dart-package.yaml` reusable workflow via
 The `v<version>` tag for `dart_monty` also triggers `release.yaml`, which
 builds native binaries and a web bundle and creates a GitHub Release.
 
-**Not published to pub.dev:** `monty_cli` and `dart_monty_mcp` are internal
-tools and are not published.
+**Not published to pub.dev:** `monty_cli` is an internal tool and is not
+published.
 
 ### Pre-release checklist
 


### PR DESCRIPTION
## Summary

- Removed `dart_monty_mcp` from the "not published to pub.dev" note in **CLAUDE.md** (line now mentions only `monty_cli`)
- Removed `dart_monty_mcp` from the "not published" note in **CONTRIBUTING.md** (same adjustment)
- Removed the `dart_monty_mcp` bullet from the **CHANGELOG.md** 0.8.0 section

No files under `packages/dart_monty_mcp/` or `packages/monty_cli/` were modified. Only `.md` files were touched.

## Test plan

- [ ] Verify no broken markdown formatting in CLAUDE.md, CONTRIBUTING.md, CHANGELOG.md
- [ ] Confirm no remaining `dart_monty_mcp` references outside `packages/dart_monty_mcp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)