### PR TITLE
chore(native): Rust quality tightening — full pedantic group, cargo-deny, zero warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,11 @@ jobs:
       - name: cargo clippy
         working-directory: native
         run: cargo clippy -- -D warnings
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@cargo-deny
+      - name: cargo deny check
+        working-directory: native
+        run: cargo deny check
       - name: Install cargo-tarpaulin
         uses: taiki-e/install-action@cargo-tarpaulin
       - name: Run tests with coverage

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -14,6 +14,34 @@ num-bigint = "0.4"
 num-traits = "0.2"
 serde_json = "1"
 
+[lints.rust]
+unsafe_op_in_unsafe_fn = "warn"
+missing_debug_implementations = "warn"
+
+[lints.clippy]
+# Correctness & safety (high value for FFI)
+undocumented_unsafe_blocks = "warn"
+multiple_unsafe_ops_per_block = "warn"
+ptr_as_ptr = "warn"
+cast_possible_truncation = "warn"
+cast_sign_loss = "warn"
+cast_possible_wrap = "warn"
+checked_conversions = "warn"
+
+# Pedantic subset (code quality)
+cloned_instead_of_copied = "warn"
+explicit_iter_loop = "warn"
+implicit_clone = "warn"
+inefficient_to_string = "warn"
+map_unwrap_or = "warn"
+needless_pass_by_value = "warn"
+redundant_closure_for_method_calls = "warn"
+semicolon_if_nothing_returned = "warn"
+unused_self = "warn"
+
+# Nursery (experimental but useful)
+or_fun_call = "warn"
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -20,27 +20,27 @@ unsafe_op_in_unsafe_fn = "warn"
 missing_debug_implementations = "warn"
 
 [lints.clippy]
-# Correctness & safety (high value for FFI)
+# Enable all pedantic lints, then allow specific exceptions
+pedantic = { level = "warn", priority = -1 }
+
+# Allowances (aligned with upstream pydantic/monty)
+cast_precision_loss = "allow"
+doc_markdown = "allow"
+match_same_arms = "allow"
+missing_errors_doc = "allow"
+similar_names = "allow"
+too_many_lines = "allow"
+# Our additions: FFI crate needs these allowed
+missing_panics_doc = "allow"
+module_name_repetitions = "allow"
+
+# Extra lints beyond pedantic (from upstream monty + FFI safety)
+dbg_macro = "warn"
+use_self = "warn"
+allow_attributes = "warn"
 undocumented_unsafe_blocks = "warn"
+redundant_clone = "warn"
 multiple_unsafe_ops_per_block = "warn"
-ptr_as_ptr = "warn"
-cast_possible_truncation = "warn"
-cast_sign_loss = "warn"
-cast_possible_wrap = "warn"
-checked_conversions = "warn"
-
-# Pedantic subset (code quality)
-cloned_instead_of_copied = "warn"
-explicit_iter_loop = "warn"
-implicit_clone = "warn"
-inefficient_to_string = "warn"
-map_unwrap_or = "warn"
-needless_pass_by_value = "warn"
-redundant_closure_for_method_calls = "warn"
-semicolon_if_nothing_returned = "warn"
-unused_self = "warn"
-
-# Nursery (experimental but useful)
 or_fun_call = "warn"
 
 [profile.release]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dart_monty_native"
 version = "0.1.0"
 edition = "2024"
+license = "MIT"
 publish = false
 
 [lib]

--- a/native/clippy.toml
+++ b/native/clippy.toml
@@ -1,0 +1,4 @@
+cognitive-complexity-threshold = 25
+too-many-arguments-threshold = 7
+too-many-lines-threshold = 100
+type-complexity-threshold = 250

--- a/native/deny.toml
+++ b/native/deny.toml
@@ -1,0 +1,32 @@
+[advisories]
+version = 2
+# atomic-polyfill is unmaintained but comes from monty's transitive deps.
+# We can't fix this until upstream monty updates their deps.
+ignore = ["RUSTSEC-2023-0089"]
+
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+confidence-threshold = 0.8
+# Our own crate doesn't have a license field in Cargo.toml (publish = false)
+exceptions = [
+    { allow = ["MIT"], crate = "dart_monty_native" },
+]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"  # git deps don't specify version
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "allow"  # monty dependency is a git fork

--- a/native/rustfmt.toml
+++ b/native/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2024"
+max_width = 100
+use_field_init_shorthand = true

--- a/native/src/convert.rs
+++ b/native/src/convert.rs
@@ -131,44 +131,60 @@ pub fn json_to_monty_object(val: &Value) -> MontyObject {
             if let Some(type_str) = map.get("__type").and_then(|v| v.as_str()) {
                 match type_str {
                     "date" => MontyObject::Date(monty::MontyDate {
-                        year: map["year"].as_i64().unwrap_or(0) as i32,
-                        month: map["month"].as_u64().unwrap_or(0) as u8,
-                        day: map["day"].as_u64().unwrap_or(0) as u8,
+                        year: map["year"].as_i64().unwrap_or(0).try_into().unwrap_or(0),
+                        month: map["month"].as_u64().unwrap_or(0).try_into().unwrap_or(0),
+                        day: map["day"].as_u64().unwrap_or(0).try_into().unwrap_or(0),
                     }),
                     "datetime" => MontyObject::DateTime(monty::MontyDateTime {
-                        year: map["year"].as_i64().unwrap_or(0) as i32,
-                        month: map["month"].as_u64().unwrap_or(0) as u8,
-                        day: map["day"].as_u64().unwrap_or(0) as u8,
-                        hour: map["hour"].as_u64().unwrap_or(0) as u8,
-                        minute: map["minute"].as_u64().unwrap_or(0) as u8,
-                        second: map["second"].as_u64().unwrap_or(0) as u8,
-                        microsecond: map["microsecond"].as_u64().unwrap_or(0) as u32,
+                        year: map["year"].as_i64().unwrap_or(0).try_into().unwrap_or(0),
+                        month: map["month"].as_u64().unwrap_or(0).try_into().unwrap_or(0),
+                        day: map["day"].as_u64().unwrap_or(0).try_into().unwrap_or(0),
+                        hour: map["hour"].as_u64().unwrap_or(0).try_into().unwrap_or(0),
+                        minute: map["minute"].as_u64().unwrap_or(0).try_into().unwrap_or(0),
+                        second: map["second"].as_u64().unwrap_or(0).try_into().unwrap_or(0),
+                        microsecond: map["microsecond"]
+                            .as_u64()
+                            .unwrap_or(0)
+                            .try_into()
+                            .unwrap_or(0),
                         offset_seconds: map
                             .get("offset_seconds")
-                            .and_then(|v| v.as_i64())
-                            .map(|v| v as i32),
+                            .and_then(serde_json::Value::as_i64)
+                            .map(|v| v.try_into().unwrap_or(0)),
                         timezone_name: map
                             .get("timezone_name")
                             .and_then(|v| v.as_str())
-                            .map(|s| s.to_string()),
+                            .map(std::string::ToString::to_string),
                     }),
                     "timedelta" => MontyObject::TimeDelta(monty::MontyTimeDelta {
-                        days: map["days"].as_i64().unwrap_or(0) as i32,
-                        seconds: map["seconds"].as_i64().unwrap_or(0) as i32,
-                        microseconds: map["microseconds"].as_i64().unwrap_or(0) as i32,
+                        days: map["days"].as_i64().unwrap_or(0).try_into().unwrap_or(0),
+                        seconds: map["seconds"].as_i64().unwrap_or(0).try_into().unwrap_or(0),
+                        microseconds: map["microseconds"]
+                            .as_i64()
+                            .unwrap_or(0)
+                            .try_into()
+                            .unwrap_or(0),
                     }),
                     "timezone" => MontyObject::TimeZone(monty::MontyTimeZone {
-                        offset_seconds: map["offset_seconds"].as_i64().unwrap_or(0) as i32,
+                        offset_seconds: map["offset_seconds"]
+                            .as_i64()
+                            .unwrap_or(0)
+                            .try_into()
+                            .unwrap_or(0),
                         name: map
                             .get("name")
                             .and_then(|v| v.as_str())
-                            .map(|s| s.to_string()),
+                            .map(std::string::ToString::to_string),
                     }),
                     "path" => MontyObject::Path(map["value"].as_str().unwrap_or("").to_string()),
                     "bytes" => MontyObject::Bytes(
                         map["value"]
                             .as_array()
-                            .map(|arr| arr.iter().map(|v| v.as_u64().unwrap_or(0) as u8).collect())
+                            .map(|arr| {
+                                arr.iter()
+                                    .map(|v| v.as_u64().unwrap_or(0).try_into().unwrap_or(0))
+                                    .collect()
+                            })
                             .unwrap_or_default(),
                     ),
                     "tuple" => MontyObject::Tuple(
@@ -216,12 +232,15 @@ pub fn json_to_monty_object(val: &Value) -> MontyObject {
                             })
                             .unwrap_or_default(),
                         attrs: match json_to_monty_object(
-                            &map.get("attrs").cloned().unwrap_or(json!({})),
+                            &map.get("attrs").cloned().unwrap_or_else(|| json!({})),
                         ) {
                             MontyObject::Dict(pairs) => pairs,
                             _ => vec![].into(),
                         },
-                        frozen: map.get("frozen").and_then(|v| v.as_bool()).unwrap_or(false),
+                        frozen: map
+                            .get("frozen")
+                            .and_then(serde_json::Value::as_bool)
+                            .unwrap_or(false),
                     },
                     _ => {
                         // Unknown __type — fall through to dict
@@ -254,9 +273,7 @@ fn bigint_to_json(n: &BigInt) -> Value {
 
 fn float_to_json(f: f64) -> Value {
     if f.is_finite() {
-        Number::from_f64(f)
-            .map(Value::Number)
-            .unwrap_or(Value::Null)
+        Number::from_f64(f).map_or(Value::Null, Value::Number)
     } else if f.is_nan() {
         Value::String("NaN".into())
     } else if f.is_sign_positive() {

--- a/native/src/error.rs
+++ b/native/src/error.rs
@@ -37,14 +37,17 @@ pub unsafe fn parse_c_str<'a>(
 ) -> Result<&'a str, ()> {
     if ptr.is_null() {
         if !out_error.is_null() {
+            // SAFETY: out_error is non-null, caller provides a valid writable out-parameter
             unsafe { *out_error = to_c_string(&format!("{name} is NULL")) };
         }
         return Err(());
     }
+    // SAFETY: ptr is non-null (checked above) and caller guarantees it is a valid NUL-terminated C string
     match unsafe { CStr::from_ptr(ptr) }.to_str() {
         Ok(s) => Ok(s),
         Err(_) => {
             if !out_error.is_null() {
+                // SAFETY: out_error is non-null, caller provides a valid writable out-parameter
                 unsafe { *out_error = to_c_string(&format!("{name} is not valid UTF-8")) };
             }
             Err(())
@@ -121,8 +124,10 @@ mod tests {
     fn test_to_c_string_basic() {
         let ptr = to_c_string("hello");
         assert!(!ptr.is_null());
+        // SAFETY: ptr was just returned by to_c_string and is a valid NUL-terminated C string
         let cs = unsafe { CStr::from_ptr(ptr) };
         assert_eq!(cs.to_str().unwrap(), "hello");
+        // SAFETY: ptr was allocated by CString::into_raw inside to_c_string, reclaiming ownership
         unsafe { drop(CString::from_raw(ptr)) };
     }
 
@@ -130,8 +135,10 @@ mod tests {
     fn test_to_c_string_empty() {
         let ptr = to_c_string("");
         assert!(!ptr.is_null());
+        // SAFETY: ptr was just returned by to_c_string and is a valid NUL-terminated C string
         let cs = unsafe { CStr::from_ptr(ptr) };
         assert_eq!(cs.to_str().unwrap(), "");
+        // SAFETY: ptr was allocated by CString::into_raw inside to_c_string, reclaiming ownership
         unsafe { drop(CString::from_raw(ptr)) };
     }
 
@@ -140,8 +147,10 @@ mod tests {
         // CString::new fails on interior nul — should return empty string
         let ptr = to_c_string("hello\0world");
         assert!(!ptr.is_null());
+        // SAFETY: ptr was just returned by to_c_string and is a valid NUL-terminated C string
         let cs = unsafe { CStr::from_ptr(ptr) };
         assert_eq!(cs.to_str().unwrap(), "");
+        // SAFETY: ptr was allocated by CString::into_raw inside to_c_string, reclaiming ownership
         unsafe { drop(CString::from_raw(ptr)) };
     }
 
@@ -232,6 +241,7 @@ mod tests {
     fn test_parse_c_str_valid() {
         let c = CString::new("hello").unwrap();
         let mut err: *mut c_char = ptr::null_mut();
+        // SAFETY: c.as_ptr() is a valid NUL-terminated C string, err is a valid writable pointer
         let result = unsafe { parse_c_str(c.as_ptr(), "arg", &mut err) };
         assert_eq!(result, Ok("hello"));
         assert!(err.is_null());
@@ -240,11 +250,14 @@ mod tests {
     #[test]
     fn test_parse_c_str_null() {
         let mut err: *mut c_char = ptr::null_mut();
+        // SAFETY: passing null ptr intentionally to test error path, err is a valid writable pointer
         let result = unsafe { parse_c_str(ptr::null(), "arg", &mut err) };
         assert!(result.is_err());
         assert!(!err.is_null());
+        // SAFETY: err was set by parse_c_str to a valid NUL-terminated C string
         let msg = unsafe { CStr::from_ptr(err) }.to_str().unwrap();
         assert_eq!(msg, "arg is NULL");
+        // SAFETY: err was allocated by CString::into_raw inside to_c_string, reclaiming ownership
         unsafe { drop(CString::from_raw(err)) };
     }
 }

--- a/native/src/error.rs
+++ b/native/src/error.rs
@@ -43,15 +43,14 @@ pub unsafe fn parse_c_str<'a>(
         return Err(());
     }
     // SAFETY: ptr is non-null (checked above) and caller guarantees it is a valid NUL-terminated C string
-    match unsafe { CStr::from_ptr(ptr) }.to_str() {
-        Ok(s) => Ok(s),
-        Err(_) => {
-            if !out_error.is_null() {
-                // SAFETY: out_error is non-null, caller provides a valid writable out-parameter
-                unsafe { *out_error = to_c_string(&format!("{name} is not valid UTF-8")) };
-            }
-            Err(())
+    if let Ok(s) = unsafe { CStr::from_ptr(ptr) }.to_str() {
+        Ok(s)
+    } else {
+        if !out_error.is_null() {
+            // SAFETY: out_error is non-null, caller provides a valid writable out-parameter
+            unsafe { *out_error = to_c_string(&format!("{name} is not valid UTF-8")) };
         }
+        Err(())
     }
 }
 

--- a/native/src/handle.rs
+++ b/native/src/handle.rs
@@ -98,6 +98,12 @@ pub struct MontyHandle {
     print_output: String,
 }
 
+impl std::fmt::Debug for MontyHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MontyHandle").finish_non_exhaustive()
+    }
+}
+
 impl MontyHandle {
     /// Create a new handle from Python source code.
     ///
@@ -146,7 +152,7 @@ impl MontyHandle {
             Ok(obj) => {
                 let val = monty_object_to_json(&obj);
                 let result_json =
-                    build_result_json(val, None, &self.usage_json, &self.print_output);
+                    build_result_json(&val, None, &self.usage_json, &self.print_output);
                 self.state = HandleState::Complete {
                     result_json: result_json.clone(),
                     is_error: false,
@@ -156,7 +162,7 @@ impl MontyHandle {
             Err(exc) => {
                 let err_json = monty_exception_to_json(&exc);
                 let result_json = build_result_json(
-                    Value::Null,
+                    &Value::Null,
                     Some(err_json),
                     &self.usage_json,
                     &self.print_output,
@@ -467,7 +473,7 @@ impl MontyHandle {
         self.print_output.push_str(&buf);
         match result {
             Ok(progress) => self.process_progress(progress),
-            Err(exc) => self.handle_exception(exc),
+            Err(exc) => self.handle_exception(&exc),
         }
     }
 
@@ -503,7 +509,7 @@ impl MontyHandle {
                 RunProgress::Complete(obj) => {
                     let val = monty_object_to_json(&obj);
                     let result_json =
-                        build_result_json(val, None, &self.usage_json, &self.print_output);
+                        build_result_json(&val, None, &self.usage_json, &self.print_output);
                     self.state = HandleState::Complete {
                         result_json,
                         is_error: false,
@@ -547,7 +553,7 @@ impl MontyHandle {
                     self.print_output.push_str(&buf);
                     match result {
                         Ok(next) => progress = next,
-                        Err(exc) => return self.handle_exception(exc),
+                        Err(exc) => return self.handle_exception(&exc),
                     }
                 }
                 RunProgress::OsCall(call) => {
@@ -587,10 +593,10 @@ impl MontyHandle {
         }
     }
 
-    fn handle_exception(&mut self, exc: MontyException) -> (MontyProgressTag, Option<String>) {
-        let err_json = monty_exception_to_json(&exc);
+    fn handle_exception(&mut self, exc: &MontyException) -> (MontyProgressTag, Option<String>) {
+        let err_json = monty_exception_to_json(exc);
         let result_json = build_result_json(
-            Value::Null,
+            &Value::Null,
             Some(err_json),
             &self.usage_json,
             &self.print_output,
@@ -647,16 +653,18 @@ fn default_usage_json() -> String {
 }
 
 fn build_result_json(
-    value: Value,
+    value: &Value,
     error: Option<Value>,
     usage_json: &str,
     print_output: &str,
 ) -> String {
-    let usage: Value = serde_json::from_str(usage_json).unwrap_or(serde_json::json!({
-        "memory_bytes_used": 0,
-        "time_elapsed_ms": 0,
-        "stack_depth_used": 0,
-    }));
+    let usage: Value = serde_json::from_str(usage_json).unwrap_or_else(|_| {
+        serde_json::json!({
+            "memory_bytes_used": 0,
+            "time_elapsed_ms": 0,
+            "stack_depth_used": 0,
+        })
+    });
     let mut result = serde_json::json!({
         "value": value,
         "usage": usage,
@@ -944,7 +952,7 @@ result
 
     #[test]
     fn test_build_result_json_ok() {
-        let result = build_result_json(json!(42), None, &default_usage_json(), "");
+        let result = build_result_json(&json!(42), None, &default_usage_json(), "");
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["value"], 42);
         assert!(parsed.get("error").is_none());
@@ -955,7 +963,7 @@ result
     #[test]
     fn test_build_result_json_error() {
         let err = json!({"message": "boom"});
-        let result = build_result_json(Value::Null, Some(err), &default_usage_json(), "");
+        let result = build_result_json(&Value::Null, Some(err), &default_usage_json(), "");
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert!(parsed["value"].is_null());
         assert_eq!(parsed["error"]["message"], "boom");
@@ -963,7 +971,7 @@ result
 
     #[test]
     fn test_build_result_json_with_print_output() {
-        let result = build_result_json(json!(42), None, &default_usage_json(), "hello world\n");
+        let result = build_result_json(&json!(42), None, &default_usage_json(), "hello world\n");
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert_eq!(parsed["value"], 42);
         assert_eq!(parsed["print_output"], "hello world\n");
@@ -971,7 +979,7 @@ result
 
     #[test]
     fn test_build_result_json_empty_print_output_omitted() {
-        let result = build_result_json(json!(42), None, &default_usage_json(), "");
+        let result = build_result_json(&json!(42), None, &default_usage_json(), "");
         let parsed: Value = serde_json::from_str(&result).unwrap();
         assert!(parsed.get("print_output").is_none());
     }

--- a/native/src/handle.rs
+++ b/native/src/handle.rs
@@ -129,16 +129,13 @@ impl MontyHandle {
     /// Run code to completion. Returns `(result_tag, result_json, error_msg)`.
     pub fn run(&mut self) -> (MontyResultTag, String, Option<String>) {
         let state = std::mem::replace(&mut self.state, HandleState::Consumed);
-        let compiled = match state {
-            HandleState::Ready(c) => c,
-            _ => {
-                self.state = state;
-                return (
-                    MontyResultTag::Error,
-                    String::new(),
-                    Some("handle not in Ready state".into()),
-                );
-            }
+        let HandleState::Ready(compiled) = state else {
+            self.state = state;
+            return (
+                MontyResultTag::Error,
+                String::new(),
+                Some("handle not in Ready state".into()),
+            );
         };
 
         let mut buf = String::new();
@@ -180,15 +177,12 @@ impl MontyHandle {
     /// Start iterative execution. Returns progress tag and sets internal state.
     pub fn start(&mut self) -> (MontyProgressTag, Option<String>) {
         let state = std::mem::replace(&mut self.state, HandleState::Consumed);
-        let compiled = match state {
-            HandleState::Ready(c) => c,
-            _ => {
-                self.state = state;
-                return (
-                    MontyProgressTag::Error,
-                    Some("handle not in Ready state".into()),
-                );
-            }
+        let HandleState::Ready(compiled) = state else {
+            self.state = state;
+            return (
+                MontyProgressTag::Error,
+                Some("handle not in Ready state".into()),
+            );
         };
 
         let limits = self.limits.clone().unwrap_or_else(default_limits);

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -227,9 +227,8 @@ pub unsafe extern "C" fn monty_resume(
     out_error: *mut *mut c_char,
 ) -> MontyProgressTag {
     // SAFETY: value_json is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
-    let json_str = match unsafe { parse_c_str(value_json, "value_json", out_error) } {
-        Ok(s) => s,
-        Err(()) => return MontyProgressTag::Error,
+    let Ok(json_str) = (unsafe { parse_c_str(value_json, "value_json", out_error) }) else {
+        return MontyProgressTag::Error;
     };
     ffi_progress!(handle, out_error, |h| h.resume(json_str))
 }
@@ -245,9 +244,8 @@ pub unsafe extern "C" fn monty_resume_with_error(
     out_error: *mut *mut c_char,
 ) -> MontyProgressTag {
     // SAFETY: error_message is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
-    let msg = match unsafe { parse_c_str(error_message, "error_message", out_error) } {
-        Ok(s) => s,
-        Err(()) => return MontyProgressTag::Error,
+    let Ok(msg) = (unsafe { parse_c_str(error_message, "error_message", out_error) }) else {
+        return MontyProgressTag::Error;
     };
     ffi_progress!(handle, out_error, |h| h.resume_with_error(msg))
 }
@@ -299,14 +297,12 @@ pub unsafe extern "C" fn monty_resume_futures(
     out_error: *mut *mut c_char,
 ) -> MontyProgressTag {
     // SAFETY: results_json is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
-    let results_str = match unsafe { parse_c_str(results_json, "results_json", out_error) } {
-        Ok(s) => s,
-        Err(()) => return MontyProgressTag::Error,
+    let Ok(results_str) = (unsafe { parse_c_str(results_json, "results_json", out_error) }) else {
+        return MontyProgressTag::Error;
     };
     // SAFETY: errors_json is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
-    let errors_str = match unsafe { parse_c_str(errors_json, "errors_json", out_error) } {
-        Ok(s) => s,
-        Err(()) => return MontyProgressTag::Error,
+    let Ok(errors_str) = (unsafe { parse_c_str(errors_json, "errors_json", out_error) }) else {
+        return MontyProgressTag::Error;
     };
     ffi_progress!(handle, out_error, |h| h
         .resume_futures(results_str, errors_str))
@@ -627,9 +623,8 @@ pub extern "C" fn monty_alloc(size: usize) -> *mut u8 {
     if size == 0 {
         return ptr::null_mut();
     }
-    let layout = match std::alloc::Layout::from_size_align(size, 1) {
-        Ok(l) => l,
-        Err(_) => return ptr::null_mut(),
+    let Ok(layout) = std::alloc::Layout::from_size_align(size, 1) else {
+        return ptr::null_mut();
     };
     // SAFETY: layout has valid non-zero size and alignment of 1, which is always valid
     let ptr = unsafe { std::alloc::alloc(layout) };
@@ -647,9 +642,8 @@ pub unsafe extern "C" fn monty_dealloc(ptr: *mut u8, size: usize) {
     if ptr.is_null() || size == 0 {
         return;
     }
-    let layout = match std::alloc::Layout::from_size_align(size, 1) {
-        Ok(l) => l,
-        Err(_) => return,
+    let Ok(layout) = std::alloc::Layout::from_size_align(size, 1) else {
+        return;
     };
     // SAFETY: ptr was allocated by monty_alloc with the same layout (size, align=1)
     unsafe { std::alloc::dealloc(ptr, layout) };

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -17,16 +17,20 @@ macro_rules! ffi_progress {
     ($handle:expr, $out_error:expr, |$h:ident| $body:expr) => {{
         if $handle.is_null() {
             if !$out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), Dart caller provides a valid writable pointer
                 unsafe { *$out_error = to_c_string("handle is NULL") };
             }
             return MontyProgressTag::Error;
         }
+        // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
         let $h = unsafe { &mut *$handle };
         match catch_ffi_panic(|| $body) {
             Ok((tag, err)) => {
                 if !$out_error.is_null() {
                     match err {
+                        // SAFETY: out_error is non-null (just checked), writing error message string
                         Some(ref msg) => unsafe { *$out_error = to_c_string(msg) },
+                        // SAFETY: out_error is non-null (just checked), clearing error to indicate success
                         None => unsafe { *$out_error = ptr::null_mut() },
                     }
                 }
@@ -34,6 +38,7 @@ macro_rules! ffi_progress {
             }
             Err(panic_msg) => {
                 if !$out_error.is_null() {
+                    // SAFETY: out_error is non-null (just checked), writing panic message string
                     unsafe { *$out_error = to_c_string(&panic_msg) };
                 }
                 MontyProgressTag::Error
@@ -61,6 +66,7 @@ pub unsafe extern "C" fn monty_create(
     script_name: *const c_char,
     out_error: *mut *mut c_char,
 ) -> *mut MontyHandle {
+    // SAFETY: code is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
     let code_str = match unsafe { parse_c_str(code, "code", out_error) } {
         Ok(s) => s.to_string(),
         Err(()) => return ptr::null_mut(),
@@ -69,6 +75,7 @@ pub unsafe extern "C" fn monty_create(
     let ext_fn_list = if ext_fns.is_null() {
         vec![]
     } else {
+        // SAFETY: ext_fns is non-null (just checked), NUL-terminated C string from Dart FFI
         match unsafe { parse_c_str(ext_fns, "ext_fns", out_error) } {
             Ok("") => vec![],
             Ok(s) => s.split(',').map(|f| f.trim().to_string()).collect(),
@@ -79,6 +86,7 @@ pub unsafe extern "C" fn monty_create(
     let name = if script_name.is_null() {
         None
     } else {
+        // SAFETY: script_name is non-null (just checked), NUL-terminated C string from Dart FFI
         match unsafe { parse_c_str(script_name, "script_name", out_error) } {
             Ok(s) => Some(s.to_string()),
             Err(()) => return ptr::null_mut(),
@@ -90,18 +98,20 @@ pub unsafe extern "C" fn monty_create(
             let ptr = Box::into_raw(Box::new(handle));
             LIVE_HANDLES
                 .write()
-                .unwrap_or_else(|e| e.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .insert(ptr as usize);
             ptr
         }
         Ok(Err(exc)) => {
             if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing compilation error message
                 unsafe { *out_error = to_c_string(&exc.summary()) };
             }
             ptr::null_mut()
         }
         Err(panic_msg) => {
             if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing panic error message
                 unsafe { *out_error = to_c_string(&panic_msg) };
             }
             ptr::null_mut()
@@ -126,11 +136,12 @@ pub unsafe extern "C" fn monty_free(handle: *mut MontyHandle) {
     let addr = handle as usize;
     let removed = LIVE_HANDLES
         .write()
-        .unwrap_or_else(|e| e.into_inner())
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .remove(&addr);
     if !removed {
         return; // already freed or unknown pointer
     }
+    // SAFETY: handle was created by Box::into_raw in monty_create/monty_restore, LIVE_HANDLES confirms it is still live
     drop(unsafe { Box::from_raw(handle) });
 }
 
@@ -153,21 +164,26 @@ pub unsafe extern "C" fn monty_run(
 ) -> MontyResultTag {
     if handle.is_null() {
         if !error_msg.is_null() {
+            // SAFETY: error_msg is non-null (just checked), Dart caller provides a valid writable pointer
             unsafe { *error_msg = to_c_string("handle is NULL") };
         }
         return MontyResultTag::Error;
     }
 
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &mut *handle };
 
     match catch_ffi_panic(|| h.run()) {
         Ok((tag, json, err)) => {
             if !result_json.is_null() {
+                // SAFETY: result_json is non-null (just checked), writing result JSON string
                 unsafe { *result_json = to_c_string(&json) };
             }
             if !error_msg.is_null() {
                 match err {
+                    // SAFETY: error_msg is non-null (just checked), writing error message
                     Some(ref msg) => unsafe { *error_msg = to_c_string(msg) },
+                    // SAFETY: error_msg is non-null (just checked), clearing error to indicate success
                     None => unsafe { *error_msg = ptr::null_mut() },
                 }
             }
@@ -175,6 +191,7 @@ pub unsafe extern "C" fn monty_run(
         }
         Err(panic_msg) => {
             if !error_msg.is_null() {
+                // SAFETY: error_msg is non-null (just checked), writing panic error message
                 unsafe { *error_msg = to_c_string(&panic_msg) };
             }
             MontyResultTag::Error
@@ -209,6 +226,7 @@ pub unsafe extern "C" fn monty_resume(
     value_json: *const c_char,
     out_error: *mut *mut c_char,
 ) -> MontyProgressTag {
+    // SAFETY: value_json is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
     let json_str = match unsafe { parse_c_str(value_json, "value_json", out_error) } {
         Ok(s) => s,
         Err(()) => return MontyProgressTag::Error,
@@ -226,6 +244,7 @@ pub unsafe extern "C" fn monty_resume_with_error(
     error_message: *const c_char,
     out_error: *mut *mut c_char,
 ) -> MontyProgressTag {
+    // SAFETY: error_message is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
     let msg = match unsafe { parse_c_str(error_message, "error_message", out_error) } {
         Ok(s) => s,
         Err(()) => return MontyProgressTag::Error,
@@ -259,6 +278,7 @@ pub unsafe extern "C" fn monty_pending_future_call_ids(handle: *const MontyHandl
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.pending_future_call_ids() {
         Some(json) => to_c_string(json),
@@ -278,10 +298,12 @@ pub unsafe extern "C" fn monty_resume_futures(
     errors_json: *const c_char,
     out_error: *mut *mut c_char,
 ) -> MontyProgressTag {
+    // SAFETY: results_json is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
     let results_str = match unsafe { parse_c_str(results_json, "results_json", out_error) } {
         Ok(s) => s,
         Err(()) => return MontyProgressTag::Error,
     };
+    // SAFETY: errors_json is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
     let errors_str = match unsafe { parse_c_str(errors_json, "errors_json", out_error) } {
         Ok(s) => s,
         Err(()) => return MontyProgressTag::Error,
@@ -301,6 +323,7 @@ pub unsafe extern "C" fn monty_pending_fn_name(handle: *const MontyHandle) -> *m
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.pending_fn_name() {
         Some(name) => to_c_string(name),
@@ -315,6 +338,7 @@ pub unsafe extern "C" fn monty_pending_fn_args_json(handle: *const MontyHandle) 
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.pending_fn_args_json() {
         Some(json) => to_c_string(json),
@@ -330,6 +354,7 @@ pub unsafe extern "C" fn monty_pending_fn_kwargs_json(handle: *const MontyHandle
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.pending_fn_kwargs_json() {
         Some(json) => to_c_string(json),
@@ -344,6 +369,7 @@ pub unsafe extern "C" fn monty_pending_call_id(handle: *const MontyHandle) -> u3
     if handle.is_null() {
         return u32::MAX;
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     h.pending_call_id().unwrap_or(u32::MAX)
 }
@@ -355,6 +381,7 @@ pub unsafe extern "C" fn monty_pending_method_call(handle: *const MontyHandle) -
     if handle.is_null() {
         return -1;
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.pending_method_call() {
         Some(true) => 1,
@@ -375,6 +402,7 @@ pub unsafe extern "C" fn monty_os_call_fn_name(handle: *const MontyHandle) -> *m
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.os_call_fn_name() {
         Some(name) => to_c_string(name),
@@ -389,6 +417,7 @@ pub unsafe extern "C" fn monty_os_call_args_json(handle: *const MontyHandle) -> 
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.os_call_args_json() {
         Some(json) => to_c_string(json),
@@ -403,6 +432,7 @@ pub unsafe extern "C" fn monty_os_call_kwargs_json(handle: *const MontyHandle) -
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.os_call_kwargs_json() {
         Some(json) => to_c_string(json),
@@ -416,6 +446,7 @@ pub unsafe extern "C" fn monty_os_call_id(handle: *const MontyHandle) -> u32 {
     if handle.is_null() {
         return u32::MAX;
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     h.os_call_id().unwrap_or(u32::MAX)
 }
@@ -427,6 +458,7 @@ pub unsafe extern "C" fn monty_complete_result_json(handle: *const MontyHandle) 
     if handle.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.complete_result_json() {
         Some(json) => to_c_string(json),
@@ -441,6 +473,7 @@ pub unsafe extern "C" fn monty_complete_is_error(handle: *const MontyHandle) -> 
     if handle.is_null() {
         return -1;
     }
+    // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match h.complete_is_error() {
         Some(true) => 1,
@@ -466,12 +499,14 @@ pub unsafe extern "C" fn monty_snapshot(
     if handle.is_null() || out_len.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: handle is non-null (checked above) and was created by monty_create via Box::into_raw
     let h = unsafe { &*handle };
     match catch_ffi_panic(|| h.snapshot()) {
         Ok(Ok(bytes)) => {
             let len = bytes.len();
             let boxed = bytes.into_boxed_slice();
-            let ptr = Box::into_raw(boxed) as *mut u8;
+            let ptr = Box::into_raw(boxed).cast::<u8>();
+            // SAFETY: out_len is non-null (checked above), writing the byte count of the snapshot
             unsafe { *out_len = len };
             ptr
         }
@@ -494,29 +529,33 @@ pub unsafe extern "C" fn monty_restore(
 ) -> *mut MontyHandle {
     if data.is_null() {
         if !out_error.is_null() {
+            // SAFETY: out_error is non-null (just checked), writing error message
             unsafe { *out_error = to_c_string("data is NULL") };
         }
         return ptr::null_mut();
     }
 
+    // SAFETY: data is non-null (just checked), len is provided by caller matching the snapshot buffer size
     let bytes = unsafe { std::slice::from_raw_parts(data, len) };
     match catch_ffi_panic(|| MontyHandle::restore(bytes)) {
         Ok(Ok(handle)) => {
             let ptr = Box::into_raw(Box::new(handle));
             LIVE_HANDLES
                 .write()
-                .unwrap_or_else(|e| e.into_inner())
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .insert(ptr as usize);
             ptr
         }
         Ok(Err(msg)) => {
             if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing restore error message
                 unsafe { *out_error = to_c_string(&msg) };
             }
             ptr::null_mut()
         }
         Err(panic_msg) => {
             if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing panic error message
                 unsafe { *out_error = to_c_string(&panic_msg) };
             }
             ptr::null_mut()
@@ -532,6 +571,7 @@ pub unsafe extern "C" fn monty_restore(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn monty_set_memory_limit(handle: *mut MontyHandle, bytes: usize) {
     if !handle.is_null() {
+        // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
         unsafe { &mut *handle }.set_memory_limit(bytes);
     }
 }
@@ -540,6 +580,7 @@ pub unsafe extern "C" fn monty_set_memory_limit(handle: *mut MontyHandle, bytes:
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn monty_set_time_limit_ms(handle: *mut MontyHandle, ms: u64) {
     if !handle.is_null() {
+        // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
         unsafe { &mut *handle }.set_time_limit_ms(ms);
     }
 }
@@ -548,6 +589,7 @@ pub unsafe extern "C" fn monty_set_time_limit_ms(handle: *mut MontyHandle, ms: u
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn monty_set_stack_limit(handle: *mut MontyHandle, depth: usize) {
     if !handle.is_null() {
+        // SAFETY: handle is non-null (just checked) and was created by monty_create via Box::into_raw
         unsafe { &mut *handle }.set_stack_limit(depth);
     }
 }
@@ -560,6 +602,7 @@ pub unsafe extern "C" fn monty_set_stack_limit(handle: *mut MontyHandle, depth: 
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn monty_string_free(ptr: *mut c_char) {
     if !ptr.is_null() {
+        // SAFETY: ptr was allocated by CString::into_raw in to_c_string, reclaiming ownership for deallocation
         drop(unsafe { std::ffi::CString::from_raw(ptr) });
     }
 }
@@ -568,6 +611,7 @@ pub unsafe extern "C" fn monty_string_free(ptr: *mut c_char) {
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn monty_bytes_free(ptr: *mut u8, len: usize) {
     if !ptr.is_null() && len > 0 {
+        // SAFETY: ptr+len were returned by monty_snapshot via Box::into_raw, reclaiming the boxed slice
         drop(unsafe { Box::from_raw(std::ptr::slice_from_raw_parts_mut(ptr, len)) });
     }
 }
@@ -587,10 +631,12 @@ pub extern "C" fn monty_alloc(size: usize) -> *mut u8 {
         Ok(l) => l,
         Err(_) => return ptr::null_mut(),
     };
+    // SAFETY: layout has valid non-zero size and alignment of 1, which is always valid
     let ptr = unsafe { std::alloc::alloc(layout) };
     if ptr.is_null() {
         return ptr::null_mut();
     }
+    // SAFETY: ptr is non-null (just checked) and points to `size` bytes of allocated memory
     unsafe { std::ptr::write_bytes(ptr, 0, size) };
     ptr
 }
@@ -605,5 +651,6 @@ pub unsafe extern "C" fn monty_dealloc(ptr: *mut u8, size: usize) {
         Ok(l) => l,
         Err(_) => return,
     };
+    // SAFETY: ptr was allocated by monty_alloc with the same layout (size, align=1)
     unsafe { std::alloc::dealloc(ptr, layout) };
 }

--- a/tool/test_rust.sh
+++ b/tool/test_rust.sh
@@ -17,6 +17,13 @@ cargo fmt --check
 echo "--- cargo clippy -- -D warnings ---"
 cargo clippy -- -D warnings
 
+echo "--- cargo deny check ---"
+if command -v cargo-deny &>/dev/null; then
+  cargo deny check
+else
+  echo "SKIP: cargo-deny not installed (cargo install cargo-deny)"
+fi
+
 echo "--- cargo test ---"
 cargo test
 


### PR DESCRIPTION
## Summary

Brings the Rust native crate up to the same quality standard as the Dart side.
Aligned with upstream pydantic/monty's clippy config.

**Before:** `cargo fmt` + `cargo clippy -D warnings` (default lints only)
**After:** Full clippy pedantic group (~90 lints) + 7 extra lints + cargo-deny supply chain scanning, all at zero warnings

### Lints Config (aligned with pydantic/monty)

```toml
pedantic = { level = "warn", priority = -1 }

# Allowances
cast_precision_loss = "allow"
doc_markdown = "allow"
match_same_arms = "allow"
missing_errors_doc = "allow"
similar_names = "allow"
too_many_lines = "allow"
missing_panics_doc = "allow"
module_name_repetitions = "allow"

# Extra (beyond pedantic)
dbg_macro, use_self, allow_attributes, undocumented_unsafe_blocks,
redundant_clone, multiple_unsafe_ops_per_block, or_fun_call
```

### Fixes Applied (111 warnings → 0)

- 70 `// SAFETY:` comments on every unsafe block in lib.rs and error.rs
- 16 cast truncation → `try_into().unwrap_or(0)`
- 8 `manual_let_else` → `let...else` syntax
- 7 redundant closures (auto-fixed)
- 3 `single_match` → `if let` (auto-fixed)
- 2 `needless_pass_by_value` → take by reference
- 2 `or_fun_call` → `unwrap_or_else`
- 1 `missing_debug_implementations` → manual Debug impl
- 1 `ptr_as_ptr` → `.cast()`
- 1 `map_unwrap_or` → `map_or`

### Supply Chain (cargo-deny)

- License allowlist: MIT, Apache-2.0, Zlib, BSD-*, Unicode-*
- Vulnerability scanning: deny
- Ignored: RUSTSEC-2023-0089 (atomic-polyfill — upstream monty dep)

### Config Files Added

- `native/clippy.toml` — complexity thresholds (CC=25, args=7, lines=100)
- `native/rustfmt.toml` — edition 2024, max_width=100
- `native/deny.toml` — supply chain config

### Gate Integration

- `tool/test_rust.sh`: `cargo deny check` added
- `ci.yaml`: `cargo-deny` step via `taiki-e/install-action`

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy` — zero warnings (full pedantic + 7 extras)
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [x] `cargo test` — 193 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)