### PR TITLE
fix: wire MontyScriptError into sealed hierarchy, fix README examples, add CI doctest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 2
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -36,6 +37,9 @@ jobs:
               - 'pubspec.*'
               - '.github/**'
               - '!**.md'
+            docs:
+              - '**.md'
+              - 'example/**'
 
   ffigen:
     name: Generate FFI bindings
@@ -125,6 +129,29 @@ jobs:
           name: lcov-${{ matrix.target }}
           path: packages/${{ matrix.target }}/coverage/lcov.info
           retention-days: 1
+
+  doctest:
+    name: README doctest
+    needs: [changes]
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native
+      - name: Install dependencies
+        run: cd packages/dart_monty_ffi && dart pub get
+      - name: Run README doctest
+        run: >-
+          cd packages/dart_monty_ffi &&
+          dart test --run-skipped --tags=integration
+          test/integration/readme_doctest.dart
 
   build-js-wrapper:
     name: Build JS wrapper

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ void main() async {
 
 ```bash
 $ dart run
-Result: 4
+4
 ```
 
 No Flutter. No bindings. No registration. It just works.
@@ -198,6 +198,12 @@ For real applications, `dart_monty_bridge` provides a higher-level API
 that handles the dispatch loop, argument coercion, and event streaming
 automatically.
 
+> **Note:** The bridge API is a separate package:
+>
+> ```bash
+> dart pub add dart_monty_bridge
+> ```
+
 **`DefaultMontyBridge`** wraps the dispatch loop and emits a
 `Stream<BridgeEvent>` — tool calls, text output, and lifecycle events:
 
@@ -219,8 +225,8 @@ bridge.register(HostFunction(
 // Execute — bridge handles the dispatch loop for you
 await for (final event in bridge.execute('price = get_price("AAPL")')) {
   switch (event) {
-    case BridgeToolCallResult(:final name, :final result):
-      print('$name returned: $result');
+    case BridgeToolCallResult(:final callId, :final result):
+      print('$callId returned: $result');
     case BridgeTextContent(:final delta):
       print('Output: $delta');
     case BridgeRunFinished():
@@ -230,7 +236,7 @@ await for (final event in bridge.execute('price = get_price("AAPL")')) {
   }
 }
 
-await bridge.dispose();
+bridge.dispose();
 ```
 
 **`MontyPlugin`** groups related host functions under a validated namespace.
@@ -266,31 +272,30 @@ available tools at runtime.
 
 ### Error Handling
 
-dart_monty uses a sealed `MontyError` hierarchy for structured error handling:
+dart_monty uses a sealed `MontyError` hierarchy for structured error handling.
+All Python script errors throw `MontyScriptError`, which carries the full
+`MontyException` with traceback and source location:
 
 ```dart
-import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';
-
 try {
-  final result = await monty.run('1 / 0');
+  await monty.run('1 / 0');
 } on MontyError catch (e) {
   switch (e) {
     case MontyScriptError(:final exception):
-      print('Python error: ${exception.message}');
-      print('Type: ${exception.excType}');
+      print('Python ${exception.excType}: ${exception.message}');
       for (final frame in exception.traceback) {
-        print('  ${frame.filename}:${frame.lineNumber} in ${frame.name}');
+        print('  ${frame.filename}:${frame.startLine} in ${frame.frameName}');
       }
-    case MontyCancelledError():
-      print('Execution was cancelled');
-    case MontyResourceError(:final exception):
-      print('Resource limit exceeded: ${exception.message}');
+    case MontyCancelledError(:final message):
+      print('Cancelled: $message');
+    case MontyResourceError(:final message):
+      print('Resource limit: $message');
     case MontyPanicError(:final message):
       print('Interpreter panic: $message');
     case MontyCrashError(:final message):
       print('Interpreter crash: $message');
-    case MontyDisposedError():
-      print('Interpreter was disposed');
+    case MontyDisposedError(:final message):
+      print('Disposed: $message');
   }
 }
 ```
@@ -321,8 +326,8 @@ final result = await session.run('x + y');
 print(result.value); // 126
 
 // Session also supports start/resume (same dispatch pattern)
-await session.clearState();
-await session.dispose();
+session.clearState();
+session.dispose();
 ```
 
 ## Monty API Coverage (~75%)

--- a/example/example.dart
+++ b/example/example.dart
@@ -16,10 +16,11 @@ Future<void> main() async {
   );
   print('Sum: ${limited.value}'); // 4950
 
-  // Handle errors.
-  final bad = await monty.run('1 / 0');
-  if (bad.isError) {
-    print('Error: ${bad.error!.message}');
+  // Handle errors — run() throws MontyScriptError for Python exceptions.
+  try {
+    await monty.run('1 / 0');
+  } on MontyScriptError catch (e) {
+    print('Python ${e.excType}: ${e.message}');
   }
 
   await monty.dispose();

--- a/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
@@ -64,10 +64,10 @@ class DefaultMontyBridge implements MontyBridge {
     MontyLimits? limits,
     bool useFutures = true,
     BridgeLogger? logger,
-  }) : _explicitPlatform = platform,
-       _limits = limits,
-       _useFutures = useFutures,
-       log = logger ?? StructLogBridgeLogger.root(LogManager.instance);
+  })  : _explicitPlatform = platform,
+        _limits = limits,
+        _useFutures = useFutures,
+        log = logger ?? StructLogBridgeLogger.root(LogManager.instance);
 
   final MontyPlatform? _explicitPlatform;
   final MontyLimits? _limits;
@@ -250,13 +250,8 @@ class DefaultMontyBridge implements MontyBridge {
       }
     } on MontyCancelledError {
       controller.add(const BridgeRunError(message: 'Execution cancelled'));
-    } on MontyError catch (e) {
-      log.warning('Monty error', attributes: {'error': e.message});
-      _flushPrintBuffer(printBuffer, controller);
-      final output = printBuffer.isNotEmpty ? printBuffer.toString() : null;
-      controller.add(BridgeRunError(message: e.message, printOutput: output));
-    } on MontyException catch (e) {
-      final adjusted = _adjustException(e);
+    } on MontyScriptError catch (e) {
+      final adjusted = _adjustException(e.exception);
       log.warning('Python error', attributes: {'error': adjusted.message});
       _flushPrintBuffer(printBuffer, controller);
       final output = printBuffer.isNotEmpty ? printBuffer.toString() : null;
@@ -267,6 +262,11 @@ class DefaultMontyBridge implements MontyBridge {
           exception: adjusted,
         ),
       );
+    } on MontyError catch (e) {
+      log.warning('Monty error', attributes: {'error': e.message});
+      _flushPrintBuffer(printBuffer, controller);
+      final output = printBuffer.isNotEmpty ? printBuffer.toString() : null;
+      controller.add(BridgeRunError(message: e.message, printOutput: output));
     } on Object catch (e, st) {
       log.error('Bridge infrastructure error', error: e, stackTrace: st);
       _flushPrintBuffer(printBuffer, controller);
@@ -566,9 +566,8 @@ class DefaultMontyBridge implements MontyBridge {
     return MontyException(
       message: e.message,
       filename: e.filename,
-      lineNumber: e.lineNumber != null
-          ? e.lineNumber! - _preambleLineCount
-          : null,
+      lineNumber:
+          e.lineNumber != null ? e.lineNumber! - _preambleLineCount : null,
       columnNumber: e.columnNumber,
       sourceCode: e.sourceCode,
       excType: e.excType,
@@ -579,9 +578,8 @@ class DefaultMontyBridge implements MontyBridge {
               filename: f.filename,
               startLine: f.startLine - _preambleLineCount,
               startColumn: f.startColumn,
-              endLine: f.endLine != null
-                  ? f.endLine! - _preambleLineCount
-                  : null,
+              endLine:
+                  f.endLine != null ? f.endLine! - _preambleLineCount : null,
               endColumn: f.endColumn,
               frameName: f.frameName,
               previewLine: f.previewLine,

--- a/packages/dart_monty_bridge/test/src/bridge/default_monty_bridge_test.dart
+++ b/packages/dart_monty_bridge/test/src/bridge/default_monty_bridge_test.dart
@@ -54,9 +54,9 @@ void main() {
       },
     );
 
-    test('adjusts thrown MontyException line numbers', () async {
-      // Simulate platform throwing MontyException (the 'error' progress state
-      // path in BaseMontyPlatform.translateProgress).
+    test('adjusts thrown MontyScriptError line numbers', () async {
+      // Simulate platform throwing MontyScriptError (the 'error' progress
+      // state path in BaseMontyPlatform.translateProgress).
       final mock = _ThrowingMontyPlatform(
         const MontyException(
           message: 'SyntaxError: invalid syntax',
@@ -771,7 +771,8 @@ class _BlockingMiddleware extends BridgeMiddleware {
     Map<String, Object?> args,
     CallRole role,
     ToolHandler next,
-  ) async => returnValue;
+  ) async =>
+      returnValue;
 }
 
 class _ThrowingMiddleware extends BridgeMiddleware {
@@ -781,14 +782,15 @@ class _ThrowingMiddleware extends BridgeMiddleware {
     Map<String, Object?> args,
     CallRole role,
     ToolHandler next,
-  ) => throw StateError('Access denied');
+  ) =>
+      throw StateError('Access denied');
 }
 
 class _CapturingMiddleware extends BridgeMiddleware {
   _CapturingMiddleware({required this.onCall});
 
   final void Function(String name, Map<String, Object?> args, CallRole role)
-  onCall;
+      onCall;
 
   @override
   Future<Object?> handle(
@@ -802,9 +804,9 @@ class _CapturingMiddleware extends BridgeMiddleware {
   }
 }
 
-/// A minimal [MontyPlatform] that throws a [MontyException] from [start].
+/// A minimal [MontyPlatform] that throws a [MontyScriptError] from [start].
 ///
-/// Used to test the bridge's `on MontyException` catch path where the
+/// Used to test the bridge's `on MontyScriptError` catch path where the
 /// platform itself throws (rather than returning a MontyComplete with error).
 class _ThrowingMontyPlatform extends MontyPlatform {
   _ThrowingMontyPlatform(this._exception);
@@ -816,7 +818,8 @@ class _ThrowingMontyPlatform extends MontyPlatform {
     String code, {
     MontyLimits? limits,
     String? scriptName,
-  }) async => throw UnimplementedError();
+  }) async =>
+      throw UnimplementedError();
 
   @override
   Future<MontyProgress> start(
@@ -824,7 +827,8 @@ class _ThrowingMontyPlatform extends MontyPlatform {
     List<String>? externalFunctions,
     MontyLimits? limits,
     String? scriptName,
-  }) async => throw _exception;
+  }) async =>
+      throw MontyScriptError(_exception);
 
   @override
   Future<MontyProgress> resume(Object? returnValue) async =>

--- a/packages/dart_monty_ffi/example/example.dart
+++ b/packages/dart_monty_ffi/example/example.dart
@@ -71,7 +71,7 @@ Future<void> _externalFunctionDispatch(MontyFfi monty) async {
 Future<void> _errorHandling(MontyFfi monty) async {
   try {
     await monty.run('1 / 0');
-  } on MontyException catch (e) {
+  } on MontyScriptError catch (e) {
     print('Exception type: ${e.excType}'); // ZeroDivisionError
     print('Message: ${e.message}');
   }

--- a/packages/dart_monty_ffi/test/integration/readme_doctest.dart
+++ b/packages/dart_monty_ffi/test/integration/readme_doctest.dart
@@ -48,10 +48,16 @@ typedef BlockHandler =
 
 /// Hand-written handlers keyed by `(readmePath, blockIndex)`.
 final Map<(String, int), BlockHandler> _handlers = {
-  // Root README.md
+  // Root README.md — 9 dart blocks
   ('README.md', 0): _handleRootBlock0,
   ('README.md', 1): _handleRootBlock1,
   ('README.md', 2): _handleRootBlock2,
+  ('README.md', 3): _handleRootBlock3,
+  ('README.md', 4): _handleRootBlock4,
+  ('README.md', 5): _handleRootBlock5,
+  ('README.md', 6): _handleRootBlock6,
+  ('README.md', 7): _handleRootBlock7,
+  ('README.md', 8): _handleRootBlock8,
 
   // platform_interface/README.md
   ('packages/dart_monty_platform_interface/README.md', 0):
@@ -74,15 +80,34 @@ final Map<(String, int), BlockHandler> _handlers = {
 // Handlers — Root README
 // ---------------------------------------------------------------------------
 
-/// README.md block 0: simple execution + resource limits.
-///
-/// The README calls `fib(30)` but Monty has no built-in fib.
-/// We validate the *pattern* — `run()` works with and without limits.
+/// README.md block 0: Quick Start example.
 Future<void> _handleRootBlock0(
   String block,
   NativeBindingsFfi bindings,
 ) async {
-  // Verify the block looks like what we expect.
+  expect(block, contains("run('2 + 2')"));
+  expect(block, contains('result.value'));
+
+  final monty = MontyFfi(bindings: bindings);
+  final result = await monty.run('2 + 2');
+  expect(result.value, 4);
+  await monty.dispose();
+}
+
+/// README.md block 1: Web Quick Start (same API, structure-only).
+Future<void> _handleRootBlock1(
+  String block,
+  NativeBindingsFfi _,
+) async {
+  expect(block, contains("run('2 + 2')"));
+  expect(block, contains('result.value'));
+}
+
+/// README.md block 2: Usage section — simple execution + json + limits.
+Future<void> _handleRootBlock2(
+  String block,
+  NativeBindingsFfi bindings,
+) async {
   expect(block, contains("run('2 + 2')"));
   expect(block, contains('MontyLimits'));
 
@@ -92,22 +117,18 @@ Future<void> _handleRootBlock0(
   final result = await monty.run('2 + 2');
   expect(result.value, 4);
 
-  // With resource limits — define fib so the code actually runs.
+  // With resource limits
   final limited = await monty.run(
-    'def fib(n):\n'
-    '  if n < 2:\n'
-    '    return n\n'
-    '  return fib(n - 1) + fib(n - 2)\n'
-    'fib(10)',
+    'sum(range(100))',
     limits: const MontyLimits(timeoutMs: 5000, memoryBytes: 10 * 1024 * 1024),
   );
-  expect(limited.value, 55);
+  expect(limited.value, 4950);
 
   await monty.dispose();
 }
 
-/// README.md block 1: external function dispatch loop.
-Future<void> _handleRootBlock1(
+/// README.md block 3: External function dispatch loop.
+Future<void> _handleRootBlock3(
   String block,
   NativeBindingsFfi bindings,
 ) async {
@@ -126,7 +147,6 @@ Future<void> _handleRootBlock1(
   expect(pending.functionName, 'fetch');
   expect(pending.arguments, ['https://api.example.com/users']);
 
-  // Resume with mock data (README uses http.get — we just provide a value).
   progress = await monty.resume({'users': <String>[]});
 
   expect(progress, isA<MontyComplete>());
@@ -136,13 +156,67 @@ Future<void> _handleRootBlock1(
   await monty.dispose();
 }
 
-/// README.md block 2: stateful sessions.
-Future<void> _handleRootBlock2(
+/// README.md block 4: Bridge (DefaultMontyBridge) — structure-only.
+/// Requires dart_monty_bridge which is a separate package.
+Future<void> _handleRootBlock4(String block, NativeBindingsFfi _) async {
+  expect(block, contains('DefaultMontyBridge'));
+  expect(block, contains('HostFunction'));
+  expect(block, contains('BridgeToolCallResult'));
+  expect(block, contains('callId'));
+  expect(block, contains('bridge.dispose()'));
+}
+
+/// README.md block 5: MontyPlugin / PluginRegistry — structure-only.
+Future<void> _handleRootBlock5(String block, NativeBindingsFfi _) async {
+  expect(block, contains('MontyPlugin'));
+  expect(block, contains('PluginRegistry'));
+  expect(block, contains('namespace'));
+}
+
+/// README.md block 6: Error handling with sealed MontyError hierarchy.
+Future<void> _handleRootBlock6(
+  String block,
+  NativeBindingsFfi bindings,
+) async {
+  expect(block, contains('MontyScriptError'));
+  expect(block, contains('exception.excType'));
+  expect(block, contains('exception.traceback'));
+  expect(block, contains('frame.startLine'));
+
+  final monty = MontyFfi(bindings: bindings);
+
+  // Verify the pattern actually works.
+  try {
+    await monty.run('1 / 0');
+    fail('Expected MontyScriptError');
+  } on MontyError catch (e) {
+    expect(e, isA<MontyScriptError>());
+    final script = e as MontyScriptError;
+    expect(script.excType, 'ZeroDivisionError');
+    expect(script.exception.excType, 'ZeroDivisionError');
+  }
+
+  await monty.dispose();
+}
+
+/// README.md block 7: Cancellation (MontyCancelToken) — structure-only.
+Future<void> _handleRootBlock7(String block, NativeBindingsFfi _) async {
+  expect(block, contains('MontyCancelToken'));
+  expect(block, contains('cancel()'));
+}
+
+/// README.md block 8: Stateful sessions.
+Future<void> _handleRootBlock8(
   String block,
   NativeBindingsFfi bindings,
 ) async {
   expect(block, contains('MontySession'));
   expect(block, contains('x = 42'));
+  expect(block, contains('session.clearState()'));
+  expect(block, contains('session.dispose()'));
+  // Verify no `await` before session.clearState() or session.dispose().
+  expect(block, isNot(contains('await session.clearState()')));
+  expect(block, isNot(contains('await session.dispose()')));
 
   final monty = MontyFfi(bindings: bindings);
   final session = MontySession(platform: monty);
@@ -371,11 +445,11 @@ void main() {
       });
       expect(progress, isA<MontyComplete>());
 
-      // Error handling — run() throws MontyException on Python errors.
+      // Error handling — run() throws MontyScriptError on Python errors.
       try {
         await monty.run('1 / 0');
-        fail('Expected MontyException');
-      } on MontyException catch (e) {
+        fail('Expected MontyScriptError');
+      } on MontyScriptError catch (e) {
         expect(e.excType, 'ZeroDivisionError');
       }
 
@@ -513,7 +587,7 @@ void main() {
       expect(source, contains('MontyLimits'));
       expect(source, contains('externalFunctions'));
       expect(source, contains('MontyPending'));
-      expect(source, contains('MontyException'));
+      expect(source, contains('MontyScriptError'));
     });
 
     // -- web: structure-only --
@@ -541,7 +615,7 @@ void main() {
       final source = _readExample(repoRoot, 'example/example.dart');
       expect(source, contains('Monty()'));
       expect(source, contains('MontyLimits'));
-      expect(source, contains('isError'));
+      expect(source, contains('MontyScriptError'));
     });
   });
 }

--- a/packages/dart_monty_ffi/test/integration/smoke_test.dart
+++ b/packages/dart_monty_ffi/test/integration/smoke_test.dart
@@ -75,7 +75,8 @@ void main() {
 
   test(
     'snapshot round-trip',
-    skip: 'API mismatch: Dart requires active state for snapshot() but '
+    skip:
+        'API mismatch: Dart requires active state for snapshot() but '
         'Rust FFI only supports Ready state (before start/run). '
         'Needs a compile-only API to bridge the gap.',
     () async {
@@ -101,7 +102,7 @@ void main() {
   test('error handling: invalid syntax', () async {
     final monty = MontyFfi(bindings: bindings);
 
-    expect(() => monty.run('def'), throwsA(isA<MontyException>()));
+    expect(() => monty.run('def'), throwsA(isA<MontyScriptError>()));
 
     await monty.dispose();
   });

--- a/packages/dart_monty_ffi/test/monty_ffi_test.dart
+++ b/packages/dart_monty_ffi/test/monty_ffi_test.dart
@@ -60,7 +60,7 @@ void main() {
       expect(mock.freeCalls, hasOne);
     });
 
-    test('throws MontyException on error result', () async {
+    test('throws MontyScriptError on error result', () async {
       mock.nextRunResult = const RunResult(
         tag: 1,
         errorMessage: 'SyntaxError: invalid syntax',
@@ -69,7 +69,7 @@ void main() {
       expect(
         () => monty.run('def'),
         throwsA(
-          isA<MontyException>().having(
+          isA<MontyScriptError>().having(
             (e) => e.message,
             'message',
             'SyntaxError: invalid syntax',
@@ -131,7 +131,7 @@ void main() {
 
       try {
         await monty.run('x');
-      } on MontyException catch (_) {
+      } on MontyScriptError catch (_) {
         // expected
       }
 
@@ -284,7 +284,7 @@ void main() {
       expect(mock.createCalls.first.scriptName, 'my_script.py');
     });
 
-    test('throws MontyException on error progress', () async {
+    test('throws MontyScriptError on error progress', () async {
       mock.nextStartResult = const ProgressResult(
         tag: 2,
         errorMessage: 'compilation failed',
@@ -293,7 +293,7 @@ void main() {
       expect(
         () => monty.start('bad code'),
         throwsA(
-          isA<MontyException>().having(
+          isA<MontyScriptError>().having(
             (e) => e.message,
             'message',
             'compilation failed',
@@ -397,14 +397,14 @@ void main() {
       expect(pending.arguments, ['data']);
     });
 
-    test('throws MontyException on error', () async {
+    test('throws MontyScriptError on error', () async {
       mock.resumeResults.add(
         const ProgressResult(tag: 2, errorMessage: 'runtime error'),
       );
 
       expect(
         () => monty.resume(null),
-        throwsA(isA<MontyException>()),
+        throwsA(isA<MontyScriptError>()),
       );
     });
 
@@ -718,7 +718,7 @@ void main() {
       expect(
         () => monty.start('x'),
         throwsA(
-          isA<MontyException>().having(
+          isA<MontyScriptError>().having(
             (e) => e.message,
             'message',
             'Unknown error',
@@ -754,7 +754,7 @@ void main() {
       expect(
         () => monty.run('x'),
         throwsA(
-          isA<MontyException>().having(
+          isA<MontyScriptError>().having(
             (e) => e.message,
             'message',
             'Unknown error',
@@ -784,12 +784,12 @@ void main() {
         try {
           await monty.run('1/0');
           fail('Expected MontyException');
-        } on MontyException catch (e) {
+        } on MontyScriptError catch (e) {
           expect(e.excType, 'ZeroDivisionError');
           expect(e.message, 'division by zero');
-          expect(e.filename, 'test.py');
-          expect(e.traceback, hasLength(1));
-          expect(e.traceback.first.filename, 'test.py');
+          expect(e.exception.filename, 'test.py');
+          expect(e.exception.traceback, hasLength(1));
+          expect(e.exception.traceback.first.filename, 'test.py');
         }
       },
     );
@@ -805,7 +805,7 @@ void main() {
         expect(
           () => monty.run('x'),
           throwsA(
-            isA<MontyException>().having(
+            isA<MontyScriptError>().having(
               (e) => e.message,
               'message',
               'fallback msg',
@@ -832,10 +832,10 @@ void main() {
       try {
         await monty.start('x', externalFunctions: ['f']);
         fail('Expected MontyException');
-      } on MontyException catch (e) {
+      } on MontyScriptError catch (e) {
         expect(e.excType, 'NameError');
         expect(e.message, 'name error');
-        expect(e.traceback, hasLength(1));
+        expect(e.exception.traceback, hasLength(1));
       }
     });
 

--- a/packages/dart_monty_native/test/integration/smoke_test.dart
+++ b/packages/dart_monty_native/test/integration/smoke_test.dart
@@ -80,7 +80,7 @@ void main() {
   test('error handling: invalid syntax', () async {
     final monty = createMonty();
 
-    expect(() => monty.run('def'), throwsA(isA<MontyException>()));
+    expect(() => monty.run('def'), throwsA(isA<MontyScriptError>()));
 
     await monty.dispose();
   });

--- a/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/base_monty_platform.dart
@@ -32,7 +32,7 @@ import 'package:meta/meta.dart';
 abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   /// Creates a [BaseMontyPlatform] backed by [bindings].
   BaseMontyPlatform({required MontyCoreBindings bindings})
-    : _bindings = bindings;
+      : _bindings = bindings;
 
   final MontyCoreBindings _bindings;
 
@@ -165,11 +165,10 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
         printOutput: r.printOutput,
       );
     }
-    _throwSealedErrorIfApplicable(r.excType, r.error ?? 'Unknown error');
-    throw MontyException(
-      message: r.error ?? 'Unknown error',
+    throw _buildSealedError(
       excType: r.excType,
-      traceback: _parseTraceback(r.traceback),
+      message: r.error ?? 'Unknown error',
+      traceback: r.traceback,
       filename: r.filename,
       lineNumber: r.lineNumber,
       columnNumber: r.columnNumber,
@@ -207,11 +206,10 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
         );
       case 'error':
         markIdle();
-        _throwSealedErrorIfApplicable(p.excType, p.error ?? 'Unknown error');
-        throw MontyException(
-          message: p.error ?? 'Unknown error',
+        throw _buildSealedError(
           excType: p.excType,
-          traceback: _parseTraceback(p.traceback),
+          message: p.error ?? 'Unknown error',
+          traceback: p.traceback,
           filename: p.filename,
           lineNumber: p.lineNumber,
           columnNumber: p.columnNumber,
@@ -253,19 +251,39 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
     return MontyStackFrame.listFromJson(traceback);
   }
 
-  /// Maps known Python exception types to the sealed [MontyError] hierarchy.
+  /// Builds a sealed [MontyError] from an error result.
   ///
-  /// Throws the appropriate sealed type for cancel and resource errors.
-  /// Returns without throwing for unmapped types, allowing fallthrough to
-  /// the existing [MontyException] path.
-  void _throwSealedErrorIfApplicable(String? excType, String message) {
+  /// Maps known Python exception types to specific subtypes:
+  /// - `KeyboardInterrupt` → [MontyCancelledError]
+  /// - `MemoryLimitExceeded` → [MontyResourceError]
+  /// - All other Python exceptions → [MontyScriptError] (with full
+  ///   [MontyException] for traceback / source location access)
+  MontyError _buildSealedError({
+    required String message,
+    String? excType,
+    List<dynamic>? traceback,
+    String? filename,
+    int? lineNumber,
+    int? columnNumber,
+    String? sourceCode,
+  }) {
     switch (excType) {
       case 'KeyboardInterrupt':
-        throw MontyCancelledError(message);
+        return MontyCancelledError(message);
       case 'MemoryLimitExceeded':
-        throw MontyResourceError(message);
+        return MontyResourceError(message);
       default:
-        return;
+        return MontyScriptError(
+          MontyException(
+            message: message,
+            excType: excType,
+            traceback: _parseTraceback(traceback),
+            filename: filename,
+            lineNumber: lineNumber,
+            columnNumber: columnNumber,
+            sourceCode: sourceCode,
+          ),
+        );
     }
   }
 }

--- a/packages/dart_monty_platform_interface/lib/src/monty_error.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_error.dart
@@ -1,3 +1,5 @@
+import 'package:dart_monty_platform_interface/src/monty_exception.dart';
+
 /// Sealed error hierarchy for Monty interpreter failures.
 ///
 /// Use exhaustive pattern matching to handle all failure modes:
@@ -43,11 +45,19 @@ class MontyCancelledError extends MontyError {
 
 /// Thrown when the interpreter hits a Python-level exception.
 ///
+/// Carries the full [MontyException] for access to traceback, source
+/// location, and the Python exception class name.
+///
 /// **Application error** — handled by orchestrator/saga, NOT supervisor.
 /// Do not restart blindly — Python exceptions are deterministic.
 class MontyScriptError extends MontyError {
-  /// Creates a [MontyScriptError].
-  const MontyScriptError(super.message, {this.excType});
+  /// Creates a [MontyScriptError] from a [MontyException].
+  MontyScriptError(this.exception)
+      : excType = exception.excType,
+        super(exception.message);
+
+  /// The full Python exception with traceback, source location, etc.
+  final MontyException exception;
 
   /// The Python exception class name (e.g. "ZeroDivisionError").
   final String? excType;

--- a/packages/dart_monty_platform_interface/lib/src/monty_session.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_session.dart
@@ -389,9 +389,9 @@ class MontySession {
   // Safe platform wrappers
   // ---------------------------------------------------------------------------
 
-  /// Wraps [MontyPlatform.start], catching [MontyException] (Python errors)
-  /// and [MontyError] (cancel, panic, disposed, resource) and converting
-  /// them to [MontyComplete] with an error result.
+  /// Wraps [MontyPlatform.start], catching [MontyError] (which now includes
+  /// [MontyScriptError] for all Python exceptions) and converting to
+  /// [MontyComplete] with an error result.
   Future<MontyProgress> _safeStart(
     String code, {
     List<String>? externalFunctions,
@@ -405,56 +405,40 @@ class MontySession {
         limits: limits,
         scriptName: scriptName,
       );
-    } on MontyException catch (e) {
-      return MontyComplete(
-        result: MontyResult(error: e, usage: _zeroUsage),
-      );
     } on MontyError catch (e) {
       return MontyComplete(
-        result: MontyResult(
-          error: MontyException(message: e.message),
-          usage: _zeroUsage,
-        ),
+        result: MontyResult(error: _exceptionFromError(e), usage: _zeroUsage),
       );
     }
   }
 
-  /// Wraps [MontyPlatform.resume], catching [MontyException] and
-  /// [MontyError].
+  /// Wraps [MontyPlatform.resume], catching [MontyError].
   Future<MontyProgress> _safeResume(Object? returnValue) async {
     try {
       return await _platform.resume(returnValue);
-    } on MontyException catch (e) {
-      return MontyComplete(
-        result: MontyResult(error: e, usage: _zeroUsage),
-      );
     } on MontyError catch (e) {
       return MontyComplete(
-        result: MontyResult(
-          error: MontyException(message: e.message),
-          usage: _zeroUsage,
-        ),
+        result: MontyResult(error: _exceptionFromError(e), usage: _zeroUsage),
       );
     }
   }
 
-  /// Wraps [MontyPlatform.resumeWithError], catching [MontyException] and
-  /// [MontyError].
+  /// Wraps [MontyPlatform.resumeWithError], catching [MontyError].
   Future<MontyProgress> _safeResumeWithError(String errorMessage) async {
     try {
       return await _platform.resumeWithError(errorMessage);
-    } on MontyException catch (e) {
-      return MontyComplete(
-        result: MontyResult(error: e, usage: _zeroUsage),
-      );
     } on MontyError catch (e) {
       return MontyComplete(
-        result: MontyResult(
-          error: MontyException(message: e.message),
-          usage: _zeroUsage,
-        ),
+        result: MontyResult(error: _exceptionFromError(e), usage: _zeroUsage),
       );
     }
+  }
+
+  /// Extracts a [MontyException] from a [MontyError], preserving full
+  /// details for [MontyScriptError] which carries the original exception.
+  static MontyException _exceptionFromError(MontyError e) {
+    if (e is MontyScriptError) return e.exception;
+    return MontyException(message: e.message);
   }
 
   void _checkNotDisposed() {

--- a/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
+++ b/packages/dart_monty_platform_interface/test/base_monty_platform_test.dart
@@ -151,7 +151,7 @@ void main() {
       expect(fake.lastRunCode, '1 + 1');
     });
 
-    test('error throws MontyException', () async {
+    test('error throws MontyScriptError', () async {
       fake.runResult = const CoreRunResult(
         ok: false,
         error: 'division by zero',
@@ -164,10 +164,14 @@ void main() {
       expect(
         () => platform.run('1 / 0'),
         throwsA(
-          isA<MontyException>()
+          isA<MontyScriptError>()
               .having((e) => e.message, 'message', 'division by zero')
               .having((e) => e.excType, 'excType', 'ZeroDivisionError')
-              .having((e) => e.traceback, 'traceback', hasLength(1)),
+              .having(
+                (e) => e.exception.traceback,
+                'traceback',
+                hasLength(1),
+              ),
         ),
       );
     });
@@ -335,7 +339,7 @@ void main() {
       expect(platform.isActive, isTrue);
     });
 
-    test('error throws MontyException and marks idle', () async {
+    test('error throws MontyScriptError and marks idle', () async {
       fake.progressResult = const CoreProgressResult(
         state: 'error',
         error: 'name not defined',
@@ -345,7 +349,7 @@ void main() {
       await expectLater(
         () => platform.start('code'),
         throwsA(
-          isA<MontyException>()
+          isA<MontyScriptError>()
               .having((e) => e.message, 'message', 'name not defined')
               .having((e) => e.excType, 'excType', 'NameError'),
         ),
@@ -605,7 +609,7 @@ void main() {
 
       await expectLater(
         () => platform.run('code'),
-        throwsA(isA<MontyException>()),
+        throwsA(isA<MontyScriptError>()),
       );
       expect(platform.isIdle, isTrue);
     });

--- a/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
+++ b/packages/dart_monty_platform_interface/test/cancel_t1_4_sealed_error_test.dart
@@ -45,7 +45,7 @@ void main() {
     });
 
     test(
-      'Python ZeroDivisionError maps to MontyException (not sealed)',
+      'Python ZeroDivisionError maps to MontyScriptError',
       () async {
         final bindings = _FakeCoreBindings();
         final platform = _TestPlatform(bindings: bindings);
@@ -59,11 +59,13 @@ void main() {
         await expectLater(
           platform.run('code'),
           throwsA(
-            isA<MontyException>().having(
-              (e) => e.excType,
-              'excType',
-              'ZeroDivisionError',
-            ),
+            isA<MontyScriptError>()
+                .having((e) => e.excType, 'excType', 'ZeroDivisionError')
+                .having(
+                  (e) => e.exception.excType,
+                  'exception.excType',
+                  'ZeroDivisionError',
+                ),
           ),
         );
       },
@@ -112,13 +114,13 @@ void main() {
     test('all 6 sealed subtypes are matchable', () {
       // This test verifies that the sealed class hierarchy compiles
       // with exhaustive pattern matching.
-      const errors = <MontyError>[
-        MontyCancelledError(),
-        MontyScriptError('test'),
-        MontyPanicError('test'),
-        MontyCrashError(),
-        MontyDisposedError(),
-        MontyResourceError('test'),
+      final errors = <MontyError>[
+        const MontyCancelledError(),
+        MontyScriptError(const MontyException(message: 'test')),
+        const MontyPanicError('test'),
+        const MontyCrashError(),
+        const MontyDisposedError(),
+        const MontyResourceError('test'),
       ];
 
       for (final error in errors) {
@@ -135,12 +137,15 @@ void main() {
     });
 
     test('MontyScriptError preserves excType', () {
-      const error = MontyScriptError(
-        'division by zero',
-        excType: 'ZeroDivisionError',
+      final error = MontyScriptError(
+        const MontyException(
+          message: 'division by zero',
+          excType: 'ZeroDivisionError',
+        ),
       );
       expect(error.excType, 'ZeroDivisionError');
       expect(error.message, 'division by zero');
+      expect(error.exception.excType, 'ZeroDivisionError');
     });
   });
 
@@ -156,7 +161,9 @@ void main() {
     });
 
     test('MontyScriptError toString', () {
-      const e = MontyScriptError('boom', excType: 'ValueError');
+      final e = MontyScriptError(
+        const MontyException(message: 'boom', excType: 'ValueError'),
+      );
       expect(e.toString(), 'MontyScriptError: boom');
     });
 

--- a/packages/dart_monty_wasm/example/example.dart
+++ b/packages/dart_monty_wasm/example/example.dart
@@ -55,7 +55,7 @@ Future<void> _externalFunctionDispatch(MontyWasm monty) async {
 Future<void> _errorHandling(MontyWasm monty) async {
   try {
     await monty.run('1 / 0');
-  } on MontyException catch (e) {
+  } on MontyScriptError catch (e) {
     print('Exception type: ${e.excType}'); // ZeroDivisionError
     print('Message: ${e.message}');
   }

--- a/packages/dart_monty_wasm/test/monty_wasm_test.dart
+++ b/packages/dart_monty_wasm/test/monty_wasm_test.dart
@@ -760,9 +760,9 @@ void main() {
       try {
         await monty.run('1/0');
         fail('Expected MontyException');
-      } on MontyException catch (e) {
+      } on MontyScriptError catch (e) {
         expect(e.excType, 'ZeroDivisionError');
-        final traceback = e.traceback;
+        final traceback = e.exception.traceback;
         expect(traceback, hasLength(1));
         final frame = traceback.first;
         expect(frame.filename, '<input>');
@@ -786,9 +786,9 @@ void main() {
       try {
         await monty.start('x');
         fail('Expected MontyException');
-      } on MontyException catch (e) {
+      } on MontyScriptError catch (e) {
         expect(e.excType, 'NameError');
-        final startTraceback = e.traceback;
+        final startTraceback = e.exception.traceback;
         expect(startTraceback, hasLength(1));
         expect(startTraceback.first.filename, 'test.py');
         expect(startTraceback.first.startLine, 5);
@@ -805,9 +805,9 @@ void main() {
       try {
         await monty.run('x');
         fail('Expected MontyException');
-      } on MontyException catch (e) {
+      } on MontyScriptError catch (e) {
         expect(e.excType, 'ValueError');
-        expect(e.traceback, isEmpty);
+        expect(e.exception.traceback, isEmpty);
       }
     });
   });


### PR DESCRIPTION
## Summary

- **Wire `MontyScriptError` into the sealed error hierarchy** — Python script errors (ZeroDivisionError, NameError, etc.) now throw `MontyScriptError` instead of raw `MontyException`. The sealed `MontyError` switch is now exhaustive for all error types.
- **Fix all README code examples** — error handling section, bridge field names (`callId` not `name`), session `dispose()`/`clearState()` (void, not awaitable), Quick Start output, and missing `dart_monty_bridge` install note.
- **Fix `example/example.dart`** — was crashing because it used `isError` pattern on `Monty` direct usage (which throws). Now uses `on MontyScriptError catch`.
- **Add CI doctest job** — new `doctest` job in CI runs `readme_doctest.dart` integration tests on every PR touching markdown or code. All 9 README dart blocks now have handlers. If a block is added without a handler, the safety-net test fails.

## What changed

| File | Change |
|------|--------|
| `monty_error.dart` | `MontyScriptError` now takes `MontyException` (has `.exception`, `.excType`, `.message`) |
| `base_monty_platform.dart` | `_buildSealedError()` replaces `_throwSealedErrorIfApplicable()` — always returns a sealed type |
| `monty_session.dart` | `_exceptionFromError()` preserves full exception details from `MontyScriptError` |
| `default_monty_bridge.dart` | Catches `MontyScriptError` before `MontyError` to preserve line-number adjustment |
| `README.md` | Fixed 5 code blocks (error handling, bridge, sessions, Quick Start output) |
| `readme_doctest.dart` | Handlers for all 9 README blocks (was 3), plus structural checks |
| `ci.yaml` | New `doctest` job + `docs` change detection filter |

## Closes

Closes #250, #251, #252, #253, #254, #255, #256, #257

## Test plan

- [x] `dart_monty_platform_interface`: 351 tests pass
- [x] `dart_monty_ffi`: 172 tests pass (14 integration skipped)
- [x] `dart_monty_bridge`: 261 tests pass
- [x] `dart_monty_wasm`: 49 tests pass
- [x] `dart_monty_mcp`: 76 tests pass
- [x] `python3 tool/analyze_packages.py` — all packages pass
- [x] End-to-end test: new error model works for both `Monty` (throws) and `MontySession` (returns isError)
- [ ] CI doctest job runs `readme_doctest.dart` with native lib (needs Rust in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)