### PR TITLE
docs: add dartdoc categories, topic pages, and generation script

### DIFF
--- a/dartdoc_options.yaml
+++ b/dartdoc_options.yaml
@@ -1,0 +1,18 @@
+dartdoc:
+  categories:
+    "Core":
+      markdown: doc/categories/core.md
+    "Execution":
+      markdown: doc/categories/execution.md
+    "Errors":
+      markdown: doc/categories/errors.md
+    "Configuration":
+      markdown: doc/categories/configuration.md
+    "Sessions":
+      markdown: doc/categories/sessions.md
+  categoryOrder:
+    - "Core"
+    - "Execution"
+    - "Errors"
+    - "Configuration"
+    - "Sessions"

--- a/doc/categories/configuration.md
+++ b/doc/categories/configuration.md
@@ -1,0 +1,1 @@
+Resource limits, usage statistics, and stack frame data.

--- a/doc/categories/core.md
+++ b/doc/categories/core.md
@@ -1,0 +1,1 @@
+The main entry point for running Python code. Start here with `Monty` and `MontyResult`.

--- a/doc/categories/errors.md
+++ b/doc/categories/errors.md
@@ -1,0 +1,1 @@
+Sealed error hierarchy for exhaustive error handling via pattern matching.

--- a/doc/categories/execution.md
+++ b/doc/categories/execution.md
@@ -1,0 +1,1 @@
+Types for iterative (multi-step) execution with external functions via `start()` / `resume()`.

--- a/doc/categories/sessions.md
+++ b/doc/categories/sessions.md
@@ -1,0 +1,1 @@
+Stateful execution sessions and cancellation tokens.

--- a/lib/dart_monty.dart
+++ b/lib/dart_monty.dart
@@ -1,7 +1,10 @@
 /// Pure Dart bindings for the Monty sandboxed Python interpreter.
 ///
-/// Backend is selected at compile time via conditional imports:
-/// native FFI on desktop/server, WASM in browsers. No Flutter required.
+/// This is the main entry point for running sandboxed Python from Dart.
+/// The backend (native FFI or browser WASM) is selected at compile time
+/// via conditional imports — no Flutter required.
+///
+/// ## Quick Start
 ///
 /// ```dart
 /// import 'package:dart_monty/dart_monty.dart';
@@ -11,6 +14,22 @@
 /// print(result.value); // 4
 /// await monty.dispose();
 /// ```
+///
+/// ## Key Types
+///
+/// - [Monty] — create an interpreter and run Python code
+/// - [MontyResult] — the return value from [Monty.run]
+/// - [MontyProgress], [MontyPending], [MontyComplete] — iterative execution
+///   with external functions via [Monty.start] / [Monty.resume]
+/// - [MontyError] — sealed error hierarchy for exhaustive error handling
+/// - [MontyLimits] — resource constraints (time, memory, stack depth)
+/// - [MontySession] — stateful sessions that persist Python globals
+///
+/// ## Related Packages
+///
+/// - **dart_monty_bridge** — high-level bridge with host function dispatch,
+///   event streaming, and a plugin system. Install separately:
+///   `dart pub add dart_monty_bridge`
 library;
 
 export 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart';

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -3,6 +3,8 @@ import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart
 
 /// Monty sandboxed Python interpreter.
 ///
+/// {@category Core}
+///
 /// Uses compile-time conditional imports to select the backend:
 /// - Native (macOS, Linux, Windows): Rust FFI via `dart:ffi`
 /// - Web (browser): WASM via `dart:js_interop`

--- a/packages/dart_monty_bridge/dartdoc_options.yaml
+++ b/packages/dart_monty_bridge/dartdoc_options.yaml
@@ -1,0 +1,17 @@
+dartdoc:
+  categories:
+    "Bridge":
+      markdown: doc/categories/bridge.md
+    "Host Functions":
+      markdown: doc/categories/host_functions.md
+    "Plugins":
+      markdown: doc/categories/plugins.md
+    "Events":
+      markdown: doc/categories/events.md
+  categoryOrder:
+    - "Bridge"
+    - "Host Functions"
+    - "Plugins"
+    - "Events"
+  exclude:
+    - "bridge_internals"

--- a/packages/dart_monty_bridge/doc/categories/bridge.md
+++ b/packages/dart_monty_bridge/doc/categories/bridge.md
@@ -1,0 +1,1 @@
+High-level bridge that wraps the start/resume loop and emits a stream of events.

--- a/packages/dart_monty_bridge/doc/categories/events.md
+++ b/packages/dart_monty_bridge/doc/categories/events.md
@@ -1,0 +1,1 @@
+Lifecycle events emitted during Python execution.

--- a/packages/dart_monty_bridge/doc/categories/host_functions.md
+++ b/packages/dart_monty_bridge/doc/categories/host_functions.md
@@ -1,0 +1,1 @@
+Register Dart functions callable from Python code.

--- a/packages/dart_monty_bridge/doc/categories/plugins.md
+++ b/packages/dart_monty_bridge/doc/categories/plugins.md
@@ -1,0 +1,1 @@
+Group related host functions into reusable, namespaced bundles.

--- a/packages/dart_monty_bridge/lib/dart_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/dart_monty_bridge.dart
@@ -1,7 +1,42 @@
 /// High-level bridge layer for dart_monty.
 ///
-/// Provides host function infrastructure, the default bridge implementation,
-/// event loop support, and a plugin system for modular host function bundles.
+/// Wraps the low-level `start()`/`resume()` loop from `dart_monty` into
+/// a stream-based API with host function dispatch, argument validation,
+/// and a plugin system.
+///
+/// ## Installation
+///
+/// This is a **separate package** from `dart_monty`:
+///
+/// ```bash
+/// dart pub add dart_monty_bridge
+/// ```
+///
+/// ## Quick Start
+///
+/// ```dart
+/// import 'package:dart_monty/dart_monty.dart';
+/// import 'package:dart_monty_bridge/dart_monty_bridge.dart';
+///
+/// final bridge = DefaultMontyBridge(platform: Monty());
+/// bridge.register(HostFunction(
+///   schema: const HostFunctionSchema(
+///     name: 'greet',
+///     description: 'Returns a greeting.',
+///     params: [HostParam(name: 'name', type: HostParamType.string)],
+///   ),
+///   handler: (args) async => 'Hello, ${args["name"]}!',
+/// ));
+/// ```
+///
+/// ## Key Types
+///
+/// | Category | Types |
+/// |----------|-------|
+/// | **Bridge** | `DefaultMontyBridge`, `MontyBridge`, `EventLoopBridge` |
+/// | **Host Functions** | `HostFunction`, `HostFunctionSchema`, `HostParam` |
+/// | **Plugins** | `MontyPlugin`, `PluginRegistry` |
+/// | **Events** | `BridgeEvent`, `BridgeRunFinished`, `BridgeToolCallResult` |
 library;
 
 export 'src/bridge/bridge_event.dart';

--- a/packages/dart_monty_bridge/lib/src/bridge/bridge_event.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/bridge_event.dart
@@ -5,12 +5,16 @@ import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart
 /// These events describe what happened during Python execution without
 /// coupling to any specific event protocol (e.g. ag-ui). Downstream
 /// consumers map these to their own protocol types.
+///
+/// {@category Events}
 sealed class BridgeEvent {
   /// Creates a [BridgeEvent].
   const BridgeEvent();
 }
 
 /// Execution started.
+///
+/// {@category Events}
 class BridgeRunStarted extends BridgeEvent {
   /// Creates a [BridgeRunStarted].
   const BridgeRunStarted({required this.threadId, required this.runId});
@@ -23,6 +27,8 @@ class BridgeRunStarted extends BridgeEvent {
 }
 
 /// Execution completed successfully.
+///
+/// {@category Events}
 class BridgeRunFinished extends BridgeEvent {
   /// Creates a [BridgeRunFinished].
   const BridgeRunFinished({
@@ -46,6 +52,8 @@ class BridgeRunFinished extends BridgeEvent {
 }
 
 /// Execution failed with an error.
+///
+/// {@category Events}
 class BridgeRunError extends BridgeEvent {
   /// Creates a [BridgeRunError].
   const BridgeRunError({
@@ -69,6 +77,8 @@ class BridgeRunError extends BridgeEvent {
 }
 
 /// A host function call step started.
+///
+/// {@category Events}
 class BridgeStepStarted extends BridgeEvent {
   /// Creates a [BridgeStepStarted].
   const BridgeStepStarted({required this.stepId});
@@ -78,6 +88,8 @@ class BridgeStepStarted extends BridgeEvent {
 }
 
 /// A host function call step finished.
+///
+/// {@category Events}
 class BridgeStepFinished extends BridgeEvent {
   /// Creates a [BridgeStepFinished].
   const BridgeStepFinished({required this.stepId});
@@ -87,6 +99,8 @@ class BridgeStepFinished extends BridgeEvent {
 }
 
 /// A tool call began (function name known).
+///
+/// {@category Events}
 class BridgeToolCallStart extends BridgeEvent {
   /// Creates a [BridgeToolCallStart].
   const BridgeToolCallStart({required this.callId, required this.name});
@@ -99,6 +113,8 @@ class BridgeToolCallStart extends BridgeEvent {
 }
 
 /// Tool call arguments (JSON delta).
+///
+/// {@category Events}
 class BridgeToolCallArgs extends BridgeEvent {
   /// Creates a [BridgeToolCallArgs].
   const BridgeToolCallArgs({required this.callId, required this.delta});
@@ -111,6 +127,8 @@ class BridgeToolCallArgs extends BridgeEvent {
 }
 
 /// Tool call arguments complete.
+///
+/// {@category Events}
 class BridgeToolCallEnd extends BridgeEvent {
   /// Creates a [BridgeToolCallEnd].
   const BridgeToolCallEnd({required this.callId});
@@ -120,6 +138,8 @@ class BridgeToolCallEnd extends BridgeEvent {
 }
 
 /// Tool call result (handler output or error).
+///
+/// {@category Events}
 class BridgeToolCallResult extends BridgeEvent {
   /// Creates a [BridgeToolCallResult].
   const BridgeToolCallResult({required this.callId, required this.result});
@@ -132,6 +152,8 @@ class BridgeToolCallResult extends BridgeEvent {
 }
 
 /// Text output started (print buffer flush).
+///
+/// {@category Events}
 class BridgeTextStart extends BridgeEvent {
   /// Creates a [BridgeTextStart].
   const BridgeTextStart({required this.messageId});
@@ -141,6 +163,8 @@ class BridgeTextStart extends BridgeEvent {
 }
 
 /// Text output content delta.
+///
+/// {@category Events}
 class BridgeTextContent extends BridgeEvent {
   /// Creates a [BridgeTextContent].
   const BridgeTextContent({required this.messageId, required this.delta});
@@ -153,6 +177,8 @@ class BridgeTextContent extends BridgeEvent {
 }
 
 /// Text output ended.
+///
+/// {@category Events}
 class BridgeTextEnd extends BridgeEvent {
   /// Creates a [BridgeTextEnd].
   const BridgeTextEnd({required this.messageId});
@@ -162,12 +188,16 @@ class BridgeTextEnd extends BridgeEvent {
 }
 
 /// Event loop entered wait state (Python called `wait_for_event()`).
+///
+/// {@category Events}
 class BridgeEventLoopWaiting extends BridgeEvent {
   /// Creates a [BridgeEventLoopWaiting].
   const BridgeEventLoopWaiting();
 }
 
 /// Event loop resumed after receiving a UI event.
+///
+/// {@category Events}
 class BridgeEventLoopResumed extends BridgeEvent {
   /// Creates a [BridgeEventLoopResumed].
   const BridgeEventLoopResumed({required this.event});
@@ -177,6 +207,8 @@ class BridgeEventLoopResumed extends BridgeEvent {
 }
 
 /// Python called `render_ui` with a schema.
+///
+/// {@category Events}
 class BridgeUiRendered extends BridgeEvent {
   /// Creates a [BridgeUiRendered].
   const BridgeUiRendered({required this.schema});

--- a/packages/dart_monty_bridge/lib/src/bridge/bridge_middleware.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/bridge_middleware.dart
@@ -31,6 +31,8 @@ typedef ToolHandler = Future<Object?> Function(
 ///
 /// Register via `use()` on the bridge. First registered = outermost in the
 /// onion chain. Call `next` to proceed, or throw/return to short-circuit.
+///
+/// {@category Bridge}
 abstract class BridgeMiddleware {
   /// Wraps a tool call. Inspect [role] to decide whether to enforce policy.
   Future<Object?> handle(

--- a/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/default_monty_bridge.dart
@@ -52,6 +52,8 @@ class _PendingFuture {
 ///
 /// Orchestrates the Monty start/resume loop, dispatching external function
 /// calls to registered [HostFunction] handlers and emitting [BridgeEvent]s.
+///
+/// {@category Bridge}
 class DefaultMontyBridge implements MontyBridge {
   /// Creates a [DefaultMontyBridge].
   ///

--- a/packages/dart_monty_bridge/lib/src/bridge/event_loop_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/event_loop_bridge.dart
@@ -37,6 +37,8 @@ typedef RenderUiCallback = void Function(Map<String, dynamic> schema);
 /// Python holds state in a `while True` loop, calling `wait_for_event()` to
 /// pause and `render_ui(schema)` to push UI updates. The host dispatches
 /// user interactions via [dispatchUiEvent].
+///
+/// {@category Bridge}
 class EventLoopBridge extends DefaultMontyBridge {
   /// Creates an [EventLoopBridge].
   ///

--- a/packages/dart_monty_bridge/lib/src/bridge/host_function.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/host_function.dart
@@ -8,6 +8,8 @@ typedef HostFunctionHandler = Future<Object?> Function(
 );
 
 /// A host function: schema + handler + optional role.
+///
+/// {@category Host Functions}
 @immutable
 class HostFunction {
   /// Creates a [HostFunction].

--- a/packages/dart_monty_bridge/lib/src/bridge/host_function_schema.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/host_function_schema.dart
@@ -7,6 +7,8 @@ import 'package:meta/meta.dart';
 /// Defines the function's name, description, and ordered parameters.
 /// Handles mapping Monty's positional/keyword arguments to named parameters
 /// and validates types before the handler runs.
+///
+/// {@category Host Functions}
 @immutable
 class HostFunctionSchema {
   /// Creates a [HostFunctionSchema].

--- a/packages/dart_monty_bridge/lib/src/bridge/host_param.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/host_param.dart
@@ -2,6 +2,8 @@ import 'package:dart_monty_bridge/src/bridge/host_param_type.dart';
 import 'package:meta/meta.dart';
 
 /// Describes a single parameter of a host function.
+///
+/// {@category Host Functions}
 @immutable
 class HostParam {
   /// Creates a [HostParam].

--- a/packages/dart_monty_bridge/lib/src/bridge/host_param_type.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/host_param_type.dart
@@ -1,4 +1,6 @@
 /// Parameter types for host function arguments.
+///
+/// {@category Host Functions}
 enum HostParamType {
   /// String parameter. Monty Python `str`.
   string,

--- a/packages/dart_monty_bridge/lib/src/bridge/monty_bridge.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/monty_bridge.dart
@@ -8,6 +8,8 @@ import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart
 ///
 /// Executes Python code in the Monty sandbox, dispatches external function
 /// calls to registered [HostFunction] handlers, and emits [BridgeEvent]s.
+///
+/// {@category Bridge}
 abstract class MontyBridge {
   /// Logger for this bridge instance.
   ///

--- a/packages/dart_monty_bridge/lib/src/bridge/monty_plugin.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/monty_plugin.dart
@@ -27,6 +27,8 @@ class ChildSpawnContext {
 ///
 /// Each plugin declares a unique [namespace], a set of [functions], and
 /// optional lifecycle hooks ([onRegister], [onDispose]).
+///
+/// {@category Plugins}
 abstract class MontyPlugin {
   /// Unique namespace prefix (e.g., "df", "chart", "sqlite").
   String get namespace;

--- a/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
+++ b/packages/dart_monty_bridge/lib/src/bridge/plugin_registry.dart
@@ -13,6 +13,8 @@ import 'package:dart_monty_platform_interface/dart_monty_platform_interface.dart
 /// All function names must be prefixed with the plugin's namespace followed
 /// by an underscore (e.g., namespace `sqlite` requires functions named
 /// `sqlite_query`, `sqlite_execute`, etc.).
+///
+/// {@category Plugins}
 class PluginRegistry {
   final List<MontyPlugin> _plugins = [];
   List<MontyPlugin>? _attachOrder;

--- a/packages/dart_monty_platform_interface/dartdoc_options.yaml
+++ b/packages/dart_monty_platform_interface/dartdoc_options.yaml
@@ -1,0 +1,20 @@
+dartdoc:
+  categories:
+    "Core":
+      markdown: doc/categories/core.md
+    "Execution":
+      markdown: doc/categories/execution.md
+    "Errors":
+      markdown: doc/categories/errors.md
+    "Configuration":
+      markdown: doc/categories/configuration.md
+    "Sessions":
+      markdown: doc/categories/sessions.md
+  categoryOrder:
+    - "Core"
+    - "Execution"
+    - "Errors"
+    - "Configuration"
+    - "Sessions"
+  exclude:
+    - "monty_backend_spi"

--- a/packages/dart_monty_platform_interface/doc/categories/configuration.md
+++ b/packages/dart_monty_platform_interface/doc/categories/configuration.md
@@ -1,0 +1,1 @@
+Resource limits, usage statistics, and stack frame data.

--- a/packages/dart_monty_platform_interface/doc/categories/core.md
+++ b/packages/dart_monty_platform_interface/doc/categories/core.md
@@ -1,0 +1,1 @@
+The main entry point for running Python code. Start here with `Monty` and `MontyResult`.

--- a/packages/dart_monty_platform_interface/doc/categories/errors.md
+++ b/packages/dart_monty_platform_interface/doc/categories/errors.md
@@ -1,0 +1,1 @@
+Sealed error hierarchy for exhaustive error handling via pattern matching.

--- a/packages/dart_monty_platform_interface/doc/categories/execution.md
+++ b/packages/dart_monty_platform_interface/doc/categories/execution.md
@@ -1,0 +1,1 @@
+Types for iterative (multi-step) execution with external functions via `start()` / `resume()`.

--- a/packages/dart_monty_platform_interface/doc/categories/sessions.md
+++ b/packages/dart_monty_platform_interface/doc/categories/sessions.md
@@ -1,0 +1,1 @@
+Stateful execution sessions and cancellation tokens.

--- a/packages/dart_monty_platform_interface/lib/dart_monty_platform_interface.dart
+++ b/packages/dart_monty_platform_interface/lib/dart_monty_platform_interface.dart
@@ -1,7 +1,24 @@
 /// Platform interface for dart_monty.
 ///
-/// Defines the shared API contract implemented by native and web backends.
-/// This package is not intended for direct use — import `dart_monty` instead.
+/// Defines the shared API contract and domain types used by all
+/// dart_monty packages. **Most users should import `dart_monty`
+/// instead**, which re-exports everything from this library plus
+/// the `Monty` convenience class.
+///
+/// ## Key Types
+///
+/// | Category | Types |
+/// |----------|-------|
+/// | **Core** | `MontyPlatform`, `MontyResult`, `MontyException` |
+/// | **Execution** | `MontyProgress`, `MontyPending`, `MontyComplete` |
+/// | **Errors** | `MontyError`, `MontyScriptError`, `MontyCancelledError` |
+/// | **Config** | `MontyLimits`, `MontyResourceUsage` |
+/// | **Sessions** | `MontySession`, `MontyCancelToken` |
+///
+/// ## For Backend Implementers
+///
+/// Import `monty_backend_spi.dart` for `BaseMontyPlatform` and
+/// `MontyCoreBindings`.
 library;
 
 export 'src/bridge_logger.dart';

--- a/packages/dart_monty_platform_interface/lib/src/monty_cancel_registry.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_cancel_registry.dart
@@ -12,6 +12,8 @@ import 'package:dart_monty_platform_interface/src/core_bindings.dart';
 ///
 /// This class is stateless — all state is held in static fields scoped
 /// to the current isolate.
+///
+/// {@category Sessions}
 abstract final class MontyCancelRegistry {
   // ---------------------------------------------------------------------------
   // Native cancel callbacks (registered by dart_monty_ffi at init time)

--- a/packages/dart_monty_platform_interface/lib/src/monty_cancel_token.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_cancel_token.dart
@@ -4,6 +4,8 @@ import 'package:dart_monty_platform_interface/src/monty_cancel_registry.dart';
 ///
 /// Wraps the monotonic handle ID for type safety.
 /// Safe to send via SendPort. Immutable.
+///
+/// {@category Sessions}
 extension type const MontyCancelToken(int id) {
   /// Cancel the interpreter this token refers to.
   ///

--- a/packages/dart_monty_platform_interface/lib/src/monty_error.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_error.dart
@@ -16,6 +16,8 @@
 ///   }
 /// }
 /// ```
+///
+/// {@category Errors}
 sealed class MontyError implements Exception {
   /// Creates a [MontyError] with the given [message].
   const MontyError(this.message);
@@ -33,6 +35,8 @@ sealed class MontyError implements Exception {
 /// Thrown when execution is cancelled via cancel() or cancelById().
 ///
 /// **Supervisor action:** Expected — no restart needed.
+///
+/// {@category Errors}
 class MontyCancelledError extends MontyError {
   /// Creates a [MontyCancelledError].
   const MontyCancelledError([super.message = 'Execution cancelled']);
@@ -45,6 +49,8 @@ class MontyCancelledError extends MontyError {
 ///
 /// **Application error** — handled by orchestrator/saga, NOT supervisor.
 /// Do not restart blindly — Python exceptions are deterministic.
+///
+/// {@category Errors}
 class MontyScriptError extends MontyError {
   /// Creates a [MontyScriptError].
   const MontyScriptError(super.message, {this.excType});
@@ -59,6 +65,8 @@ class MontyScriptError extends MontyError {
 /// Thrown when the Rust interpreter panics (caught by catch_unwind).
 ///
 /// **Supervisor action:** Harsh backoff — indicates a native bridge bug.
+///
+/// {@category Errors}
 class MontyPanicError extends MontyError {
   /// Creates a [MontyPanicError].
   const MontyPanicError(super.message);
@@ -70,6 +78,8 @@ class MontyPanicError extends MontyError {
 /// Thrown when the isolate/Worker died unexpectedly.
 ///
 /// **Supervisor action:** Restart immediately (infrastructure failure).
+///
+/// {@category Errors}
 class MontyCrashError extends MontyError {
   /// Creates a [MontyCrashError].
   const MontyCrashError([super.message = 'Interpreter crashed unexpectedly']);
@@ -81,6 +91,8 @@ class MontyCrashError extends MontyError {
 /// Thrown when the interpreter is disposed while execution is in flight.
 ///
 /// **Supervisor action:** Do NOT restart — fix the caller.
+///
+/// {@category Errors}
 class MontyDisposedError extends MontyError {
   /// Creates a [MontyDisposedError].
   const MontyDisposedError([
@@ -94,6 +106,8 @@ class MontyDisposedError extends MontyError {
 /// Thrown on resource exhaustion: OOM, timeout, WASM trap.
 ///
 /// **Supervisor action:** Reduce concurrency, then restart.
+///
+/// {@category Errors}
 class MontyResourceError extends MontyError {
   /// Creates a [MontyResourceError].
   const MontyResourceError(super.message);

--- a/packages/dart_monty_platform_interface/lib/src/monty_exception.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_exception.dart
@@ -28,6 +28,8 @@ const _deepEquality = DeepCollectionEquality();
 ///     handleGenericError(exception);
 /// }
 /// ```
+///
+/// {@category Core}
 @immutable
 final class MontyException implements Exception {
   /// Creates a [MontyException] with the given [message] and optional

--- a/packages/dart_monty_platform_interface/lib/src/monty_limits.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_limits.dart
@@ -3,6 +3,8 @@ import 'package:meta/meta.dart';
 /// Resource limits to impose on a Monty Python execution.
 ///
 /// All fields are optional — omitted limits are unconstrained.
+///
+/// {@category Configuration}
 @immutable
 final class MontyLimits {
   /// Creates a [MontyLimits] with optional resource constraints.

--- a/packages/dart_monty_platform_interface/lib/src/monty_platform.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_platform.dart
@@ -7,11 +7,10 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 /// The platform interface for the Monty sandboxed Python interpreter.
 ///
 /// Platform implementations (FFI, Web) extend this class to provide
-/// concrete behavior.
+/// concrete behavior. Most users should use `Monty` from `dart_monty`
+/// instead of this class directly.
 ///
-/// See also:
-/// - `dart_monty_ffi` — native FFI implementation
-/// - `dart_monty_web` — web JS interop implementation
+/// {@category Core}
 abstract class MontyPlatform extends PlatformInterface {
   /// Creates a [MontyPlatform] with the platform interface verification
   /// token.

--- a/packages/dart_monty_platform_interface/lib/src/monty_progress.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_progress.dart
@@ -24,6 +24,8 @@ const _deepEquality = DeepCollectionEquality();
 ///     print('Resolve futures: $pendingCallIds');
 /// }
 /// ```
+///
+/// {@category Execution}
 sealed class MontyProgress {
   /// Creates a [MontyProgress].
   const MontyProgress();
@@ -49,6 +51,8 @@ sealed class MontyProgress {
 }
 
 /// Execution completed with a [result].
+///
+/// {@category Execution}
 @immutable
 final class MontyComplete extends MontyProgress {
   /// Creates a [MontyComplete] with the given [result].
@@ -103,6 +107,8 @@ final class MontyComplete extends MontyProgress {
 ///     print('$functionName called with kwargs: $kwargs');
 ///   }
 /// ```
+///
+/// {@category Execution}
 @immutable
 final class MontyPending extends MontyProgress {
   /// Creates a [MontyPending] with the given [functionName] and [arguments].
@@ -208,6 +214,8 @@ final class MontyPending extends MontyProgress {
 ///     Map.fromIterables(pendingCallIds, results),
 ///   );
 /// ```
+///
+/// {@category Execution}
 @immutable
 final class MontyResolveFutures extends MontyProgress {
   /// Creates a [MontyResolveFutures] with the given [pendingCallIds].

--- a/packages/dart_monty_platform_interface/lib/src/monty_resource_usage.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_resource_usage.dart
@@ -4,6 +4,8 @@ import 'package:meta/meta.dart';
 ///
 /// Tracks [memoryBytesUsed], [timeElapsedMs], and [stackDepthUsed] to help
 /// callers monitor and budget sandbox resources.
+///
+/// {@category Configuration}
 @immutable
 final class MontyResourceUsage {
   /// Creates a [MontyResourceUsage] with the given resource metrics.

--- a/packages/dart_monty_platform_interface/lib/src/monty_result.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_result.dart
@@ -7,6 +7,8 @@ import 'package:meta/meta.dart';
 /// A result always carries [usage] statistics. It contains either a [value]
 /// (the Python expression result) or an [error] (a [MontyException]), but
 /// never both.
+///
+/// {@category Core}
 @immutable
 final class MontyResult {
   /// Creates a [MontyResult] with the given [value], optional [error], and

--- a/packages/dart_monty_platform_interface/lib/src/monty_session.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_session.dart
@@ -60,6 +60,8 @@ const _statementPrefixes = [
 /// final result = await session.run('x + 1');
 /// print(result.value); // 43
 /// ```
+///
+/// {@category Sessions}
 class MontySession {
   /// Creates a [MontySession] wrapping the given [platform].
   ///

--- a/packages/dart_monty_platform_interface/lib/src/monty_stack_frame.dart
+++ b/packages/dart_monty_platform_interface/lib/src/monty_stack_frame.dart
@@ -11,6 +11,8 @@ import 'package:meta/meta.dart';
 ///   if (frame.previewLine != null) print('  ${frame.previewLine}');
 /// }
 /// ```
+///
+/// {@category Configuration}
 @immutable
 final class MontyStackFrame {
   /// Creates a [MontyStackFrame] with source location and optional metadata.

--- a/tool/dartdoc.sh
+++ b/tool/dartdoc.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Generate dartdoc for all published packages.
+#
+# Usage:
+#   bash tool/dartdoc.sh              # All packages
+#   bash tool/dartdoc.sh dart_monty   # Single package
+#
+# Output goes to packages/<name>/doc/ (or doc/ for root).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Packages to document (published to pub.dev).
+PACKAGES=(
+  "."
+  "packages/dart_monty_platform_interface"
+  "packages/dart_monty_bridge"
+  "packages/dart_monty_ffi"
+  "packages/dart_monty_wasm"
+)
+
+generate() {
+  local pkg_dir="$1"
+  local abs_dir="$REPO_ROOT/$pkg_dir"
+  local name
+  name=$(grep '^name:' "$abs_dir/pubspec.yaml" | head -1 | awk '{print $2}')
+
+  echo "=== Generating docs for $name ==="
+  (cd "$abs_dir" && dart doc --validate-links .)
+  echo ""
+}
+
+if [[ $# -gt 0 ]]; then
+  # Single package by name
+  target="$1"
+  for pkg in "${PACKAGES[@]}"; do
+    abs="$REPO_ROOT/$pkg"
+    name=$(grep '^name:' "$abs/pubspec.yaml" | head -1 | awk '{print $2}')
+    if [[ "$name" == "$target" ]]; then
+      generate "$pkg"
+      exit 0
+    fi
+  done
+  echo "Unknown package: $target"
+  exit 1
+else
+  for pkg in "${PACKAGES[@]}"; do
+    generate "$pkg"
+  done
+fi
+
+echo "Done. Open doc/api/index.html in any package to browse."


### PR DESCRIPTION
## Summary

- Add `dartdoc_options.yaml` to 3 published packages with category definitions
- Add `{@category}` tags to 45+ public types across `dart_monty`, `dart_monty_platform_interface`, and `dart_monty_bridge`
- Improve library-level doc comments with key types tables and ecosystem navigation
- Hide internal SPI libraries (`monty_backend_spi`, `bridge_internals`) from public docs
- Add `tool/dartdoc.sh` for local doc generation

## Before / After

**Before:** Flat list of types on pub.dev with no grouping, no cross-links, no category sidebar.

**After:** Types are grouped into categorized topic pages:

| Package | Categories |
|---------|-----------|
| `dart_monty` | Core, Execution, Errors, Configuration, Sessions |
| `dart_monty_platform_interface` | Core, Execution, Errors, Configuration, Sessions |
| `dart_monty_bridge` | Bridge, Host Functions, Plugins, Events |

Each category gets a sidebar entry and a topic page with a short description.

## Test plan

- [x] `dart doc .` succeeds with 0 warnings / 0 errors for `dart_monty`
- [x] `dart doc .` succeeds for `dart_monty_platform_interface`
- [x] `dart doc .` succeeds for `dart_monty_bridge`
- [x] `python3 tool/analyze_packages.py` — all packages pass
- [x] Generated HTML contains category sidebar links and topic pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)