### PR TITLE
chore(release): bump versions for 0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Added
 
+- **Tier 19: Lifecycle Errors** (8 tests) — external function error recovery,
+  finally cleanup, async error propagation, nested try-except, gather partial errors
 - **Tier 17: `json` module** (13 tests) — `json.dumps`, `json.loads`, roundtrip
   nested structures, `indent`/`sort_keys`/`separators` kwargs, None/bool
   serialization, number types, invalid JSON error handling
@@ -24,6 +26,16 @@
 
 ### Fixed
 
+- **D-1**: Invalidate WASM session after `MontyPanicError` so `init()` can
+  respawn a fresh Worker instead of reusing a dead one
+- **A-2**: Guard `monty_free` against double-free via `HANDLE_REGISTRY` check —
+  second call is a safe no-op (was SIGSEGV)
+- **B-1**: Emit `dart:developer` warning when zombie isolate count reaches
+  threshold (3)
+- **C-1**: Catch `MontyError` in `MontySession._safeStart` so session state
+  stays consistent after cancel or panic
+- **E-2**: Cancel the platform in `DefaultMontyBridge.dispose()` when execution
+  is in-flight
 - Un-xfail tier 7 test #66 (`nested subscript assignment`) — now passes with
   monty 0.0.9
 - **Native ladder gate was silently passing** — `tool/test_python_ladder.sh`

--- a/packages/dart_monty_bridge/CHANGELOG.md
+++ b/packages/dart_monty_bridge/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1
+
+- **E-2**: Cancel the platform in `DefaultMontyBridge.dispose()` when execution
+  is in-flight, preventing orphaned events
+
 ## 0.5.0
 
 ### Added

--- a/packages/dart_monty_bridge/pubspec.yaml
+++ b/packages/dart_monty_bridge/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_bridge
 description: High-level bridge layer for dart_monty. Host functions, event loop, plugin system.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_ffi/CHANGELOG.md
+++ b/packages/dart_monty_ffi/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.4
+
+- **B-1**: Emit `dart:developer` warning when zombie isolate count reaches
+  threshold (3), aiding diagnosis of stuck executions
+
 ## 0.8.3
 
 - Update `dart_monty_platform_interface` constraint to `^0.8.0` (fixes pub.dev

--- a/packages/dart_monty_ffi/pubspec.yaml
+++ b/packages/dart_monty_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_ffi
 description: Native FFI backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.3
+version: 0.8.4
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_native/CHANGELOG.md
+++ b/packages/dart_monty_native/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.1
+
+- **A-2**: Guard `monty_free` against double-free via `HANDLE_REGISTRY` check
+  before `Box::from_raw` — second call is a safe no-op (was SIGSEGV)
+- Upgrade Monty Rust crate from 0.0.8 to 0.0.9
+
 ## 0.8.0
 
 ### Changed

--- a/packages/dart_monty_native/pubspec.yaml
+++ b/packages/dart_monty_native/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_native
 description: Native plugin for dart_monty (replaces dart_monty_desktop). Pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_platform_interface/CHANGELOG.md
+++ b/packages/dart_monty_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.1
+
+- **C-1**: Catch `MontyError` (sealed parent of `MontyCancelledError`,
+  `MontyPanicError`, etc.) in `MontySession._safeStart`/`_safeResume`/
+  `_safeResumeWithError` so session state stays consistent after cancel or panic
+
 ## 0.8.0
 
 - Extract `MontyCancelRegistry` from `BaseMontyPlatform` for cleaner separation of concerns

--- a/packages/dart_monty_platform_interface/pubspec.yaml
+++ b/packages/dart_monty_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_platform_interface
 description: Platform interface for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/packages/dart_monty_wasm/CHANGELOG.md
+++ b/packages/dart_monty_wasm/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.5
+
+- **D-1**: Invalidate WASM session after `MontyPanicError` — nulls `_sessionId`
+  so `init()` can respawn a fresh Worker instead of reusing a dead one
+
 ## 0.8.4
 
 - Update `dart_monty_platform_interface` constraint to `^0.8.0` (fixes pub.dev

--- a/packages/dart_monty_wasm/pubspec.yaml
+++ b/packages/dart_monty_wasm/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_wasm
 description: WASM backend for dart_monty, pure Dart bindings for Monty — a restricted sandboxed Python interpreter built in Rust.
-version: 0.8.4
+version: 0.8.5
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
-version: 0.10.0
+version: 0.11.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues


### PR DESCRIPTION
## Summary

Version bumps and CHANGELOG updates for the 0.11.0 release.

| Package | Old | New | Changes |
|---------|-----|-----|---------|
| `dart_monty` | 0.10.0 | 0.11.0 | Monty 0.0.9 upgrade, lifecycle fixes, tier 17-19 |
| `dart_monty_platform_interface` | 0.8.0 | 0.8.1 | C-1: MontySession catches MontyError |
| `dart_monty_ffi` | 0.8.3 | 0.8.4 | B-1: zombie isolate warning logging |
| `dart_monty_wasm` | 0.8.4 | 0.8.5 | D-1: session invalidation after panic |
| `dart_monty_bridge` | 0.5.0 | 0.5.1 | E-2: dispose cancels in-flight execution |
| `dart_monty_native` | 0.8.0 | 0.8.1 | A-2: double-free protection, monty 0.0.9 |

## Release order

After merge, tag in dependency order per CONTRIBUTING.md:

```bash
git tag platform_interface-v0.8.1
git push origin platform_interface-v0.8.1
# wait for publish

git tag ffi-v0.8.4 wasm-v0.8.5 bridge-v0.5.1
git push origin ffi-v0.8.4 wasm-v0.8.5 bridge-v0.5.1
# wait for publish

git tag native-v0.8.1
git push origin native-v0.8.1
# wait for publish

git tag v0.11.0
git push origin v0.11.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)