### PR TITLE
feat: OsCall/VFS unification — composable handler subsystem

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,14 +184,9 @@ jobs:
           retention-days: 1
 
   wasm-ladder:
-    # Known issue: Worker resolves WASM binary via import.meta.url which
-    # requires the npm package directory structure at the exact serve path.
-    # CI copies the files but the Worker's relative URL resolution still
-    # fails. Needs a CI-specific server config or esbuild --serve.
     name: WASM ladder integration
     needs: [changes, build-wasm]
     if: needs.changes.outputs.code == 'true'
-    continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -207,27 +202,27 @@ jobs:
         with:
           name: wasm-binary
           path: native/target/wasm32-wasip1/release
-      - name: Build JS bridge
-        working-directory: spike/web_test
+      - name: Build JS bridge from source
+        working-directory: packages/dart_monty_wasm/js
         run: |
           npm install --force
-          npm run bundle
+          npm run build
       - name: Prepare integration test
         run: |
           INTEG_WEB="test/wasm/integration/web"
+          WASM_ASSETS="packages/dart_monty_wasm/assets"
+          WASM_JS="packages/dart_monty_wasm/js"
 
-          # Copy JS bridge assets from spike build
-          cp spike/web_test/web/monty_bundle.js "$INTEG_WEB/dart_monty_bridge.js"
-          cp spike/web_test/web/monty_worker.js "$INTEG_WEB/"
+          # Copy built JS bridge assets
+          cp "$WASM_ASSETS/dart_monty_bridge.js" "$INTEG_WEB/"
+          cp "$WASM_ASSETS/dart_monty_worker.js" "$INTEG_WEB/"
+          cp "$WASM_ASSETS/dart_monty_native.wasm" "$INTEG_WEB/"
 
-          # Copy WASM binary and WASI worker from npm package
-          # The worker resolves these via import.meta.url relative paths
-          cp spike/web_test/node_modules/@pydantic/monty-wasm32-wasi/monty.wasm32-wasi.wasm "$INTEG_WEB/"
+          # Copy WASI runtime from npm package for Worker import.meta.url resolution
+          WASI_PKG="$WASM_JS/node_modules/@pydantic/monty-wasm32-wasi"
           mkdir -p "$INTEG_WEB/@pydantic/monty-wasm32-wasi"
-          cp spike/web_test/node_modules/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs \
-            "$INTEG_WEB/@pydantic/monty-wasm32-wasi/"
-          cp spike/web_test/node_modules/@pydantic/monty-wasm32-wasi/monty.wasm32-wasi.wasm \
-            "$INTEG_WEB/@pydantic/monty-wasm32-wasi/"
+          cp "$WASI_PKG/wasi-worker-browser.mjs" "$INTEG_WEB/@pydantic/monty-wasm32-wasi/"
+          cp "$WASI_PKG/monty.wasm32-wasi.wasm" "$INTEG_WEB/@pydantic/monty-wasm32-wasi/"
 
           # Compile Dart ladder runner to JS
           dart pub get
@@ -237,6 +232,11 @@ jobs:
           # Copy fixtures
           mkdir -p "$INTEG_WEB/fixtures"
           cp test/fixtures/python_ladder/tier_*.json "$INTEG_WEB/fixtures/"
+
+          # Diagnostic: verify all required files exist
+          echo "=== Integration test files ==="
+          ls -la "$INTEG_WEB/"*.js "$INTEG_WEB/"*.wasm "$INTEG_WEB/"*.html || true
+          ls -la "$INTEG_WEB/@pydantic/monty-wasm32-wasi/" || true
       - name: Run WASM ladder in headless Chrome
         run: |
           INTEG_WEB="test/wasm/integration/web"
@@ -278,7 +278,12 @@ jobs:
 
           if [ -z "$WEB_RESULTS" ]; then
             echo "ERROR: No LADDER_RESULT lines captured from Chrome."
-            grep -i "CONSOLE" "$LADDER_LOG" | head -20 || true
+            echo "--- Chrome console output ---"
+            grep -i "CONSOLE" "$LADDER_LOG" | head -40 || true
+            echo "--- LADDER_ERROR lines ---"
+            grep "LADDER_ERROR\|LADDER_STACKTRACE" "$LADDER_LOG" || true
+            echo "--- All stderr (last 50 lines) ---"
+            tail -50 "$LADDER_LOG" || true
             rm -f "$LADDER_LOG"
             exit 1
           fi

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -67,6 +67,9 @@ jobs:
       - name: Compile visualizer.dart
         working-directory: example/web
         run: dart compile js bin/visualizer.dart -o web/visualizer.dart.js
+      - name: Compile vfs_demo.dart
+        working-directory: example/web
+        run: dart compile js bin/vfs_demo.dart -o web/vfs_demo.dart.js
 
       # ── Assemble site ────────────────────────────────────────────────
       - name: Copy WASM binary
@@ -85,7 +88,6 @@ jobs:
         run: |
           stamp="$(date -u +'%Y-%m-%d %H:%M UTC')"
           sed -i "s/__BUILD_DATE__/$stamp/g" example/web/web/index.html
-          sed -i "s/__BUILD_DATE__/$stamp/g" example/web/web/mcp-docs.html
 
       # ── Deploy ───────────────────────────────────────────────────────
       - uses: actions/configure-pages@v5

--- a/dcm_options.yaml
+++ b/dcm_options.yaml
@@ -52,8 +52,11 @@ dcm:
     - avoid-throw-in-finally-block
     - avoid-unsafe-collection-methods:
         exclude:
-          # Python schema enforces arg count
+          # Python schema enforces arg count — all handlers receive well-formed args
           - "lib/src/bridge/os_call/default_os_call_handler_native.dart"
+          - "lib/src/bridge/os_call/memory_fs_os_call_handler.dart"
+          - "lib/src/bridge/os_call/sandboxed_native_fs_handler.dart"
+          - "lib/src/bridge/os_call/env_os_call_handler.dart"
           # Mock tracking lists: only accessed after recording calls
           - "lib/src/platform/mock_monty_platform.dart"
           # Guarded by isEmpty/isNotEmpty/length checks before access
@@ -135,6 +138,8 @@ dcm:
           # FFI/WASM binding abstractions
           - "lib/**/native_bindings.dart"
           - "lib/**/wasm_bindings.dart"
+          # Factory function before class declaration
+          - "lib/src/bridge/os_call/default_os_call_handler_native.dart"
           # Part files: first type is a sealed subclass, not the file name
           - "lib/src/platform/monty_value_scalars.dart"
           - "lib/src/platform/monty_value_collections.dart"
@@ -165,6 +170,9 @@ dcm:
           - "lib/src/bridge/bridge/monty_bridge.dart"
           # Empty .then() callback for unawaited future cleanup
           - "lib/src/bridge/bridge/default_monty_bridge.dart"
+          # Intentional no-op dispose: abstract base and non-owning handler
+          - "lib/src/bridge/os_call/os_call_handler.dart"
+          - "lib/src/bridge/os_call/sandboxed_native_fs_handler.dart"
     - no-equal-then-else
     - prefer-first
     - prefer-last
@@ -211,6 +219,8 @@ dcm:
     - avoid-late-keyword:
         exclude:
           - "test/**"
+          # Lazy-initialized sorted prefixes for longest-prefix-first matching
+          - "lib/src/bridge/os_call/router_os_call_handler.dart"
     - avoid-dynamic:
         exclude:
           - "test/**"
@@ -239,6 +249,10 @@ dcm:
           - "lib/src/bridge/bridge/plugin_registry.dart"
           - "lib/src/bridge/plugins/sandbox_plugin.dart"
           - "lib/src/bridge/os_call/default_os_call_handler_native.dart"
+          - "lib/src/bridge/os_call/memory_fs_os_call_handler.dart"
+          - "lib/src/bridge/os_call/sandboxed_native_fs_handler.dart"
+          # Router prefix map lookup: non-null guaranteed by startsWith check
+          - "lib/src/bridge/os_call/router_os_call_handler.dart"
           # WASM JS interop: non-null guaranteed by JS bridge contract
           - "lib/src/wasm/wasm_bindings_js.dart"
           - "lib/src/wasm/wasm_core_bindings.dart"

--- a/docs/lifecycles.md
+++ b/docs/lifecycles.md
@@ -61,7 +61,7 @@ Last updated: 2026-04-10 (monty 0.0.10, post-OsCall + MontyValue)
 |----|----------|--------|-------------|
 | ~~B-1~~ | ~~Critical~~ | RESOLVED | Zombie tracking + diagnostic logging added. Handle leak is intentional safety choice. |
 | B-3 | Safe | OK | `_freeHandle` nulls `_handle` before calling `free()`. Prevents double-free. |
-| B-4 | Moderate | OPEN | `restoreSnapshot` does not free prior handle. Protected by state machine `assertIdle` but no defensive code. |
+| ~~B-4~~ | ~~Moderate~~ | RESOLVED | `restoreSnapshot` now frees prior handle before loading new snapshot. |
 
 ---
 
@@ -85,7 +85,7 @@ Last updated: 2026-04-10 (monty 0.0.10, post-OsCall + MontyValue)
 
 | ID | Severity | Status | Description |
 |----|----------|--------|-------------|
-| C-3 | Moderate | OPEN | No "disposed while active" recovery. Concurrent resume and dispose could race on FFI handle. |
+| ~~C-3~~ | ~~Moderate~~ | RESOLVED | `dispose()` force-idles active state before disposing. |
 
 ---
 
@@ -110,7 +110,7 @@ Last updated: 2026-04-10 (monty 0.0.10, post-OsCall + MontyValue)
 | ID | Severity | Status | Description |
 |----|----------|--------|-------------|
 | ~~D-1~~ | ~~Critical~~ | RESOLVED | `_invalidateSession()` called on panic — session properly invalidated. |
-| D-2 | Moderate | OPEN | Error classification uses string matching (`'Panic'`, `'RuntimeError'`). Fragile if Worker error format changes. |
+| ~~D-2~~ | ~~Moderate~~ | RESOLVED | `wasmPanicErrorType` constant replaces raw string matching. |
 
 ---
 
@@ -151,6 +151,80 @@ Last updated: 2026-04-10 (monty 0.0.10, post-OsCall + MontyValue)
 
 ---
 
+## F. OsCall / VFS Handlers (`lib/src/bridge/os_call/`)
+
+The OsCall subsystem intercepts Python standard-library operations
+(`pathlib`, `os`, `datetime`) and routes them through Dart handlers.
+Two filesystem strategies provide the **VFS** layer:
+
+- **MemoryFsOsCallHandler** — pure in-memory VFS (ephemeral, platform-agnostic,
+  works on WASM). Backed by `package:file`'s `MemoryFileSystem`.
+- **SandboxedNativeFsHandler** — chrooted real filesystem with path-traversal
+  and symlink-escape protection.
+
+Non-filesystem handlers cover environment variables (`EnvOsCallHandler`)
+and date/time (`TimeOsCallHandler`). A `RouterOsCallHandler` composes
+them by operation-name prefix.
+
+### Resources
+
+| Resource | Allocated by | Freed by | Owner |
+|----------|-------------|----------|-------|
+| `OsCallHandler` (abstract) | Caller (`createDefaultOsCallHandler()` or custom) | `RouterOsCallHandler.dispose()` via bridge/session dispose | `DefaultMontyBridge` or `MontySession` |
+| `RouterOsCallHandler` child map | Constructor | `dispose()` iterates + dedup-disposes children | `RouterOsCallHandler` |
+| `MemoryFileSystem` (VFS backing store) | `MemoryFsOsCallHandler` constructor | GC (no explicit dispose) | `MemoryFsOsCallHandler` |
+| `SandboxedNativeFsHandler._root` (resolved path) | Factory constructor (resolves symlinks) | N/A — handler does not own root directory | Caller |
+| `EnvOsCallHandler.environment` map | Constructor (caller-provided) | GC | `EnvOsCallHandler` |
+| `TimeOsCallHandler._clock` | Constructor | GC | `TimeOsCallHandler` |
+
+### Ownership Chain
+
+1. **`DefaultMontyBridge`** accepts handler via `registerOsCallHandler()`.
+   Disposes it in `bridge.dispose()` with `unawaited(_osCallHandler?.dispose())`.
+2. **`MontySession`** accepts optional handler in constructor.
+   Disposes it in `session.dispose()` with `unawaited(_osCallHandler?.dispose())`.
+3. These two owners are mutually exclusive by design: `MontySession` is for
+   simple `run()` mode; `DefaultMontyBridge` is for full bridge mode. A handler
+   instance should never be given to both.
+4. **`RouterOsCallHandler.dispose()`** iterates child handlers using a
+   `Set<OsCallHandler>` to deduplicate. A handler registered under multiple
+   prefixes (e.g., `TimeOsCallHandler` for both `'date.'` and `'datetime.'`)
+   is disposed exactly once. The fallback handler, if present, is also disposed.
+
+### Crash Behavior
+
+- **Handler throws `OsCallException`**: Caught by `_handleOsCall` (`on Object`),
+  logged, sent back to Python via `resumeWithError()`. No handler leak.
+  Subclasses (`OsCallPermissionError`, `OsCallFileNotFoundError`) are
+  translated to the corresponding Python exception type.
+- **Handler throws unexpected error**: Same `on Object catch (e, st)` path.
+  Error logged with stack trace, resumed as Python error string.
+- **No handler registered**: Bridge resumes with `PermissionError` message.
+  No crash.
+- **Handler `dispose()` throws**: Fire-and-forget via `unawaited()` in both
+  `DefaultMontyBridge.dispose()` and `MontySession.dispose()`. Error does not
+  propagate to caller.
+- **VFS path escape (`SandboxedNativeFsHandler`)**: Throws
+  `OsCallPermissionError`. Symlink escape after initial resolution also caught
+  by `_safeResolved()`. All caught by `_handleOsCall`.
+- **Web: `os.*` call with no handler**: Router has no `'os.'` prefix on web.
+  `UnsupportedError` thrown by router, caught by bridge, sent back to Python.
+
+### Findings
+
+| ID | Severity | Status | Description |
+|----|----------|--------|-------------|
+| F-1 | Low | BY DESIGN | Dual ownership: both `DefaultMontyBridge` and `MontySession` accept and dispose an `OsCallHandler`. They are mutually exclusive entry points — never share a handler instance across both. |
+| F-2 | Safe | OK | `RouterOsCallHandler.dispose()` deduplicates via `Set`. Handler registered under multiple prefixes is disposed once. Fallback handler is also disposed. |
+| F-3 | Safe | OK | `SandboxedNativeFsHandler` does not own its root directory. Caller must clean up. Documented in dispose comment and constructor doc. |
+| F-4 | Safe | OK | `MemoryFsOsCallHandler` (VFS) has no dispose logic. `MemoryFileSystem` is GC-collected. Files are ephemeral by design. |
+| F-5 | Safe | OK | `_handleOsCall` catches `on Object` — no unhandled exception can leak from a handler call. Error is always sent back to Python. |
+| F-6 | Low | OK | `unawaited()` on handler dispose in both bridge and session means dispose errors are fire-and-forget. If a handler's `dispose()` throws, it silently fails. |
+| F-7 | Info | OK | Web default factory omits `os.*` prefix. Any `os.getenv` call from Python hits router's `UnsupportedError` path, which the bridge catches and sends back as a Python error. Correct. |
+| F-8 | Low | OK | Path escape protection in `SandboxedNativeFsHandler` uses `startsWith` on normalized paths plus symlink re-check. Factory constructor resolves root symlinks at construction. TOCTOU: if root itself becomes a symlink after construction, the check uses the stale resolved path. Low practical risk (root is typically a temp dir). |
+
+---
+
 ## Summary
 
 ### Resolved (7)
@@ -171,12 +245,25 @@ Last updated: 2026-04-10 (monty 0.0.10, post-OsCall + MontyValue)
 |----|----------|-----------|-------|
 | E-4 | Moderate | Bridge | In-flight host functions not stoppable (known; cancel removed) |
 
-### By Design (2)
+### By Design (3)
 
 | ID | Subsystem | Rationale |
 |----|-----------|-----------|
 | E-1 | Bridge | Bridge doesn't own platform lifecycle |
 | E-3 | Bridge | Children persist for output access |
+| F-1 | OsCall/VFS | Dual ownership is by design — bridge mode and session mode are mutually exclusive |
+
+### Reviewed — No Action (7)
+
+| ID | Subsystem | Note |
+|----|-----------|------|
+| F-2 | OsCall | Router dedup dispose correct |
+| F-3 | OsCall/VFS | Sandbox handler doesn't own root (documented) |
+| F-4 | OsCall/VFS | MemoryFS (VFS) is GC-collected |
+| F-5 | OsCall | All handler errors caught by bridge |
+| F-6 | OsCall | Dispose errors are fire-and-forget (acceptable) |
+| F-7 | OsCall/VFS | Web `os.*` correctly unsupported |
+| F-8 | OsCall/VFS | Path escape TOCTOU — low practical risk |
 
 ---
 

--- a/example/web/bin/vfs_demo.dart
+++ b/example/web/bin/vfs_demo.dart
@@ -1,0 +1,290 @@
+// Standalone JS-compiled demo, not a package:test file.
+// ignore_for_file: avoid_print, unnecessary_raw_strings, lines_longer_than_80_chars
+/// Interactive VFS Demo — shows Python↔VFS round-trip in the browser.
+///
+/// Compiled to JS, exposes functions to the HTML UI via window.VfsDemo.
+///
+/// Build:
+///   dart compile js test/wasm/integration/vfs_demo.dart \
+///     -o test/wasm/integration/web/vfs_demo.dart.js
+library;
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+
+// ---------------------------------------------------------------------------
+// JS interop — WASM bridge (static method API on window.DartMontyBridge)
+// ---------------------------------------------------------------------------
+
+@JS('DartMontyBridge.init')
+external JSPromise<JSBoolean> _bridgeInit();
+
+@JS('DartMontyBridge.start')
+external JSPromise<JSString> _bridgeStart(JSString code);
+
+@JS('DartMontyBridge.resume')
+external JSPromise<JSString> _bridgeResume(JSString valueJson);
+
+@JS('DartMontyBridge.resumeWithError')
+external JSPromise<JSString> _bridgeResumeWithError(JSString errorJson);
+
+// ---------------------------------------------------------------------------
+// JS interop — expose API to HTML
+// ---------------------------------------------------------------------------
+
+@JS('window.VfsDemo')
+external set _vfsDemo(JSObject obj);
+
+@JS('window._onOsCall')
+external void _jsOnOsCall(JSString jsonPayload);
+
+@JS('window._onReady')
+external void _jsOnReady();
+
+@JS('window._onFilesChanged')
+external void _jsOnFilesChanged(JSString filesJson);
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+var _vfs = MemoryFsOsCallHandler();
+late TimeOsCallHandler _time;
+final _osCallLog = <Map<String, dynamic>>[];
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+Map<String, dynamic> _parse(String json) =>
+    jsonDecode(json) as Map<String, dynamic>;
+
+bool _isOsCall(String? fn) {
+  if (fn == null) return false;
+  return fn.startsWith('Path.') ||
+      fn.startsWith('date.') ||
+      fn.startsWith('datetime.');
+}
+
+Future<Object?> _handleOsCall(Map<String, dynamic> state) async {
+  final op = state['functionName'] as String;
+  final rawArgs = state['args'] as List? ?? [];
+  final args = rawArgs.map(MontyValue.fromJson).toList();
+
+  Map<String, MontyValue>? kwargs;
+  final rawKwargs = state['kwargs'] as Map<String, dynamic>?;
+  if (rawKwargs != null) {
+    kwargs = rawKwargs.map((k, v) => MapEntry(k, MontyValue.fromJson(v)));
+  }
+
+  final call = MontyOsCall(
+    operationName: op,
+    arguments: args,
+    kwargs: kwargs,
+  );
+
+  final sw = Stopwatch()..start();
+  Object? result;
+
+  if (op.startsWith('Path.')) {
+    result = await _vfs.handle(call);
+  } else if (op.startsWith('date.') || op.startsWith('datetime.')) {
+    result = await _time.handle(call);
+  } else {
+    throw UnsupportedError('Unhandled os_call: $op');
+  }
+
+  sw.stop();
+
+  // Log the os_call for the UI.
+  final logEntry = {
+    'op': op,
+    'args': rawArgs.map((a) => a.toString()).toList(),
+    'result': _summarize(result),
+    'durationMs': sw.elapsedMilliseconds,
+  };
+  _osCallLog.add(logEntry);
+
+  // Notify the HTML UI in real-time.
+  try {
+    _jsOnOsCall(jsonEncode(logEntry).toJS);
+  } catch (_) {
+    // _onOsCall not defined — OK in headless mode.
+  }
+
+  return result;
+}
+
+String _summarize(Object? value) {
+  if (value == null) return 'null';
+  final s = value.toString();
+  return s.length > 80 ? '${s.substring(0, 77)}...' : s;
+}
+
+Future<Map<String, dynamic>> _runWithVfs(String code) async {
+  _osCallLog.clear();
+  _vfs = MemoryFsOsCallHandler();
+  _time = TimeOsCallHandler();
+
+  // Mount any pre-staged files (set by mountFile before run).
+  for (final entry in _stagedFiles.entries) {
+    _vfs.writeFile(entry.key, entry.value);
+  }
+
+  var state = _parse((await _bridgeStart(code.toJS).toDart).toDart);
+
+  while (state['state'] != 'complete') {
+    if (state['ok'] != true) return state;
+
+    if (state['state'] == 'os_call' ||
+        (state['state'] == 'pending' &&
+            _isOsCall(state['functionName'] as String?))) {
+      try {
+        final result = await _handleOsCall(state);
+        state = _parse(
+          (await _bridgeResume(jsonEncode(result).toJS).toDart).toDart,
+        );
+      } on Object catch (e) {
+        state = _parse(
+          (await _bridgeResumeWithError(
+            jsonEncode(e.toString()).toJS,
+          ).toDart)
+              .toDart,
+        );
+      }
+    } else {
+      return {
+        'ok': false,
+        'error': 'Unexpected state: ${state['state']}',
+      };
+    }
+  }
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// File staging (mount files before run)
+// ---------------------------------------------------------------------------
+
+final _stagedFiles = <String, String>{};
+
+Future<void> _mountFile(String path, String content) async {
+  _stagedFiles[path] = content;
+  _vfs.writeFile(path, content);
+  // Refresh VFS panel immediately.
+  final files = await _collectFiles();
+  try {
+    _jsOnFilesChanged(jsonEncode(files).toJS);
+  } catch (_) {}
+}
+
+void _clearMounts() {
+  _stagedFiles.clear();
+}
+
+// ---------------------------------------------------------------------------
+// API exposed to HTML via window.VfsDemo
+// ---------------------------------------------------------------------------
+
+/// Returns a JSON object:
+/// { ok, value?, error?, osCallLog, files }
+Future<String> _apiRun(String code) async {
+  final result = await _runWithVfs(code);
+
+  // Collect VFS file tree after execution.
+  final files = await _collectFiles();
+
+  return jsonEncode({
+    'ok': result['ok'],
+    if (result['value'] != null) 'value': result['value'],
+    if (result['error'] != null) 'error': result['error'],
+    'osCallLog': _osCallLog,
+    'files': files,
+  });
+}
+
+Future<List<Map<String, dynamic>>> _collectFiles() async {
+  final files = <Map<String, dynamic>>[];
+  Future<void> walk(String dirPath) async {
+    try {
+      final entries = await _listDir(dirPath);
+      for (final entry in entries) {
+        if (_vfs.exists(entry)) {
+          // Check if it's a file by trying to read it.
+          try {
+            final content = _vfs.readFile(entry);
+            files.add({
+              'path': entry,
+              'type': 'file',
+              'size': content.length,
+              'preview': content.length > 200
+                  ? '${content.substring(0, 197)}...'
+                  : content,
+            });
+          } catch (_) {
+            // It's a directory.
+            files.add({'path': entry, 'type': 'dir'});
+            await walk(entry);
+          }
+        }
+      }
+    } catch (_) {
+      // Not a directory or doesn't exist.
+    }
+  }
+
+  // Walk from /sandbox root.
+  await walk('/sandbox');
+  return files;
+}
+
+Future<List<String>> _listDir(String path) async {
+  try {
+    final call = MontyOsCall(
+      operationName: 'Path.iterdir',
+      arguments: [MontyString(path)],
+    );
+    final r = await _vfs.handle(call);
+    if (r is List) {
+      return r.map((e) => e is MontyPath ? e.value : e.toString()).toList();
+    }
+    return [];
+  } catch (_) {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main — wire up JS API and initialize
+// ---------------------------------------------------------------------------
+
+Future<void> main() async {
+  // Expose API to HTML.
+  final api = <String, JSFunction>{
+    'run':
+        ((JSString code) => _apiRun(code.toDart).then((r) => r.toJS).toJS).toJS,
+    'mountFile': ((JSString path, JSString content) {
+      _mountFile(path.toDart, content.toDart);
+    }).toJS,
+    'clearMounts': (() => _clearMounts()).toJS,
+  }.jsify();
+  _vfsDemo = api as JSObject;
+
+  // Initialize WASM bridge (static method API).
+  final ok = (await _bridgeInit().toDart).toDart;
+  if (!ok) {
+    print('VFS_DEMO_ERROR: WASM init failed');
+    return;
+  }
+
+  print('VFS Demo ready');
+  try {
+    _jsOnReady();
+  } catch (_) {
+    // _onReady not defined — OK in headless mode.
+  }
+}

--- a/example/web/pubspec.yaml
+++ b/example/web/pubspec.yaml
@@ -6,4 +6,6 @@ environment:
   sdk: '>=3.5.0 <4.0.0'
 
 dependencies:
+  dart_monty:
+    path: ../..
   web: ^1.1.1

--- a/example/web/run.sh
+++ b/example/web/run.sh
@@ -53,6 +53,8 @@ dart compile js bin/ladder_showcase.dart -o "$WEB_DIR/ladder_showcase.dart.js"
 echo "  Compiled: web/ladder_showcase.dart.js"
 dart compile js bin/visualizer.dart -o "$WEB_DIR/visualizer.dart.js"
 echo "  Compiled: web/visualizer.dart.js"
+dart compile js bin/vfs_demo.dart -o "$WEB_DIR/vfs_demo.dart.js"
+echo "  Compiled: web/vfs_demo.dart.js"
 
 # ── Step 5: Start COOP/COEP server ──────────────────────────────────────
 PORT=8088
@@ -73,7 +75,10 @@ cleanup() {
         "$WEB_DIR/ladder_showcase.dart.js.map" \
         "$WEB_DIR/visualizer.dart.js" \
         "$WEB_DIR/visualizer.dart.js.deps" \
-        "$WEB_DIR/visualizer.dart.js.map"
+        "$WEB_DIR/visualizer.dart.js.map" \
+        "$WEB_DIR/vfs_demo.dart.js" \
+        "$WEB_DIR/vfs_demo.dart.js.deps" \
+        "$WEB_DIR/vfs_demo.dart.js.map"
   rm -rf "$WEB_DIR/fixtures"
 }
 trap cleanup EXIT
@@ -106,6 +111,7 @@ echo "  Home:       http://localhost:$PORT/"
 echo "  Demo:       http://localhost:$PORT/demo.html"
 echo "  Ladder:     http://localhost:$PORT/ladder.html"
 echo "  Visualizer: http://localhost:$PORT/visualizer.html"
+echo "  VFS:        http://localhost:$PORT/vfs.html"
 echo "  Press Ctrl+C to stop."
 echo ""
 

--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -1645,15 +1645,10 @@ graph LR
       <h3>Algorithm Visualizer</h3>
       <p>8 sorting algorithms. Python writes the logic. Monty's iterative execution pauses at each step. You see every comparison and swap.</p>
     </a>
-    <a class="demo-card" href="mcp-docs.html">
-      <div class="demo-badge badge-mcp">MCP</div>
-      <h3>MCP Server Docs</h3>
-      <p>Give your LLM a Python interpreter. Model Context Protocol server with host function plugins, session persistence, and 6 guides.</p>
-    </a>
-    <a class="demo-card" href="flutter/">
-      <div class="demo-badge badge-flutter">FLUTTER</div>
-      <h3>Flutter Web App</h3>
-      <p>Full Material app with sorting visualizer, traveling salesman, ladder runner, and code examples. May not be available in all builds.</p>
+    <a class="demo-card" href="vfs.html">
+      <div class="demo-badge badge-wasm">VFS</div>
+      <h3>VFS Playground</h3>
+      <p>Virtual filesystem in the browser. Python reads and writes files through pathlib. Dart handles every OS call. Watch the round-trip live.</p>
     </a>
   </div>
 </section>
@@ -1800,7 +1795,7 @@ timeline
     <a href="https://github.com/runyaga/dart_monty">GitHub</a>
     <a href="https://pub.dev/packages/dart_monty">pub.dev</a>
     <a href="https://github.com/runyaga/dart_monty/tree/main/docs">Docs</a>
-    <a href="mcp-docs.html">MCP</a>
+    <a href="vfs.html">VFS Playground</a>
   </div>
 </footer>
 

--- a/example/web/web/vfs.html
+++ b/example/web/web/vfs.html
@@ -1,0 +1,513 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dart_monty VFS Playground</title>
+  <style>
+    :root {
+      --bg: #1a1b26;
+      --surface: #24283b;
+      --surface2: #2f3447;
+      --border: #3b4261;
+      --text: #c0caf5;
+      --text-dim: #565f89;
+      --accent: #7aa2f7;
+      --green: #9ece6a;
+      --yellow: #e0af68;
+      --red: #f7768e;
+      --orange: #ff9e64;
+      --cyan: #7dcfff;
+      --mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      padding: 12px 20px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    header h1 {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--accent);
+    }
+
+    header .tag {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-weight: 500;
+    }
+
+    .tag-wasm { background: #2d3a5e; color: var(--cyan); }
+    .tag-vfs { background: #2d3e2d; color: var(--green); }
+
+    #status {
+      margin-left: auto;
+      font-size: 12px;
+      color: var(--text-dim);
+    }
+
+    #status.ready { color: var(--green); }
+    #status.running { color: var(--yellow); }
+    #status.error { color: var(--red); }
+
+    .main {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      gap: 1px;
+      background: var(--border);
+      overflow: hidden;
+    }
+
+    .panel {
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .panel-header {
+      padding: 8px 12px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-dim);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+
+    .panel-header .count {
+      background: var(--surface2);
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+    }
+
+    .panel-body {
+      flex: 1;
+      overflow: auto;
+      padding: 0;
+    }
+
+    /* Code editor */
+    #editor {
+      width: 100%;
+      height: 100%;
+      background: transparent;
+      color: var(--text);
+      border: none;
+      resize: none;
+      padding: 12px;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.6;
+      outline: none;
+      tab-size: 4;
+    }
+
+    .editor-panel .panel-header {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .btn-group { display: flex; gap: 6px; }
+
+    .btn {
+      padding: 4px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--surface2);
+      color: var(--text);
+      font-size: 11px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+
+    .btn:hover { border-color: var(--accent); }
+
+    .btn-run {
+      background: #1a3a1a;
+      border-color: var(--green);
+      color: var(--green);
+      font-weight: 600;
+    }
+
+    .btn-run:hover { background: #2a4a2a; }
+    .btn-run:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* File tree */
+    .file-entry {
+      padding: 6px 12px;
+      font-family: var(--mono);
+      font-size: 12px;
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+    }
+
+    .file-entry:hover { background: var(--surface2); }
+    .file-entry.selected { background: var(--surface2); border-left: 2px solid var(--accent); }
+
+    .file-icon { margin-right: 6px; }
+    .file-size { float: right; color: var(--text-dim); font-size: 11px; }
+
+    .file-preview {
+      padding: 12px;
+      font-family: var(--mono);
+      font-size: 12px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: var(--text-dim);
+    }
+
+    .empty-state {
+      padding: 24px;
+      text-align: center;
+      color: var(--text-dim);
+      font-size: 13px;
+    }
+
+    /* OS Call log */
+    .oscall-entry {
+      padding: 6px 12px;
+      font-family: var(--mono);
+      font-size: 11px;
+      border-bottom: 1px solid var(--border);
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 8px;
+      align-items: baseline;
+    }
+
+    .oscall-op {
+      color: var(--cyan);
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .oscall-args {
+      color: var(--text-dim);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .oscall-time {
+      color: var(--text-dim);
+      font-size: 10px;
+      white-space: nowrap;
+    }
+
+    /* Output */
+    #output {
+      padding: 12px;
+      font-family: var(--mono);
+      font-size: 13px;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .output-value { color: var(--green); }
+    .output-error { color: var(--red); }
+    .output-info { color: var(--text-dim); font-size: 12px; }
+
+    /* Mount panel */
+    .mount-bar {
+      padding: 6px 12px;
+      display: flex;
+      gap: 6px;
+      border-top: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    .mount-bar input {
+      flex: 1;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 4px 8px;
+      font-family: var(--mono);
+      font-size: 11px;
+      outline: none;
+    }
+
+    .mount-bar input:focus { border-color: var(--accent); }
+
+    /* Examples dropdown */
+    select {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 4px 8px;
+      font-size: 11px;
+      cursor: pointer;
+      outline: none;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>dart_monty VFS Playground</h1>
+    <span class="tag tag-wasm">WASM</span>
+    <span class="tag tag-vfs">VFS</span>
+    <select id="examples">
+      <option value="">Load example...</option>
+      <option value="hello">Hello VFS</option>
+      <option value="config">Config File Injection</option>
+      <option value="pipeline">Data Pipeline</option>
+      <option value="datetime">Date &amp; Time</option>
+      <option value="explorer">File Explorer</option>
+    </select>
+    <span id="status">Initializing WASM...</span>
+  </header>
+
+  <div class="main">
+    <!-- Top-left: Python editor -->
+    <div class="panel editor-panel">
+      <div class="panel-header">
+        <span>Python Code</span>
+        <div class="btn-group">
+          <button class="btn btn-run" id="runBtn" disabled>Run</button>
+        </div>
+      </div>
+      <div class="panel-body">
+        <textarea id="editor" spellcheck="false">from pathlib import Path
+
+# Write a file to the virtual filesystem
+Path('/sandbox/hello.txt').write_text('Hello from Python in WASM!')
+
+# Read it back
+content = Path('/sandbox/hello.txt').read_text()
+
+# Create a directory and list it
+Path('/sandbox/data').mkdir(parents=True)
+Path('/sandbox/data/a.txt').write_text('alpha')
+Path('/sandbox/data/b.txt').write_text('beta')
+files = sorted([p.name for p in Path('/sandbox/data').iterdir()], key=str)
+
+{'content': content, 'files': files}</textarea>
+      </div>
+    </div>
+
+    <!-- Top-right: OS Call log -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>OS Call Log</span>
+        <span class="count" id="callCount">0</span>
+      </div>
+      <div class="panel-body" id="callLog">
+        <div class="empty-state">Run code to see OS calls intercepted in real-time</div>
+      </div>
+    </div>
+
+    <!-- Bottom-left: Files -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Virtual Filesystem</span>
+        <span class="count" id="fileCount">0</span>
+      </div>
+      <div class="panel-body" id="fileTree">
+        <div class="empty-state">VFS is empty. Run code or mount files below.</div>
+      </div>
+      <div class="mount-bar">
+        <input type="text" id="mountPath" placeholder="/sandbox/input.csv" />
+        <input type="text" id="mountContent" placeholder="file content..." />
+        <button class="btn" id="mountBtn">Mount</button>
+      </div>
+    </div>
+
+    <!-- Bottom-right: Output -->
+    <div class="panel">
+      <div class="panel-header">Output</div>
+      <div class="panel-body" id="output">
+        <div class="empty-state">Python result will appear here</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- COOP/COEP for SharedArrayBuffer (required by WASM worker) -->
+  <script src="coi-serviceworker.js"></script>
+
+  <!-- Dart callbacks — MUST be defined before vfs_demo.dart.js loads -->
+  <script>
+    let _callCount = 0;
+    let _ready = false;
+
+    window._onOsCall = function(jsonStr) {
+      const entry = JSON.parse(jsonStr);
+      _callCount++;
+      console.log(`[VFS] OS call #${_callCount}: ${entry.op}(${(entry.args||[]).join(', ')}) => ${entry.result} [${entry.durationMs}ms]`);
+      const el = document.getElementById('callLog');
+      const countEl = document.getElementById('callCount');
+      if (!el || !countEl) return;
+      countEl.textContent = _callCount;
+      if (_callCount === 1) el.innerHTML = '';
+      const div = document.createElement('div');
+      div.className = 'oscall-entry';
+      div.innerHTML = `<span class="oscall-op">${entry.op}</span><span class="oscall-args">${(entry.args||[]).join(', ')}</span><span class="oscall-time">${entry.durationMs}ms</span>`;
+      el.appendChild(div);
+      el.scrollTop = el.scrollHeight;
+    };
+
+    window._onReady = function() {
+      _ready = true;
+      console.log('[VFS] WASM ready — Run button enabled');
+      const s = document.getElementById('status');
+      const b = document.getElementById('runBtn');
+      if (s) { s.textContent = 'Ready'; s.className = 'ready'; }
+      if (b) { b.disabled = false; }
+    };
+
+    window._onFilesChanged = function(filesJson) {
+      const files = JSON.parse(filesJson);
+      renderFiles(files);
+    };
+  </script>
+
+  <!-- Load WASM bridge, then compiled Dart VFS demo -->
+  <script src="dart_monty_bridge.js"></script>
+  <script src="vfs_demo.dart.js"></script>
+
+  <!-- UI wiring (DOM is ready at this point) -->
+  <script>
+    const $ = (s) => document.getElementById(s);
+    const editor = $('editor');
+    const runBtn = $('runBtn');
+    const status = $('status');
+    const callLog = $('callLog');
+    const fileTree = $('fileTree');
+    const output = $('output');
+
+    async function run() {
+      if (!_ready || !window.VfsDemo) return;
+      console.log('[VFS] Running...');
+      runBtn.disabled = true;
+      status.textContent = 'Running...';
+      status.className = 'running';
+      _callCount = 0;
+      $('callCount').textContent = '0';
+      callLog.innerHTML = '';
+      output.innerHTML = '';
+      fileTree.innerHTML = '';
+
+      try {
+        const resultPromise = window.VfsDemo.run(editor.value);
+        const resultJson = await resultPromise;
+        const result = JSON.parse(resultJson);
+        console.log('[VFS] Result:', result);
+
+        if (result.ok) {
+          output.innerHTML = `<div class="output-value">${formatValue(result.value)}</div>\n<div class="output-info">${result.osCallLog.length} OS calls</div>`;
+        } else {
+          output.innerHTML = `<div class="output-error">${result.error}</div>`;
+        }
+        renderFiles(result.files || []);
+        status.textContent = result.ok ? 'Done' : 'Error';
+        status.className = result.ok ? 'ready' : 'error';
+      } catch (e) {
+        console.error('[VFS] Run error:', e);
+        output.innerHTML = `<div class="output-error">${e}</div>`;
+        status.textContent = 'Error';
+        status.className = 'error';
+      }
+      runBtn.disabled = false;
+    }
+
+    function formatValue(v) {
+      if (v === null || v === undefined) return 'None';
+      if (typeof v === 'object') return JSON.stringify(v, null, 2);
+      return String(v);
+    }
+
+    function renderFiles(files) {
+      if (!files.length) {
+        fileTree.innerHTML = '<div class="empty-state">No files in VFS</div>';
+        $('fileCount').textContent = '0';
+        return;
+      }
+      $('fileCount').textContent = files.filter(f => f.type === 'file').length;
+      fileTree.innerHTML = '';
+      for (const f of files) {
+        if (f.type !== 'file') continue;
+        const div = document.createElement('div');
+        div.className = 'file-entry';
+        div.innerHTML = `<span class="file-icon">\ud83d\udcc4</span>${f.path}<span class="file-size">${f.size}B</span>`;
+        div.onclick = () => {
+          document.querySelectorAll('.file-entry').forEach(e => e.classList.remove('selected'));
+          div.classList.add('selected');
+          output.innerHTML = `<div class="output-info">${f.path} (${f.size} bytes)</div>\n<div class="output-value">${escapeHtml(f.preview)}</div>`;
+        };
+        fileTree.appendChild(div);
+      }
+    }
+
+    function escapeHtml(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+    $('mountBtn').onclick = function() {
+      const path = $('mountPath').value.trim();
+      const content = $('mountContent').value;
+      if (!path || !window.VfsDemo) return;
+      console.log(`[VFS] Mounting ${path} (${content.length} bytes)`);
+      window.VfsDemo.mountFile(path, content);
+      $('mountPath').value = '';
+      $('mountContent').value = '';
+    };
+
+    const examples = {
+      hello: `from pathlib import Path\n\n# Write a file to the virtual filesystem\nPath('/sandbox/hello.txt').write_text('Hello from Python in WASM!')\n\n# Read it back\ncontent = Path('/sandbox/hello.txt').read_text()\n\n# Create a directory and list it\nPath('/sandbox/data').mkdir(parents=True)\nPath('/sandbox/data/a.txt').write_text('alpha')\nPath('/sandbox/data/b.txt').write_text('beta')\nfiles = sorted([p.name for p in Path('/sandbox/data').iterdir()], key=str)\n\n{'content': content, 'files': files}`,
+      config: `import json\nfrom pathlib import Path\n\n# Read a config file injected from Dart/JS\n# (click Mount below to add /sandbox/config.json first)\nconfig = json.loads(Path('/sandbox/config.json').read_text())\n\n# Process it\nresult = {\n    'api_key': config.get('api_key', 'missing'),\n    'retries': config.get('retries', 0),\n    'debug': config.get('debug', False),\n}\nresult`,
+      pipeline: `from pathlib import Path\n\n# Read CSV input (mount /sandbox/input.csv first, or use default)\ntry:\n    raw = Path('/sandbox/input.csv').read_text()\nexcept:\n    # Default data if not mounted\n    raw = 'name,score\\nalice,95\\nbob,87\\ncarol,92\\ndave,78'\n    Path('/sandbox/input.csv').write_text(raw)\n\n# Parse\nlines = raw.strip().split('\\n')\nheader = lines[0].split(',')\nrows = [l.split(',') for l in lines[1:]]\n\n# Compute\nscores = [int(r[1]) for r in rows]\navg = sum(scores) / len(scores)\ntop = max(rows, key=lambda r: int(r[1]))\n\n# Write summary\nsummary = f"Students: {len(rows)}\\nAverage: {avg:.1f}\\nTop: {top[0]} ({top[1]})"\nPath('/sandbox/summary.txt').write_text(summary)\n\n# Write sorted leaderboard\nranked = sorted(rows, key=lambda r: int(r[1]), reverse=True)\nboard = '\\n'.join(f"{i+1}. {r[0]}: {r[1]}" for i, r in enumerate(ranked))\nPath('/sandbox/leaderboard.txt').write_text(board)\n\n{'average': avg, 'top': top[0], 'files_written': 2}`,
+      datetime: `from datetime import date, datetime\n\n# Get today's date (yields OsCall to host)\nd = date.today()\nprint(f"Today: {d.year}-{d.month:02d}-{d.day:02d}")\n\n# Get current datetime\ndt = datetime.now()\nprint(f"Now: {dt.year}-{dt.month:02d}-{dt.day:02d} {dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}")\n\n{'date': str(d), 'datetime': str(dt)}`,
+      explorer: `from pathlib import Path\n\n# Build a directory structure\nbase = Path('/sandbox/project')\nbase.mkdir(parents=True)\n\n# Source files\n(base / 'src').mkdir()\n(base / 'src' / 'main.py').write_text('print("hello world")')\n(base / 'src' / 'utils.py').write_text('def add(a, b): return a + b')\n\n# Config\n(base / 'config.json').write_text('{"debug": true, "port": 8080}')\n\n# Docs\n(base / 'docs').mkdir()\n(base / 'docs' / 'README.md').write_text('# My Project\\nA demo of the VFS.')\n\n# Count everything\nall_files = []\ndef walk(d):\n    for p in sorted(d.iterdir(), key=str):\n        if p.is_file():\n            all_files.append(str(p))\n        elif p.is_dir():\n            walk(p)\n\nwalk(base)\n{'files': all_files, 'count': len(all_files)}`,
+    };
+
+    $('examples').onchange = function() {
+      const key = this.value;
+      if (key && examples[key]) {
+        editor.value = examples[key];
+        if (key === 'config' && window.VfsDemo) {
+          window.VfsDemo.clearMounts();
+          window.VfsDemo.mountFile('/sandbox/config.json', '{"api_key": "sk-abc123", "retries": 3, "debug": true}');
+        }
+      }
+      this.value = '';
+    };
+
+    editor.addEventListener('keydown', (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') { e.preventDefault(); run(); }
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const start = editor.selectionStart;
+        editor.value = editor.value.substring(0, start) + '    ' + editor.value.substring(editor.selectionEnd);
+        editor.selectionStart = editor.selectionEnd = start + 4;
+      }
+    });
+
+    runBtn.onclick = run;
+  </script>
+</body>
+</html>

--- a/lib/dart_monty_bridge.dart
+++ b/lib/dart_monty_bridge.dart
@@ -17,6 +17,14 @@ export 'src/bridge/bridge/monty_plugin.dart';
 export 'src/bridge/bridge/plugin_registry.dart';
 export 'src/bridge/bridge/struct_log_bridge_logger.dart';
 export 'src/bridge/os_call/default_os_call_handler.dart';
+export 'src/bridge/os_call/env_os_call_handler.dart';
+export 'src/bridge/os_call/memory_fs_os_call_handler.dart';
+export 'src/bridge/os_call/os_call_exception.dart';
+export 'src/bridge/os_call/os_call_handler.dart';
+export 'src/bridge/os_call/router_os_call_handler.dart';
+export 'src/bridge/os_call/sandboxed_native_fs_handler_stub.dart'
+    if (dart.library.io) 'src/bridge/os_call/sandboxed_native_fs_handler.dart';
+export 'src/bridge/os_call/time_os_call_handler.dart';
 export 'src/bridge/plugins/message_bus_plugin.dart';
 export 'src/bridge/plugins/sandbox_plugin.dart';
 export 'src/bridge/plugins/template_plugin.dart';

--- a/lib/src/bridge/bridge/bridge_event.dart
+++ b/lib/src/bridge/bridge/bridge_event.dart
@@ -191,6 +191,7 @@ class BridgeOsCallStart extends BridgeEvent {
   const BridgeOsCallStart({
     required this.callId,
     required this.operationName,
+    this.argumentSummary,
   });
 
   /// Call identifier (bridge-assigned).
@@ -198,16 +199,31 @@ class BridgeOsCallStart extends BridgeEvent {
 
   /// The OS operation name, e.g. `"Path.read_text"`, `"os.getenv"`.
   final String operationName;
+
+  /// Human-readable summary of the call's arguments (for telemetry).
+  ///
+  /// Example: `"'/sandbox/test.txt'"` for a read_text call.
+  /// May be null for calls with no arguments.
+  final String? argumentSummary;
 }
 
 /// An OS call completed with a result (or error string).
 class BridgeOsCallResult extends BridgeEvent {
   /// Creates a [BridgeOsCallResult].
-  const BridgeOsCallResult({required this.callId, required this.result});
+  const BridgeOsCallResult({
+    required this.callId,
+    required this.result,
+    this.durationMs,
+  });
 
   /// Call identifier (bridge-assigned).
   final String callId;
 
   /// Result string (or error description).
   final String result;
+
+  /// Wall-clock duration of the handler invocation in milliseconds.
+  ///
+  /// Null when the call was rejected (no handler registered).
+  final int? durationMs;
 }

--- a/lib/src/bridge/bridge/default_monty_bridge.dart
+++ b/lib/src/bridge/bridge/default_monty_bridge.dart
@@ -8,6 +8,7 @@ import 'package:dart_monty/src/bridge/bridge/host_function.dart';
 import 'package:dart_monty/src/bridge/bridge/host_function_schema.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
 import 'package:dart_monty/src/bridge/bridge/struct_log_bridge_logger.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
 import 'package:meta/meta.dart';
 import 'package:struct_log/struct_log.dart';
 
@@ -34,12 +35,6 @@ const _preambleLineCount = 5;
 
 const _consoleWriteFn = '__console_write__';
 const _roleKwarg = '__role__';
-
-/// Handler callback for OS-level calls (pathlib, os.getenv, datetime, etc.).
-///
-/// Receives the [MontyOsCall] and returns the result to resume Python with.
-/// Throw an exception to resume Python with an error.
-typedef OsCallHandler = Future<Object?> Function(MontyOsCall call);
 
 /// Tracks an in-flight host function future awaiting resolution.
 class _PendingFuture {
@@ -151,6 +146,7 @@ class DefaultMontyBridge implements MontyBridge {
   @override
   void dispose() {
     _isDisposed = true;
+    unawaited(_osCallHandler?.dispose());
     log.close();
   }
 
@@ -373,8 +369,17 @@ class DefaultMontyBridge implements MontyBridge {
   ) async {
     final callId = _nextId;
     final opName = osCall.operationName;
+    final argSummary = osCall.arguments.isEmpty
+        ? null
+        : osCall.arguments.map((a) => a.dartValue).join(', ');
 
-    controller.add(BridgeOsCallStart(callId: callId, operationName: opName));
+    controller.add(
+      BridgeOsCallStart(
+        callId: callId,
+        operationName: opName,
+        argumentSummary: argSummary,
+      ),
+    );
 
     final handler = _osCallHandler;
     if (handler == null) {
@@ -386,24 +391,34 @@ class DefaultMontyBridge implements MontyBridge {
       return _platform.resumeWithError(errorMsg);
     }
 
+    final sw = Stopwatch()..start();
     try {
-      final result = await handler(osCall);
+      final result = await handler.handle(osCall);
+      sw.stop();
       controller.add(
         BridgeOsCallResult(
           callId: callId,
           result: result?.toString() ?? '',
+          durationMs: sw.elapsedMilliseconds,
         ),
       );
 
       return await _platform.resume(result);
     } on Object catch (e, st) {
+      sw.stop();
       log.error(
         'OS call handler error',
         error: e,
         stackTrace: st,
         attributes: {'op': opName},
       );
-      controller.add(BridgeOsCallResult(callId: callId, result: 'Error: $e'));
+      controller.add(
+        BridgeOsCallResult(
+          callId: callId,
+          result: 'Error: $e',
+          durationMs: sw.elapsedMilliseconds,
+        ),
+      );
 
       return _platform.resumeWithError(e.toString());
     }

--- a/lib/src/bridge/os_call/default_os_call_handler_native.dart
+++ b/lib/src/bridge/os_call/default_os_call_handler_native.dart
@@ -13,6 +13,7 @@ import 'package:dart_monty/src/bridge/os_call/time_os_call_handler.dart';
 /// - `os.*` -> [EnvOsCallHandler] (full host environment)
 OsCallHandler createDefaultOsCallHandler() {
   final time = TimeOsCallHandler();
+
   return RouterOsCallHandler({
     'Path.': DefaultNativePathHandler(),
     'os.': EnvOsCallHandler(Platform.environment),
@@ -67,11 +68,13 @@ Object? _handlePathOp(
 
 Object? _unlink(List<MontyValue> args) {
   File(_str(args.first)).deleteSync();
+
   return null;
 }
 
 Object? _rmdir(List<MontyValue> args) {
   Directory(_str(args.first)).deleteSync();
+
   return null;
 }
 
@@ -79,6 +82,7 @@ int _writeText(List<MontyValue> args) {
   final path = _str(args.first);
   final content = _str(args[1]);
   File(path).writeAsStringSync(content);
+
   return content.length;
 }
 
@@ -86,6 +90,7 @@ int _writeBytes(List<MontyValue> args) {
   final path = _str(args.first);
   final bytes = (args[1].dartValue! as List).cast<int>();
   File(path).writeAsBytesSync(bytes);
+
   return bytes.length;
 }
 
@@ -96,6 +101,7 @@ Object? _mkdir(List<MontyValue> args, Map<String, MontyValue>? kwargs) {
   final dir = Directory(path);
   if (existOk && dir.existsSync()) return null;
   dir.createSync(recursive: parents);
+
   return null;
 }
 
@@ -103,6 +109,7 @@ String _rename(List<MontyValue> args) {
   final oldPath = _str(args.first);
   final newPath = _str(args[1]);
   File(oldPath).renameSync(newPath);
+
   return newPath;
 }
 

--- a/lib/src/bridge/os_call/default_os_call_handler_native.dart
+++ b/lib/src/bridge/os_call/default_os_call_handler_native.dart
@@ -1,28 +1,36 @@
 import 'dart:io';
 
 import 'package:dart_monty/dart_monty.dart';
-import 'package:dart_monty/src/bridge/bridge/default_monty_bridge.dart';
+import 'package:dart_monty/src/bridge/os_call/env_os_call_handler.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+import 'package:dart_monty/src/bridge/os_call/router_os_call_handler.dart';
+import 'package:dart_monty/src/bridge/os_call/time_os_call_handler.dart';
 
-/// Creates a default OsCallHandler backed by dart:io.
+/// Creates a default [OsCallHandler] backed by `dart:io`.
 ///
-/// Handles filesystem (pathlib), environment (os.getenv/os.environ),
-/// and datetime (date.today/datetime.now) operations.
+/// Returns a [RouterOsCallHandler] that composes:
+/// - `Path.*` -> [DefaultNativePathHandler] (unrestricted filesystem)
+/// - `os.*` -> [EnvOsCallHandler] (full host environment)
 OsCallHandler createDefaultOsCallHandler() {
-  return (MontyOsCall call) => Future.value(_handleCall(call));
+  final time = TimeOsCallHandler();
+  return RouterOsCallHandler({
+    'Path.': DefaultNativePathHandler(),
+    'os.': EnvOsCallHandler(Platform.environment),
+    'date.': time,
+    'datetime.': time,
+  });
 }
 
-Object? _handleCall(MontyOsCall call) {
-  final op = call.operationName;
-  if (op.startsWith('Path.')) {
-    return _handlePathOp(op, call.arguments, call.kwargs);
-  }
-  if (op.startsWith('os.')) {
-    return _handleEnvOp(op, call.arguments);
-  }
-  if (op.startsWith('date.') || op.startsWith('datetime.')) {
-    return _handleDateTimeOp(op);
-  }
-  throw UnsupportedError('Unsupported OS operation: $op');
+/// Handles `Path.*` OS calls using unrestricted `dart:io`.
+///
+/// Provides the sandboxed Python code with full read/write access to the
+/// host filesystem. For production use, prefer `SandboxedNativeFsHandler`
+/// which restricts access to a chroot directory.
+class DefaultNativePathHandler extends OsCallHandler {
+  @override
+  Future<Object?> handle(MontyOsCall call) => Future.value(
+    _handlePathOp(call.operationName, call.arguments, call.kwargs),
+  );
 }
 
 Object? _handlePathOp(
@@ -31,24 +39,18 @@ Object? _handlePathOp(
   Map<String, MontyValue>? kwargs,
 ) => switch (op) {
   'Path.exists' =>
-    FileSystemEntity.typeSync(_extractPath(args.first)) !=
+    FileSystemEntity.typeSync(_str(args.first)) !=
         FileSystemEntityType.notFound,
   'Path.is_file' =>
-    FileSystemEntity.typeSync(_extractPath(args.first)) ==
-        FileSystemEntityType.file,
+    FileSystemEntity.typeSync(_str(args.first)) == FileSystemEntityType.file,
   'Path.is_dir' =>
-    FileSystemEntity.typeSync(_extractPath(args.first)) ==
+    FileSystemEntity.typeSync(_str(args.first)) ==
         FileSystemEntityType.directory,
   'Path.is_symlink' =>
-    FileSystemEntity.typeSync(
-          _extractPath(args.first),
-          followLinks: false,
-        ) ==
+    FileSystemEntity.typeSync(_str(args.first), followLinks: false) ==
         FileSystemEntityType.link,
-  'Path.read_text' => File(_extractPath(args.first)).readAsStringSync(),
-  'Path.read_bytes' => File(
-    _extractPath(args.first),
-  ).readAsBytesSync().toList(),
+  'Path.read_text' => File(_str(args.first)).readAsStringSync(),
+  'Path.read_bytes' => File(_str(args.first)).readAsBytesSync().toList(),
   'Path.write_text' => _writeText(args),
   'Path.write_bytes' => _writeBytes(args),
   'Path.mkdir' => _mkdir(args, kwargs),
@@ -56,98 +58,55 @@ Object? _handlePathOp(
   'Path.rmdir' => _rmdir(args),
   'Path.rename' => _rename(args),
   'Path.iterdir' => Directory(
-    _extractPath(args.first),
-  ).listSync().map((e) => e.path).toList(),
-  'Path.resolve' => File(_extractPath(args.first)).resolveSymbolicLinksSync(),
-  'Path.absolute' => File(_extractPath(args.first)).absolute.path,
+    _str(args.first),
+  ).listSync().map((e) => MontyPath(e.path)).toList(),
+  'Path.resolve' => File(_str(args.first)).resolveSymbolicLinksSync(),
+  'Path.absolute' => File(_str(args.first)).absolute.path,
   _ => throw UnsupportedError('Unsupported path operation: $op'),
 };
 
 Object? _unlink(List<MontyValue> args) {
-  File(_extractPath(args.first)).deleteSync();
-
+  File(_str(args.first)).deleteSync();
   return null;
 }
 
 Object? _rmdir(List<MontyValue> args) {
-  Directory(_extractPath(args.first)).deleteSync();
-
+  Directory(_str(args.first)).deleteSync();
   return null;
 }
 
 int _writeText(List<MontyValue> args) {
-  final path = _extractPath(args.first);
-  final content = _extractPath(args[1]);
+  final path = _str(args.first);
+  final content = _str(args[1]);
   File(path).writeAsStringSync(content);
-
   return content.length;
 }
 
 int _writeBytes(List<MontyValue> args) {
-  final path = _extractPath(args.first);
+  final path = _str(args.first);
   final bytes = (args[1].dartValue! as List).cast<int>();
   File(path).writeAsBytesSync(bytes);
-
   return bytes.length;
 }
 
 Object? _mkdir(List<MontyValue> args, Map<String, MontyValue>? kwargs) {
-  final path = _extractPath(args.first);
+  final path = _str(args.first);
   final parents = kwargs?['parents']?.dartValue as bool? ?? false;
   final existOk = kwargs?['exist_ok']?.dartValue as bool? ?? false;
   final dir = Directory(path);
   if (existOk && dir.existsSync()) return null;
   dir.createSync(recursive: parents);
-
   return null;
 }
 
 String _rename(List<MontyValue> args) {
-  final oldPath = _extractPath(args.first);
-  final newPath = _extractPath(args[1]);
+  final oldPath = _str(args.first);
+  final newPath = _str(args[1]);
   File(oldPath).renameSync(newPath);
-
   return newPath;
 }
 
-Object? _handleEnvOp(String op, List<MontyValue> args) => switch (op) {
-  'os.getenv' =>
-    Platform.environment[_extractPath(args.first)] ??
-        (args.length > 1 ? args[1].dartValue : null),
-  'os.environ' => Platform.environment,
-  _ => throw UnsupportedError('Unsupported env operation: $op'),
-};
-
-Object? _handleDateTimeOp(String op) {
-  final now = DateTime.now();
-
-  return switch (op) {
-    'date.today' => {
-      '__type': 'date',
-      'year': now.year,
-      'month': now.month,
-      'day': now.day,
-    },
-    'datetime.now' => {
-      '__type': 'datetime',
-      'year': now.year,
-      'month': now.month,
-      'day': now.day,
-      'hour': now.hour,
-      'minute': now.minute,
-      'second': now.second,
-      'microsecond': now.microsecond,
-      'offset_seconds': now.timeZoneOffset.inSeconds,
-      'timezone_name': now.timeZoneName,
-    },
-    _ => throw UnsupportedError('Unsupported datetime operation: $op'),
-  };
-}
-
-/// Extracts a string path from a [MontyValue] argument.
-///
-/// Handles [MontyString] and [MontyPath] values.
-String _extractPath(MontyValue arg) => switch (arg) {
+String _str(MontyValue arg) => switch (arg) {
   MontyString(:final value) || MontyPath(:final value) => value,
   _ => throw ArgumentError('Expected string or path, got: $arg'),
 };

--- a/lib/src/bridge/os_call/default_os_call_handler_stub.dart
+++ b/lib/src/bridge/os_call/default_os_call_handler_stub.dart
@@ -1,8 +1,8 @@
-import 'package:dart_monty/src/bridge/bridge/default_monty_bridge.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+import 'package:dart_monty/src/bridge/os_call/router_os_call_handler.dart';
 
-/// Stub — throws on platforms that support neither dart:io nor dart:js_interop.
-OsCallHandler createDefaultOsCallHandler() {
-  return (_) => throw UnsupportedError(
-    'OsCallHandler not available on this platform',
-  );
-}
+/// Creates a stub [OsCallHandler] for unsupported platforms.
+///
+/// Returns an empty [RouterOsCallHandler] that throws [UnsupportedError]
+/// for all operations.
+OsCallHandler createDefaultOsCallHandler() => RouterOsCallHandler({});

--- a/lib/src/bridge/os_call/default_os_call_handler_web.dart
+++ b/lib/src/bridge/os_call/default_os_call_handler_web.dart
@@ -1,44 +1,19 @@
-import 'package:dart_monty/dart_monty.dart';
-import 'package:dart_monty/src/bridge/bridge/default_monty_bridge.dart';
+import 'package:dart_monty/src/bridge/os_call/memory_fs_os_call_handler.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+import 'package:dart_monty/src/bridge/os_call/router_os_call_handler.dart';
+import 'package:dart_monty/src/bridge/os_call/time_os_call_handler.dart';
 
-/// Creates a default OsCallHandler for web platforms.
+/// Creates a default [OsCallHandler] for web platforms.
 ///
-/// Supports datetime operations (via Dart's DateTime which works on web).
-/// Filesystem and environment operations throw PermissionError since
-/// dart:io is not available in the browser.
+/// Returns a [RouterOsCallHandler] with:
+/// - `Path.*` -> [MemoryFsOsCallHandler] (in-memory VFS)
+///
+/// No `os.*` environment access on web (no `dart:io`).
 OsCallHandler createDefaultOsCallHandler() {
-  return (MontyOsCall call) => Future.value(_handleCall(call));
-}
-
-Object? _handleCall(MontyOsCall call) {
-  switch (call.operationName) {
-    case 'date.today':
-      final now = DateTime.now();
-
-      return {
-        '__type': 'date',
-        'year': now.year,
-        'month': now.month,
-        'day': now.day,
-      };
-    case 'datetime.now':
-      final now = DateTime.now();
-
-      return {
-        '__type': 'datetime',
-        'year': now.year,
-        'month': now.month,
-        'day': now.day,
-        'hour': now.hour,
-        'minute': now.minute,
-        'second': now.second,
-        'microsecond': now.microsecond,
-        'offset_seconds': now.timeZoneOffset.inSeconds,
-        'timezone_name': now.timeZoneName,
-      };
-    default:
-      throw UnsupportedError(
-        'PermissionError: ${call.operationName} not available on web',
-      );
-  }
+  final time = TimeOsCallHandler();
+  return RouterOsCallHandler({
+    'Path.': MemoryFsOsCallHandler(),
+    'date.': time,
+    'datetime.': time,
+  });
 }

--- a/lib/src/bridge/os_call/default_os_call_handler_web.dart
+++ b/lib/src/bridge/os_call/default_os_call_handler_web.dart
@@ -11,6 +11,7 @@ import 'package:dart_monty/src/bridge/os_call/time_os_call_handler.dart';
 /// No `os.*` environment access on web (no `dart:io`).
 OsCallHandler createDefaultOsCallHandler() {
   final time = TimeOsCallHandler();
+
   return RouterOsCallHandler({
     'Path.': MemoryFsOsCallHandler(),
     'date.': time,

--- a/lib/src/bridge/os_call/env_os_call_handler.dart
+++ b/lib/src/bridge/os_call/env_os_call_handler.dart
@@ -1,0 +1,37 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+
+/// Handles `os.*` environment operations using a provided map.
+///
+/// Prevents leaking the host's full `Platform.environment` into the
+/// sandboxed Python code. Only the keys in [environment] are visible.
+///
+/// ```dart
+/// EnvOsCallHandler({'APP_ENV': 'production', 'DEBUG': '0'});
+/// ```
+class EnvOsCallHandler extends OsCallHandler {
+  /// Creates a handler backed by the given [environment] map.
+  EnvOsCallHandler(this.environment);
+
+  /// The environment variables visible to Python.
+  final Map<String, String> environment;
+
+  @override
+  Future<Object?> handle(MontyOsCall call) {
+    final op = call.operationName;
+    final args = call.arguments;
+
+    return Future.value(switch (op) {
+      'os.getenv' =>
+        environment[_extractString(args.first)] ??
+            (args.length > 1 ? args[1].dartValue : null),
+      'os.environ' => Map<String, String>.unmodifiable(environment),
+      _ => throw UnsupportedError('Unsupported env operation: $op'),
+    });
+  }
+}
+
+String _extractString(MontyValue arg) => switch (arg) {
+  MontyString(:final value) || MontyPath(:final value) => value,
+  _ => throw ArgumentError('Expected string, got: $arg'),
+};

--- a/lib/src/bridge/os_call/memory_fs_os_call_handler.dart
+++ b/lib/src/bridge/os_call/memory_fs_os_call_handler.dart
@@ -1,0 +1,192 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_exception.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+import 'package:file/memory.dart';
+
+/// Handles `Path.*` OS calls using an in-memory virtual filesystem.
+///
+/// Works on all platforms (FFI and WASM) since it has no `dart:io` dependency.
+/// Files are ephemeral — they exist only for the lifetime of this handler.
+///
+/// Use [writeFile] and [readFile] from Dart to pre-populate the VFS before
+/// execution or read results after execution.
+///
+/// ```dart
+/// final vfs = MemoryFsOsCallHandler();
+/// vfs.writeFile('/sandbox/config.json', '{"key": "value"}');
+/// bridge.registerOsCallHandler(RouterOsCallHandler({
+///   'Path.': vfs,
+///   ...
+/// }));
+/// ```
+class MemoryFsOsCallHandler extends OsCallHandler {
+  /// Creates a handler backed by a fresh in-memory filesystem.
+  MemoryFsOsCallHandler() : _fs = MemoryFileSystem();
+
+  final MemoryFileSystem _fs;
+
+  /// Pre-populates a file in the VFS from Dart.
+  ///
+  /// Creates intermediate directories as needed.
+  void writeFile(String path, String content) {
+    _fs.file(path)
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(content);
+  }
+
+  /// Pre-populates a binary file in the VFS from Dart.
+  void writeFileBytes(String path, List<int> bytes) {
+    _fs.file(path)
+      ..parent.createSync(recursive: true)
+      ..writeAsBytesSync(bytes);
+  }
+
+  /// Reads a file from the VFS (for Dart-side verification after execution).
+  String readFile(String path) => _fs.file(path).readAsStringSync();
+
+  /// Reads binary content from the VFS.
+  List<int> readFileBytes(String path) =>
+      _fs.file(path).readAsBytesSync().toList();
+
+  /// Whether a path exists in the VFS.
+  bool exists(String path) =>
+      _fs.file(path).existsSync() || _fs.directory(path).existsSync();
+
+  @override
+  Future<Object?> handle(MontyOsCall call) => Future.value(_handleSync(call));
+
+  Object? _handleSync(MontyOsCall call) {
+    final op = call.operationName;
+    final args = call.arguments;
+    final kwargs = call.kwargs;
+
+    return switch (op) {
+      'Path.exists' => _exists(args),
+      'Path.is_file' => _isFile(args),
+      'Path.is_dir' => _isDir(args),
+      'Path.is_symlink' => false, // VFS doesn't support symlinks
+      'Path.read_text' => _readText(args),
+      'Path.read_bytes' => _readBytes(args),
+      'Path.write_text' => _writeText(args),
+      'Path.write_bytes' => _writeBytes(args),
+      'Path.mkdir' => _mkdir(args, kwargs),
+      'Path.unlink' => _unlink(args),
+      'Path.rmdir' => _rmdir(args),
+      'Path.rename' => _rename(args),
+      'Path.iterdir' => _iterdir(args),
+      'Path.resolve' => _str(args.first), // No symlinks to resolve
+      'Path.absolute' => _str(args.first),
+      _ => throw UnsupportedError('Unsupported path operation: $op'),
+    };
+  }
+
+  bool _exists(List<MontyValue> args) {
+    final path = _str(args.first);
+    return _fs.file(path).existsSync() || _fs.directory(path).existsSync();
+  }
+
+  bool _isFile(List<MontyValue> args) =>
+      _fs.file(_str(args.first)).existsSync();
+
+  bool _isDir(List<MontyValue> args) =>
+      _fs.directory(_str(args.first)).existsSync();
+
+  String _readText(List<MontyValue> args) {
+    final path = _str(args.first);
+    final file = _fs.file(path);
+    if (!file.existsSync()) {
+      throw OsCallFileNotFoundError(
+        'Path.read_text',
+        'No such file: $path',
+      );
+    }
+    return file.readAsStringSync();
+  }
+
+  List<int> _readBytes(List<MontyValue> args) {
+    final path = _str(args.first);
+    final file = _fs.file(path);
+    if (!file.existsSync()) {
+      throw OsCallFileNotFoundError(
+        'Path.read_bytes',
+        'No such file: $path',
+      );
+    }
+    return file.readAsBytesSync().toList();
+  }
+
+  int _writeText(List<MontyValue> args) {
+    final path = _str(args.first);
+    final content = _str(args[1]);
+    _fs.file(path)
+      ..parent.createSync(recursive: true)
+      ..writeAsStringSync(content);
+    return content.length;
+  }
+
+  int _writeBytes(List<MontyValue> args) {
+    final path = _str(args.first);
+    final bytes = (args[1].dartValue! as List).cast<int>();
+    _fs.file(path)
+      ..parent.createSync(recursive: true)
+      ..writeAsBytesSync(bytes);
+    return bytes.length;
+  }
+
+  Object? _mkdir(List<MontyValue> args, Map<String, MontyValue>? kwargs) {
+    final path = _str(args.first);
+    final parents = kwargs?['parents']?.dartValue as bool? ?? false;
+    final existOk = kwargs?['exist_ok']?.dartValue as bool? ?? false;
+    final dir = _fs.directory(path);
+    if (existOk && dir.existsSync()) return null;
+    if (!parents && dir.existsSync()) {
+      throw OsCallException('Path.mkdir', 'Directory exists: $path');
+    }
+    dir.createSync(recursive: parents);
+    return null;
+  }
+
+  Object? _unlink(List<MontyValue> args) {
+    final path = _str(args.first);
+    final file = _fs.file(path);
+    if (!file.existsSync()) {
+      throw OsCallFileNotFoundError('Path.unlink', 'No such file: $path');
+    }
+    file.deleteSync();
+    return null;
+  }
+
+  Object? _rmdir(List<MontyValue> args) {
+    final path = _str(args.first);
+    final dir = _fs.directory(path);
+    if (!dir.existsSync()) {
+      throw OsCallFileNotFoundError('Path.rmdir', 'No such directory: $path');
+    }
+    dir.deleteSync();
+    return null;
+  }
+
+  String _rename(List<MontyValue> args) {
+    final oldPath = _str(args.first);
+    final newPath = _str(args[1]);
+    _fs.file(oldPath).renameSync(newPath);
+    return newPath;
+  }
+
+  List<MontyPath> _iterdir(List<MontyValue> args) {
+    final path = _str(args.first);
+    final dir = _fs.directory(path);
+    if (!dir.existsSync()) {
+      throw OsCallFileNotFoundError(
+        'Path.iterdir',
+        'No such directory: $path',
+      );
+    }
+    return dir.listSync().map((e) => MontyPath(e.path)).toList();
+  }
+}
+
+String _str(MontyValue arg) => switch (arg) {
+  MontyString(:final value) || MontyPath(:final value) => value,
+  _ => throw ArgumentError('Expected string or path, got: $arg'),
+};

--- a/lib/src/bridge/os_call/memory_fs_os_call_handler.dart
+++ b/lib/src/bridge/os_call/memory_fs_os_call_handler.dart
@@ -74,14 +74,14 @@ class MemoryFsOsCallHandler extends OsCallHandler {
       'Path.rmdir' => _rmdir(args),
       'Path.rename' => _rename(args),
       'Path.iterdir' => _iterdir(args),
-      'Path.resolve' => _str(args.first), // No symlinks to resolve
-      'Path.absolute' => _str(args.first),
+      'Path.resolve' || 'Path.absolute' => _str(args.first),
       _ => throw UnsupportedError('Unsupported path operation: $op'),
     };
   }
 
   bool _exists(List<MontyValue> args) {
     final path = _str(args.first);
+
     return _fs.file(path).existsSync() || _fs.directory(path).existsSync();
   }
 
@@ -100,6 +100,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
         'No such file: $path',
       );
     }
+
     return file.readAsStringSync();
   }
 
@@ -112,6 +113,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
         'No such file: $path',
       );
     }
+
     return file.readAsBytesSync().toList();
   }
 
@@ -121,6 +123,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
     _fs.file(path)
       ..parent.createSync(recursive: true)
       ..writeAsStringSync(content);
+
     return content.length;
   }
 
@@ -130,6 +133,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
     _fs.file(path)
       ..parent.createSync(recursive: true)
       ..writeAsBytesSync(bytes);
+
     return bytes.length;
   }
 
@@ -138,11 +142,13 @@ class MemoryFsOsCallHandler extends OsCallHandler {
     final parents = kwargs?['parents']?.dartValue as bool? ?? false;
     final existOk = kwargs?['exist_ok']?.dartValue as bool? ?? false;
     final dir = _fs.directory(path);
-    if (existOk && dir.existsSync()) return null;
-    if (!parents && dir.existsSync()) {
+    final exists = dir.existsSync();
+    if (existOk && exists) return null;
+    if (!parents && exists) {
       throw OsCallException('Path.mkdir', 'Directory exists: $path');
     }
     dir.createSync(recursive: parents);
+
     return null;
   }
 
@@ -153,6 +159,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
       throw OsCallFileNotFoundError('Path.unlink', 'No such file: $path');
     }
     file.deleteSync();
+
     return null;
   }
 
@@ -163,6 +170,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
       throw OsCallFileNotFoundError('Path.rmdir', 'No such directory: $path');
     }
     dir.deleteSync();
+
     return null;
   }
 
@@ -170,6 +178,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
     final oldPath = _str(args.first);
     final newPath = _str(args[1]);
     _fs.file(oldPath).renameSync(newPath);
+
     return newPath;
   }
 
@@ -182,6 +191,7 @@ class MemoryFsOsCallHandler extends OsCallHandler {
         'No such directory: $path',
       );
     }
+
     return dir.listSync().map((e) => MontyPath(e.path)).toList();
   }
 }

--- a/lib/src/bridge/os_call/os_call_exception.dart
+++ b/lib/src/bridge/os_call/os_call_exception.dart
@@ -1,0 +1,37 @@
+/// Base exception for OS call handler errors.
+///
+/// Thrown by `OsCallHandler` implementations to signal domain errors.
+/// The bridge translates these into the corresponding Python exception
+/// types when resuming execution.
+class OsCallException implements Exception {
+  /// Creates an [OsCallException] for the given [operation] and [message].
+  const OsCallException(this.operation, this.message);
+
+  /// The operation that failed (e.g., `Path.read_text`, `os.getenv`).
+  final String operation;
+
+  /// Human-readable error message.
+  final String message;
+
+  @override
+  String toString() => 'OsCallException($operation): $message';
+}
+
+/// Thrown when an OS call is denied due to missing permissions or
+/// an unconfigured handler.
+class OsCallPermissionError extends OsCallException {
+  /// Creates an [OsCallPermissionError] for the given [operation].
+  const OsCallPermissionError(super.operation, super.message);
+
+  @override
+  String toString() => 'PermissionError($operation): $message';
+}
+
+/// Thrown when a file or directory referenced by an OS call does not exist.
+class OsCallFileNotFoundError extends OsCallException {
+  /// Creates an [OsCallFileNotFoundError] for the given [operation].
+  const OsCallFileNotFoundError(super.operation, super.message);
+
+  @override
+  String toString() => 'FileNotFoundError($operation): $message';
+}

--- a/lib/src/bridge/os_call/os_call_handler.dart
+++ b/lib/src/bridge/os_call/os_call_handler.dart
@@ -1,0 +1,23 @@
+import 'package:dart_monty/dart_monty.dart';
+
+/// Interface for handling OS-level calls from sandboxed Python code.
+///
+/// OS calls are triggered implicitly when Python accesses standard library
+/// modules like `pathlib`, `os`, or `datetime`. The interpreter pauses and
+/// yields a [MontyOsCall] describing the operation. The bridge invokes
+/// [handle] and resumes Python with the returned value.
+///
+/// Implementations should throw `OsCallException` (or subclasses) for
+/// domain errors (file not found, permission denied, etc.). The bridge
+/// translates these into the corresponding Python exception types.
+abstract class OsCallHandler {
+  /// Handles the OS call and returns the result to resume Python.
+  ///
+  /// Throw an `OsCallException` to resume Python with a typed error.
+  Future<Object?> handle(MontyOsCall call);
+
+  /// Lifecycle hook called when the bridge is disposed.
+  ///
+  /// Override to release resources (temp directories, open files, etc.).
+  Future<void> dispose() async {}
+}

--- a/lib/src/bridge/os_call/router_os_call_handler.dart
+++ b/lib/src/bridge/os_call/router_os_call_handler.dart
@@ -1,0 +1,64 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+
+/// Routes [MontyOsCall] operations to child handlers based on prefix matching.
+///
+/// Each entry in [handlers] maps an operation name prefix (e.g., `'Path.'`,
+/// `'os.'`, `'date.'`) to the [OsCallHandler] responsible for that group.
+///
+/// When multiple prefixes match, the longest prefix wins. If no prefix
+/// matches, the [fallback] handler is invoked. If no fallback is configured,
+/// an [UnsupportedError] is thrown.
+///
+/// ```dart
+/// final router = RouterOsCallHandler({
+///   'Path.': memoryFsHandler,
+///   'os.': envHandler,
+///   'date.': timeHandler,
+///   'datetime.': timeHandler,
+/// });
+/// ```
+class RouterOsCallHandler extends OsCallHandler {
+  /// Creates a router with the given prefix-to-handler mapping.
+  ///
+  /// [fallback] is invoked for operations that don't match any prefix.
+  RouterOsCallHandler(this.handlers, {this.fallback});
+
+  /// Prefix-to-handler mapping, checked longest-prefix-first.
+  final Map<String, OsCallHandler> handlers;
+
+  /// Optional fallback for unmatched operations.
+  final OsCallHandler? fallback;
+
+  /// Sorted prefixes, longest first (computed lazily).
+  late final List<String> _sortedPrefixes = handlers.keys.toList()
+    ..sort((a, b) => b.length.compareTo(a.length));
+
+  /// Returns the handler registered for [prefix], or `null`.
+  OsCallHandler? handlerFor(String prefix) => handlers[prefix];
+
+  @override
+  Future<Object?> handle(MontyOsCall call) {
+    final op = call.operationName;
+
+    for (final prefix in _sortedPrefixes) {
+      if (op.startsWith(prefix)) {
+        return handlers[prefix]!.handle(call);
+      }
+    }
+
+    if (fallback != null) return fallback!.handle(call);
+
+    throw UnsupportedError('No handler for OS operation: $op');
+  }
+
+  @override
+  Future<void> dispose() async {
+    final seen = <OsCallHandler>{};
+    for (final handler in handlers.values) {
+      // Same handler may be registered under multiple prefixes.
+      if (seen.add(handler)) await handler.dispose();
+    }
+    await fallback?.dispose();
+  }
+}

--- a/lib/src/bridge/os_call/sandboxed_native_fs_handler.dart
+++ b/lib/src/bridge/os_call/sandboxed_native_fs_handler.dart
@@ -24,6 +24,7 @@ class SandboxedNativeFsHandler extends OsCallHandler {
   /// paths inside this directory.
   factory SandboxedNativeFsHandler({required Directory root}) {
     final resolved = root.resolveSymbolicLinksSync();
+
     return SandboxedNativeFsHandler._(resolved);
   }
 
@@ -66,7 +67,7 @@ class SandboxedNativeFsHandler extends OsCallHandler {
       'Path.rename' => _rename(args),
       'Path.iterdir' => _iterdir(args),
       'Path.resolve' => _resolve(args),
-      'Path.absolute' => _safePath(op, _str(args[0])),
+      'Path.absolute' => _safePath(op, _str(args.first)),
       _ => throw UnsupportedError('Unsupported path operation: $op'),
     };
   }
@@ -87,6 +88,7 @@ class SandboxedNativeFsHandler extends OsCallHandler {
         'Path escapes sandbox: $pythonPath',
       );
     }
+
     return joined;
   }
 
@@ -103,84 +105,97 @@ class SandboxedNativeFsHandler extends OsCallHandler {
           'Symlink escapes sandbox: $pythonPath -> $resolved',
         );
       }
+
       return resolved;
     }
+
     return safe;
   }
 
   bool _exists(List<MontyValue> args) {
-    final safe = _safePath('Path.exists', _str(args[0]));
+    final safe = _safePath('Path.exists', _str(args.first));
+
     return FileSystemEntity.typeSync(safe) != FileSystemEntityType.notFound;
   }
 
   bool _isFile(List<MontyValue> args) {
-    final safe = _safePath('Path.is_file', _str(args[0]));
+    final safe = _safePath('Path.is_file', _str(args.first));
+
     return FileSystemEntity.typeSync(safe) == FileSystemEntityType.file;
   }
 
   bool _isDir(List<MontyValue> args) {
-    final safe = _safePath('Path.is_dir', _str(args[0]));
+    final safe = _safePath('Path.is_dir', _str(args.first));
+
     return FileSystemEntity.typeSync(safe) == FileSystemEntityType.directory;
   }
 
   bool _isSymlink(List<MontyValue> args) {
-    final safe = _safePath('Path.is_symlink', _str(args[0]));
+    final safe = _safePath('Path.is_symlink', _str(args.first));
+
     return FileSystemEntity.typeSync(safe, followLinks: false) ==
         FileSystemEntityType.link;
   }
 
   String _readText(List<MontyValue> args) {
-    final safe = _safeResolved('Path.read_text', _str(args[0]));
+    final safe = _safeResolved('Path.read_text', _str(args.first));
+
     return File(safe).readAsStringSync();
   }
 
   List<int> _readBytes(List<MontyValue> args) {
-    final safe = _safeResolved('Path.read_bytes', _str(args[0]));
+    final safe = _safeResolved('Path.read_bytes', _str(args.first));
+
     return File(safe).readAsBytesSync().toList();
   }
 
   int _writeText(List<MontyValue> args) {
-    final safe = _safePath('Path.write_text', _str(args[0]));
+    final safe = _safePath('Path.write_text', _str(args.first));
     final content = _str(args[1]);
     final file = File(safe);
     file.parent.createSync(recursive: true);
     file.writeAsStringSync(content);
+
     return content.length;
   }
 
   int _writeBytes(List<MontyValue> args) {
-    final safe = _safePath('Path.write_bytes', _str(args[0]));
+    final safe = _safePath('Path.write_bytes', _str(args.first));
     final bytes = (args[1].dartValue! as List).cast<int>();
     final file = File(safe);
     file.parent.createSync(recursive: true);
     file.writeAsBytesSync(bytes);
+
     return bytes.length;
   }
 
   Object? _mkdir(List<MontyValue> args, Map<String, MontyValue>? kwargs) {
-    final safe = _safePath('Path.mkdir', _str(args[0]));
+    final safe = _safePath('Path.mkdir', _str(args.first));
     final parents = kwargs?['parents']?.dartValue as bool? ?? false;
     final existOk = kwargs?['exist_ok']?.dartValue as bool? ?? false;
     final dir = Directory(safe);
     if (existOk && dir.existsSync()) return null;
     dir.createSync(recursive: parents);
+
     return null;
   }
 
   Object? _unlink(List<MontyValue> args) {
-    final safe = _safeResolved('Path.unlink', _str(args[0]));
+    final safe = _safeResolved('Path.unlink', _str(args.first));
     File(safe).deleteSync();
+
     return null;
   }
 
   Object? _rmdir(List<MontyValue> args) {
-    final safe = _safePath('Path.rmdir', _str(args[0]));
+    final safe = _safePath('Path.rmdir', _str(args.first));
     Directory(safe).deleteSync();
+
     return null;
   }
 
   String _rename(List<MontyValue> args) {
-    final oldSafe = _safeResolved('Path.rename', _str(args[0]));
+    final oldSafe = _safeResolved('Path.rename', _str(args.first));
     final newSafe = _safePath('Path.rename', _str(args[1]));
     File(oldSafe).renameSync(newSafe);
 
@@ -188,13 +203,13 @@ class SandboxedNativeFsHandler extends OsCallHandler {
   }
 
   List<MontyPath> _iterdir(List<MontyValue> args) {
-    final safe = _safePath('Path.iterdir', _str(args[0]));
+    final safe = _safePath('Path.iterdir', _str(args.first));
 
     return Directory(safe).listSync().map((e) => MontyPath(e.path)).toList();
   }
 
   String _resolve(List<MontyValue> args) =>
-      _safeResolved('Path.resolve', _str(args[0]));
+      _safeResolved('Path.resolve', _str(args.first));
 }
 
 String _str(MontyValue arg) => switch (arg) {

--- a/lib/src/bridge/os_call/sandboxed_native_fs_handler.dart
+++ b/lib/src/bridge/os_call/sandboxed_native_fs_handler.dart
@@ -1,0 +1,203 @@
+import 'dart:io';
+
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_exception.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+import 'package:path/path.dart' as p;
+
+/// Handles `Path.*` OS calls against the real filesystem, restricted to
+/// a `root` directory.
+///
+/// Every incoming path from Python is resolved to an absolute, normalized
+/// path and checked against `root`. Paths that escape the sandbox (via
+/// `../`, absolute paths outside root, or symlinks pointing outside) are
+/// rejected with `OsCallPermissionError`.
+///
+/// ```dart
+/// final tmp = Directory.systemTemp.createTempSync('monty_');
+/// final handler = SandboxedNativeFsHandler(root: tmp);
+/// ```
+class SandboxedNativeFsHandler extends OsCallHandler {
+  /// Creates a handler rooted at [root].
+  ///
+  /// [root] must exist. All Python file operations are restricted to
+  /// paths inside this directory.
+  factory SandboxedNativeFsHandler({required Directory root}) {
+    final resolved = root.resolveSymbolicLinksSync();
+    return SandboxedNativeFsHandler._(resolved);
+  }
+
+  SandboxedNativeFsHandler._(this._rootExact)
+    : _root = _rootExact.endsWith(Platform.pathSeparator)
+          ? _rootExact
+          : '$_rootExact${Platform.pathSeparator}';
+
+  /// Normalized root path WITH trailing separator (for startsWith checks).
+  final String _root;
+
+  /// Normalized root path WITHOUT trailing separator (for == checks).
+  final String _rootExact;
+
+  @override
+  Future<Object?> handle(MontyOsCall call) => Future.value(_handleSync(call));
+
+  @override
+  Future<void> dispose() async {
+    // We don't own the root directory — caller is responsible for cleanup.
+  }
+
+  Object? _handleSync(MontyOsCall call) {
+    final op = call.operationName;
+    final args = call.arguments;
+    final kwargs = call.kwargs;
+
+    return switch (op) {
+      'Path.exists' => _exists(args),
+      'Path.is_file' => _isFile(args),
+      'Path.is_dir' => _isDir(args),
+      'Path.is_symlink' => _isSymlink(args),
+      'Path.read_text' => _readText(args),
+      'Path.read_bytes' => _readBytes(args),
+      'Path.write_text' => _writeText(args),
+      'Path.write_bytes' => _writeBytes(args),
+      'Path.mkdir' => _mkdir(args, kwargs),
+      'Path.unlink' => _unlink(args),
+      'Path.rmdir' => _rmdir(args),
+      'Path.rename' => _rename(args),
+      'Path.iterdir' => _iterdir(args),
+      'Path.resolve' => _resolve(args),
+      'Path.absolute' => _safePath(op, _str(args[0])),
+      _ => throw UnsupportedError('Unsupported path operation: $op'),
+    };
+  }
+
+  /// Resolves a Python path to a safe absolute path inside the sandbox.
+  ///
+  /// The path from Python may be absolute (e.g., `/sandbox/foo`) or
+  /// relative. We join it with [_rootExact], normalize, and verify it
+  /// does not escape.
+  String _safePath(String op, String pythonPath) {
+    final joined = p.isAbsolute(pythonPath)
+        ? p.normalize(pythonPath)
+        : p.normalize(p.join(_rootExact, pythonPath));
+
+    if (joined != _rootExact && !joined.startsWith(_root)) {
+      throw OsCallPermissionError(
+        op,
+        'Path escapes sandbox: $pythonPath',
+      );
+    }
+    return joined;
+  }
+
+  /// Like [_safePath] but also resolves symlinks and re-checks.
+  String _safeResolved(String op, String pythonPath) {
+    final safe = _safePath(op, pythonPath);
+    // Only resolve symlinks if the target exists.
+    final type = FileSystemEntity.typeSync(safe, followLinks: false);
+    if (type != FileSystemEntityType.notFound) {
+      final resolved = File(safe).resolveSymbolicLinksSync();
+      if (resolved != _rootExact && !resolved.startsWith(_root)) {
+        throw OsCallPermissionError(
+          op,
+          'Symlink escapes sandbox: $pythonPath -> $resolved',
+        );
+      }
+      return resolved;
+    }
+    return safe;
+  }
+
+  bool _exists(List<MontyValue> args) {
+    final safe = _safePath('Path.exists', _str(args[0]));
+    return FileSystemEntity.typeSync(safe) != FileSystemEntityType.notFound;
+  }
+
+  bool _isFile(List<MontyValue> args) {
+    final safe = _safePath('Path.is_file', _str(args[0]));
+    return FileSystemEntity.typeSync(safe) == FileSystemEntityType.file;
+  }
+
+  bool _isDir(List<MontyValue> args) {
+    final safe = _safePath('Path.is_dir', _str(args[0]));
+    return FileSystemEntity.typeSync(safe) == FileSystemEntityType.directory;
+  }
+
+  bool _isSymlink(List<MontyValue> args) {
+    final safe = _safePath('Path.is_symlink', _str(args[0]));
+    return FileSystemEntity.typeSync(safe, followLinks: false) ==
+        FileSystemEntityType.link;
+  }
+
+  String _readText(List<MontyValue> args) {
+    final safe = _safeResolved('Path.read_text', _str(args[0]));
+    return File(safe).readAsStringSync();
+  }
+
+  List<int> _readBytes(List<MontyValue> args) {
+    final safe = _safeResolved('Path.read_bytes', _str(args[0]));
+    return File(safe).readAsBytesSync().toList();
+  }
+
+  int _writeText(List<MontyValue> args) {
+    final safe = _safePath('Path.write_text', _str(args[0]));
+    final content = _str(args[1]);
+    final file = File(safe);
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+    return content.length;
+  }
+
+  int _writeBytes(List<MontyValue> args) {
+    final safe = _safePath('Path.write_bytes', _str(args[0]));
+    final bytes = (args[1].dartValue! as List).cast<int>();
+    final file = File(safe);
+    file.parent.createSync(recursive: true);
+    file.writeAsBytesSync(bytes);
+    return bytes.length;
+  }
+
+  Object? _mkdir(List<MontyValue> args, Map<String, MontyValue>? kwargs) {
+    final safe = _safePath('Path.mkdir', _str(args[0]));
+    final parents = kwargs?['parents']?.dartValue as bool? ?? false;
+    final existOk = kwargs?['exist_ok']?.dartValue as bool? ?? false;
+    final dir = Directory(safe);
+    if (existOk && dir.existsSync()) return null;
+    dir.createSync(recursive: parents);
+    return null;
+  }
+
+  Object? _unlink(List<MontyValue> args) {
+    final safe = _safeResolved('Path.unlink', _str(args[0]));
+    File(safe).deleteSync();
+    return null;
+  }
+
+  Object? _rmdir(List<MontyValue> args) {
+    final safe = _safePath('Path.rmdir', _str(args[0]));
+    Directory(safe).deleteSync();
+    return null;
+  }
+
+  String _rename(List<MontyValue> args) {
+    final oldSafe = _safeResolved('Path.rename', _str(args[0]));
+    final newSafe = _safePath('Path.rename', _str(args[1]));
+    File(oldSafe).renameSync(newSafe);
+
+    return newSafe;
+  }
+
+  List<MontyPath> _iterdir(List<MontyValue> args) {
+    final safe = _safePath('Path.iterdir', _str(args[0]));
+
+    return Directory(safe).listSync().map((e) => MontyPath(e.path)).toList();
+  }
+
+  String _resolve(List<MontyValue> args) =>
+      _safeResolved('Path.resolve', _str(args[0]));
+}
+
+String _str(MontyValue arg) => switch (arg) {
+  MontyString(:final value) || MontyPath(:final value) => value,
+  _ => throw ArgumentError('Expected string or path, got: $arg'),
+};

--- a/lib/src/bridge/os_call/sandboxed_native_fs_handler_stub.dart
+++ b/lib/src/bridge/os_call/sandboxed_native_fs_handler_stub.dart
@@ -1,0 +1,2 @@
+// Stub — SandboxedNativeFsHandler is only available on native platforms.
+// This file exists so the conditional export resolves on web/stub targets.

--- a/lib/src/bridge/os_call/time_os_call_handler.dart
+++ b/lib/src/bridge/os_call/time_os_call_handler.dart
@@ -1,0 +1,50 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
+
+/// Handles `date.*` and `datetime.*` OS calls.
+///
+/// Accepts an injectable `clock` function for deterministic testing.
+/// When no clock is provided, uses `DateTime.now`.
+///
+/// Register under both `'date.'` and `'datetime.'` prefixes in the router:
+/// ```dart
+/// final time = TimeOsCallHandler(clock: () => DateTime(2026, 1, 1));
+/// RouterOsCallHandler({
+///   'date.': time,
+///   'datetime.': time,
+/// });
+/// ```
+class TimeOsCallHandler extends OsCallHandler {
+  /// Creates a handler with an optional frozen [clock].
+  TimeOsCallHandler({DateTime Function()? clock})
+    : _clock = clock ?? DateTime.now;
+
+  final DateTime Function() _clock;
+
+  @override
+  Future<Object?> handle(MontyOsCall call) {
+    final now = _clock();
+
+    return Future.value(switch (call.operationName) {
+      'date.today' => {
+        '__type': 'date',
+        'year': now.year,
+        'month': now.month,
+        'day': now.day,
+      },
+      'datetime.now' => {
+        '__type': 'datetime',
+        'year': now.year,
+        'month': now.month,
+        'day': now.day,
+        'hour': now.hour,
+        'minute': now.minute,
+        'second': now.second,
+        'microsecond': now.microsecond,
+        'offset_seconds': now.timeZoneOffset.inSeconds,
+        'timezone_name': now.timeZoneName,
+      },
+      final op => throw UnsupportedError('Unsupported datetime operation: $op'),
+    });
+  }
+}

--- a/lib/src/bridge/plugins/sandbox_plugin.dart
+++ b/lib/src/bridge/plugins/sandbox_plugin.dart
@@ -241,6 +241,7 @@ class SandboxPlugin extends MontyPlugin {
     this.childLimits,
     this.sandboxBaseDir,
     this.systemPromptBuilder,
+    this.parentOsCallHandler,
   });
 
   /// Creates a fresh [MontyPlatform] for each child.
@@ -283,6 +284,14 @@ class SandboxPlugin extends MontyPlugin {
   /// string (if non-null) is prepended before any runtime `system_prompt`
   /// argument from `sandbox_spawn`.
   final ChildSystemPromptBuilder? systemPromptBuilder;
+
+  /// Optional OS call handler from the parent bridge.
+  ///
+  /// When provided, each child gets an isolated VFS with its own
+  /// `MemoryFsOsCallHandler`. Time and environment handlers are shared
+  /// from the parent (if the parent uses a `RouterOsCallHandler`).
+  /// When null, children have no OS call access.
+  final OsCallHandler? parentOsCallHandler;
 
   final Map<int, _ChildHandle> _children = {};
   int _nextId = 0;
@@ -484,6 +493,11 @@ class SandboxPlugin extends MontyPlugin {
         },
       );
 
+      final childOsHandler = _buildChildOsCallHandler();
+      if (childOsHandler != null) {
+        bridge.registerOsCallHandler(childOsHandler);
+      }
+
       childRegistry = await _wireChildPlugins(
         spawnContext,
         bridge,
@@ -676,6 +690,34 @@ class SandboxPlugin extends MontyPlugin {
     childPlugins.forEach(registry.register);
 
     return registry;
+  }
+
+  /// Builds an isolated [OsCallHandler] for a child sandbox.
+  ///
+  /// Each child gets a fresh [MemoryFsOsCallHandler] (isolated VFS).
+  /// Time and environment handlers are shared from the parent's router
+  /// if available. Returns `null` when no parent handler is configured.
+  OsCallHandler? _buildChildOsCallHandler() {
+    final parent = parentOsCallHandler;
+    if (parent == null) return null;
+
+    if (parent is RouterOsCallHandler) {
+      final childHandlers = <String, OsCallHandler>{
+        'Path.': MemoryFsOsCallHandler(),
+      };
+      // Share env and time handlers from parent.
+      for (final prefix in const ['os.', 'date.', 'datetime.']) {
+        final handler = parent.handlerFor(prefix);
+        if (handler != null) childHandlers[prefix] = handler;
+      }
+
+      return RouterOsCallHandler(childHandlers);
+    }
+
+    // Non-router parent: give child an isolated VFS only.
+    return RouterOsCallHandler({
+      'Path.': MemoryFsOsCallHandler(),
+    });
   }
 
   /// Concatenates builder + runtime prompt layers.

--- a/lib/src/ffi/native_bindings_ffi.dart
+++ b/lib/src/ffi/native_bindings_ffi.dart
@@ -3,7 +3,8 @@
 import 'dart:ffi';
 import 'dart:typed_data';
 
-import 'package:dart_monty/dart_monty.dart' show MontyException;
+import 'package:dart_monty/dart_monty.dart'
+    show MontyException, MontyScriptError;
 import 'package:dart_monty/src/ffi/generated/dart_monty_bindings.dart'
     as ffi_native;
 import 'package:dart_monty/src/ffi/native_bindings.dart';
@@ -40,8 +41,17 @@ class NativeBindingsFfi extends NativeBindings {
         outError,
       );
       if (handle == nullptr) {
-        final errorMsg = _readAndFreeString(outError.value);
-        throw MontyException(message: errorMsg ?? 'monty_create returned null');
+        final errorMsg = _readAndFreeString(outError.value) ??
+            'monty_create returned null';
+        // Parse errors (SyntaxError, etc.) are script errors — throw
+        // MontyScriptError so callers using `on MontyScriptError` catch them.
+        final excType = _extractExcType(errorMsg);
+        final exception = MontyException(message: errorMsg, excType: excType);
+        throw MontyScriptError(
+          errorMsg,
+          excType: excType,
+          exception: exception,
+        );
       }
 
       return handle.address;
@@ -320,5 +330,22 @@ class NativeBindingsFfi extends NativeBindings {
     ffi_native.monty_string_free(ptr);
 
     return str;
+  }
+
+  /// Extracts the Python exception type from a "Type: message" error string.
+  ///
+  /// Returns `null` if no colon-separated prefix is found.
+  static String? _extractExcType(String message) {
+    final colonIdx = message.indexOf(':');
+    if (colonIdx <= 0) return null;
+    final prefix = message.substring(0, colonIdx);
+    // Only treat it as an exc type if it looks like a Python identifier
+    // (e.g. "SyntaxError", "ValueError").
+    if (RegExp(r'^[A-Z][a-zA-Z]*(?:Error|Exception|Warning)$')
+        .hasMatch(prefix)) {
+      return prefix;
+    }
+
+    return null;
   }
 }

--- a/lib/src/ffi/native_bindings_ffi.dart
+++ b/lib/src/ffi/native_bindings_ffi.dart
@@ -41,8 +41,8 @@ class NativeBindingsFfi extends NativeBindings {
         outError,
       );
       if (handle == nullptr) {
-        final errorMsg = _readAndFreeString(outError.value) ??
-            'monty_create returned null';
+        final errorMsg =
+            _readAndFreeString(outError.value) ?? 'monty_create returned null';
         // Parse errors (SyntaxError, etc.) are script errors — throw
         // MontyScriptError so callers using `on MontyScriptError` catch them.
         final excType = _extractExcType(errorMsg);
@@ -341,8 +341,9 @@ class NativeBindingsFfi extends NativeBindings {
     final prefix = message.substring(0, colonIdx);
     // Only treat it as an exc type if it looks like a Python identifier
     // (e.g. "SyntaxError", "ValueError").
-    if (RegExp(r'^[A-Z][a-zA-Z]*(?:Error|Exception|Warning)$')
-        .hasMatch(prefix)) {
+    if (RegExp(
+      r'^[A-Z][a-zA-Z]*(?:Error|Exception|Warning)$',
+    ).hasMatch(prefix)) {
       return prefix;
     }
 

--- a/lib/src/platform/monty_progress.dart
+++ b/lib/src/platform/monty_progress.dart
@@ -202,7 +202,7 @@ final class MontyPending extends MontyProgress {
 /// Execution paused, awaiting an OS/filesystem operation.
 ///
 /// Yielded when Python code accesses `pathlib`, `os.getenv`, `os.environ`,
-/// `date.today()`, `datetime.now()`, or similar OS-level operations.
+/// or similar OS-level operations.
 /// The host (Dart) handles the I/O and resumes with the result.
 ///
 /// ```dart
@@ -241,8 +241,7 @@ final class MontyOsCall extends MontyProgress {
     );
   }
 
-  /// The OS operation name, e.g. `"Path.read_text"`, `"os.getenv"`,
-  /// `"date.today"`.
+  /// The OS operation name, e.g. `"Path.read_text"`, `"os.getenv"`.
   final String operationName;
 
   /// The positional arguments for the operation.

--- a/lib/src/platform/monty_session.dart
+++ b/lib/src/platform/monty_session.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
 import 'package:dart_monty/src/platform/monty_error.dart';
 import 'package:dart_monty/src/platform/monty_exception.dart';
 import 'package:dart_monty/src/platform/monty_limits.dart';
@@ -66,9 +69,18 @@ class MontySession {
   ///
   /// The session does not take ownership of the platform — calling
   /// [dispose] on the session does NOT dispose the underlying platform.
-  MontySession({required MontyPlatform platform}) : _platform = platform;
+  ///
+  /// If [osCallHandler] is provided, OS calls (pathlib, os.getenv,
+  /// datetime) are dispatched through it during [run]. Without a handler,
+  /// OS calls resume with an error.
+  MontySession({
+    required MontyPlatform platform,
+    OsCallHandler? osCallHandler,
+  }) : _platform = platform,
+       _osCallHandler = osCallHandler;
 
   final MontyPlatform _platform;
+  final OsCallHandler? _osCallHandler;
   Map<String, Object?> _state = {};
   bool _disposed = false;
 
@@ -122,9 +134,18 @@ class MontySession {
           progress = await _safeResume(null);
 
         case MontyOsCall():
-          progress = await _safeResumeWithError(
-            'OS operations not available in session run() mode',
-          );
+          if (_osCallHandler != null) {
+            try {
+              final result = await _osCallHandler.handle(progress);
+              progress = await _safeResume(result);
+            } on Object catch (e) {
+              progress = await _safeResumeWithError(e.toString());
+            }
+          } else {
+            progress = await _safeResumeWithError(
+              'OS operations not available — no OsCallHandler configured',
+            );
+          }
       }
     }
   }
@@ -196,10 +217,12 @@ class MontySession {
 
   /// Disposes the session.
   ///
-  /// Clears persisted state. Does NOT dispose the underlying [MontyPlatform].
+  /// Clears persisted state and disposes the [OsCallHandler] if one was
+  /// provided. Does NOT dispose the underlying [MontyPlatform].
   void dispose() {
     _state = {};
     _disposed = true;
+    unawaited(_osCallHandler?.dispose());
   }
 
   /// Whether this session has been disposed.

--- a/lib/src/platform/testing/ladder_runner.dart
+++ b/lib/src/platform/testing/ladder_runner.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dart_monty/src/bridge/os_call/os_call_handler.dart';
 import 'package:dart_monty/src/platform/monty_error.dart';
 import 'package:dart_monty/src/platform/monty_exception.dart';
 import 'package:dart_monty/src/platform/monty_future_capable.dart';
@@ -32,11 +33,6 @@ List<(String, List<Map<String, dynamic>>)> loadLadderFixtures(Directory dir) {
   ];
 }
 
-/// Callback type for handling OsCall progress in the ladder runner.
-///
-/// Receives the [MontyOsCall] and returns the value to resume with.
-typedef LadderOsCallHandler = Future<Object?> Function(MontyOsCall call);
-
 /// Runs a simple (non-error, non-iterative) fixture through [platform].
 Future<void> runSimpleFixture(
   MontyPlatform platform,
@@ -55,7 +51,7 @@ Future<void> runSimpleFixture(
 Future<void> runOsCallFixture(
   MontyPlatform platform,
   Map<String, dynamic> fixture,
-  LadderOsCallHandler osCallHandler,
+  OsCallHandler osCallHandler,
 ) async {
   final code = fixture['code'] as String;
   final expectError = fixture['expectError'] as bool? ?? false;
@@ -70,7 +66,7 @@ Future<void> runOsCallFixture(
     while (progress is! MontyComplete) {
       if (progress is MontyOsCall) {
         try {
-          final result = await osCallHandler(progress);
+          final result = await osCallHandler.handle(progress);
           progress = await platform.resume(result);
         } on Object catch (e) {
           progress = await platform.resumeWithError(e.toString());
@@ -351,7 +347,7 @@ Future<void> runIterativeFixture(
 void registerLadderTests({
   required MontyPlatform Function() createPlatform,
   required Directory fixtureDir,
-  LadderOsCallHandler? osCallHandler,
+  OsCallHandler? osCallHandler,
   bool isWeb = false,
 }) {
   final tiers = loadLadderFixtures(fixtureDir);
@@ -423,7 +419,7 @@ Future<void> _runFixture(
   String code,
   bool expectError,
   bool osCall,
-  LadderOsCallHandler? osCallHandler,
+  OsCallHandler? osCallHandler,
 ) async {
   if (osCall && osCallHandler != null) {
     await runOsCallFixture(monty, fixture, osCallHandler);

--- a/packages/dart_monty_wasm/assets/dart_monty_bridge.js
+++ b/packages/dart_monty_wasm/assets/dart_monty_bridge.js
@@ -1,0 +1,238 @@
+(() => {
+  // src/bridge.js
+  var nextSessionId = 1;
+  var sessions = /* @__PURE__ */ new Map();
+  var defaultSessionId = null;
+  var _bridgeBase = typeof document !== "undefined" && document.currentScript ? new URL(".", document.currentScript.src).href : window.location.href;
+  function createSession() {
+    return new Promise((resolve, reject) => {
+      const sessionId = nextSessionId++;
+      try {
+        const workerUrl = new URL("./dart_monty_worker.js", _bridgeBase).href;
+        const blob = new Blob(
+          [`import "${workerUrl}";`],
+          { type: "application/javascript" }
+        );
+        const blobUrl = URL.createObjectURL(blob);
+        const worker = new Worker(blobUrl, { type: "module" });
+        worker.onerror = (event) => {
+          const session = sessions.get(sessionId);
+          if (session) {
+            for (const req of session.pending.values()) {
+              if (req.timer) clearTimeout(req.timer);
+              req.reject(new Error(`Panic: Worker crashed: ${event.message || event}`));
+            }
+            session.pending.clear();
+            sessions.delete(sessionId);
+            if (defaultSessionId === sessionId) defaultSessionId = null;
+          }
+          reject(new Error(`Worker failed to start: ${event.message || event}`));
+        };
+        worker.onmessage = (e) => {
+          const msg = e.data;
+          if (msg.type === "ready") {
+            URL.revokeObjectURL(blobUrl);
+            sessions.set(sessionId, {
+              worker,
+              nextMsgId: 1,
+              pending: /* @__PURE__ */ new Map(),
+              timeoutMs: null
+            });
+            console.log(`[DartMontyBridge] Session ${sessionId} ready`);
+            resolve(sessionId);
+            return;
+          }
+          if (msg.type === "error" && !msg.id) {
+            console.error(`[DartMontyBridge] Session ${sessionId} init error:`, msg.message);
+            reject(new Error(msg.message || "Worker init failed"));
+            return;
+          }
+          const session = sessions.get(sessionId);
+          if (!session) return;
+          if (msg.id && session.pending.has(msg.id)) {
+            const req = session.pending.get(msg.id);
+            if (req.timer) clearTimeout(req.timer);
+            session.pending.delete(msg.id);
+            req.resolve(msg);
+          }
+        };
+      } catch (e) {
+        reject(new Error(`Failed to create Worker: ${e.message}`));
+      }
+    });
+  }
+  function disposeSession(sessionId) {
+    const session = sessions.get(sessionId);
+    if (!session) return;
+    for (const req of session.pending.values()) {
+      if (req.timer) clearTimeout(req.timer);
+      req.reject(new Error("MontyDisposed: Session disposed"));
+    }
+    session.pending.clear();
+    session.worker.terminate();
+    sessions.delete(sessionId);
+    if (defaultSessionId === sessionId) defaultSessionId = null;
+  }
+  function callWorker(sessionId, msg, timeoutMs) {
+    return new Promise((resolve, reject) => {
+      const session = sessions.get(sessionId);
+      if (!session) {
+        reject(new Error(`Session ${sessionId} not found`));
+        return;
+      }
+      const msgId = session.nextMsgId++;
+      let timer = null;
+      if (timeoutMs != null && timeoutMs > 0) {
+        timer = setTimeout(() => {
+          for (const req of session.pending.values()) {
+            if (req.timer) clearTimeout(req.timer);
+            req.reject(new Error("MontyWorkerError: Execution timed out"));
+          }
+          session.pending.clear();
+          session.worker.terminate();
+          sessions.delete(sessionId);
+          if (defaultSessionId === sessionId) defaultSessionId = null;
+        }, timeoutMs);
+      }
+      session.pending.set(msgId, { resolve, reject, timer });
+      session.worker.postMessage({ ...msg, id: msgId });
+    });
+  }
+  function notInitializedError() {
+    return JSON.stringify({ ok: false, error: "Not initialized", errorType: "InitError" });
+  }
+  function resolveSessionId(sessionId) {
+    if (sessionId != null) return sessionId;
+    return defaultSessionId;
+  }
+  function parseHardTimeout(limitsJson) {
+    if (!limitsJson) return null;
+    const limits = typeof limitsJson === "string" ? JSON.parse(limitsJson) : limitsJson;
+    if (limits.timeout_ms != null) {
+      return limits.timeout_ms + 1e3;
+    }
+    return null;
+  }
+  async function init() {
+    if (defaultSessionId != null && sessions.has(defaultSessionId)) return true;
+    try {
+      defaultSessionId = await createSession();
+      return true;
+    } catch (e) {
+      console.error("[DartMontyBridge] Init failed:", e.message);
+      return false;
+    }
+  }
+  async function run(code, limitsJson, scriptName) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const hardTimeout = parseHardTimeout(limitsJson);
+    if (hardTimeout != null) session.timeoutMs = hardTimeout;
+    const limits = limitsJson ? JSON.parse(limitsJson) : null;
+    const msg = { type: "run", code, limits };
+    if (scriptName) msg.scriptName = scriptName;
+    const result = await callWorker(sid, msg, session.timeoutMs);
+    return JSON.stringify(result);
+  }
+  async function start(code, extFnsJson, limitsJson, scriptName) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const hardTimeout = parseHardTimeout(limitsJson);
+    if (hardTimeout != null) session.timeoutMs = hardTimeout;
+    const extFns = extFnsJson ? JSON.parse(extFnsJson) : [];
+    const limits = limitsJson ? JSON.parse(limitsJson) : null;
+    const msg = { type: "start", code, extFns, limits };
+    if (scriptName) msg.scriptName = scriptName;
+    const result = await callWorker(sid, msg, session.timeoutMs);
+    return JSON.stringify(result);
+  }
+  async function resume(valueJson) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const value = JSON.parse(valueJson);
+    const result = await callWorker(sid, { type: "resume", value }, session.timeoutMs);
+    return JSON.stringify(result);
+  }
+  async function resumeWithError(errorJson) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const errorMessage = JSON.parse(errorJson);
+    const result = await callWorker(sid, { type: "resumeWithError", errorMessage }, session.timeoutMs);
+    return JSON.stringify(result);
+  }
+  async function resumeAsFuture() {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const result = await callWorker(sid, { type: "resumeAsFuture" }, session.timeoutMs);
+    return JSON.stringify(result);
+  }
+  async function resolveFutures(resultsJson, errorsJson) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const result = await callWorker(
+      sid,
+      { type: "resolveFutures", resultsJson, errorsJson },
+      session.timeoutMs
+    );
+    return JSON.stringify(result);
+  }
+  async function snapshot() {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) {
+      return { ok: false, error: "Not initialized" };
+    }
+    const session = sessions.get(sid);
+    const result = await callWorker(sid, { type: "snapshot" }, session.timeoutMs);
+    return result;
+  }
+  async function restore(dataBase64) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const result = await callWorker(sid, { type: "restore", dataBase64 }, session.timeoutMs);
+    return JSON.stringify(result);
+  }
+  function discover() {
+    return JSON.stringify({
+      loaded: sessions.size > 0,
+      sessionCount: sessions.size,
+      architecture: "worker-pool"
+    });
+  }
+  async function dispose() {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) {
+      return JSON.stringify({ ok: true });
+    }
+    try {
+      await callWorker(sid, { type: "dispose" }, 5e3);
+    } catch (_) {
+    }
+    disposeSession(sid);
+    return JSON.stringify({ ok: true });
+  }
+  window.DartMontyBridge = {
+    init,
+    run,
+    start,
+    resume,
+    resumeWithError,
+    resumeAsFuture,
+    resolveFutures,
+    snapshot,
+    restore,
+    discover,
+    dispose,
+    // Phase 2 multi-session API
+    createSession,
+    disposeSession,
+    getDefaultSessionId: () => defaultSessionId
+  };
+  console.log("[DartMontyBridge] Registered on window (Worker pool architecture)");
+})();

--- a/packages/dart_monty_wasm/assets/dart_monty_worker.js
+++ b/packages/dart_monty_wasm/assets/dart_monty_worker.js
@@ -1,0 +1,776 @@
+// src/wasm_glue.js
+function createWasiImports(getMemory) {
+  return {
+    random_get(buf, bufLen) {
+      const mem = new Uint8Array(getMemory().buffer);
+      for (let i = 0; i < bufLen; i += 65536) {
+        const chunk = Math.min(65536, bufLen - i);
+        crypto.getRandomValues(mem.subarray(buf + i, buf + i + chunk));
+      }
+      return 0;
+    },
+    // CLOCK_REALTIME = 0, CLOCK_MONOTONIC = 1
+    clock_time_get(id, _precision, out) {
+      const mem = new DataView(getMemory().buffer);
+      let nowNs;
+      if (id === 0) {
+        nowNs = BigInt(Date.now()) * 1000000n;
+      } else {
+        nowNs = BigInt(Math.round(performance.now() * 1e6));
+      }
+      mem.setBigUint64(out, nowNs, true);
+      return 0;
+    },
+    fd_write(fd, iovs, iovsLen, nwritten) {
+      const mem = new DataView(getMemory().buffer);
+      const bytes = new Uint8Array(getMemory().buffer);
+      let totalWritten = 0;
+      const parts = [];
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = mem.getUint32(iovs + i * 8, true);
+        const len = mem.getUint32(iovs + i * 8 + 4, true);
+        parts.push(new TextDecoder().decode(bytes.subarray(ptr, ptr + len)));
+        totalWritten += len;
+      }
+      const text = parts.join("");
+      if (fd === 1) console.log("[monty]", text);
+      else if (fd === 2) console.warn("[monty]", text);
+      mem.setUint32(nwritten, totalWritten, true);
+      return 0;
+    },
+    environ_get() {
+      return 0;
+    },
+    environ_sizes_get(countOut, bufsizeOut) {
+      const mem = new DataView(getMemory().buffer);
+      mem.setUint32(countOut, 0, true);
+      mem.setUint32(bufsizeOut, 0, true);
+      return 0;
+    },
+    proc_exit(code) {
+      throw new Error(`WASI proc_exit called with code ${code}`);
+    }
+  };
+}
+var wasm = null;
+async function instantiateMonty(wasmUrl) {
+  let memory;
+  const wasiImports = createWasiImports(() => memory);
+  const imports = { wasi_snapshot_preview1: wasiImports };
+  let instance;
+  try {
+    const result = await WebAssembly.instantiateStreaming(
+      fetch(wasmUrl),
+      imports
+    );
+    instance = result.instance;
+  } catch (e) {
+    if (e instanceof TypeError || e.message && e.message.includes("Mime")) {
+      const resp = await fetch(wasmUrl);
+      const bytes = await resp.arrayBuffer();
+      const result = await WebAssembly.instantiate(bytes, imports);
+      instance = result.instance;
+    } else {
+      throw e;
+    }
+  }
+  wasm = instance.exports;
+  memory = wasm.memory;
+  return wasm;
+}
+var encoder = new TextEncoder();
+var decoder = new TextDecoder();
+function allocCString(str) {
+  const encoded = encoder.encode(str);
+  const size = encoded.length + 1;
+  const ptr = wasm.monty_alloc(size);
+  if (ptr === 0) throw new Error(`monty_alloc(${size}) returned null \u2014 OOM`);
+  const mem = new Uint8Array(wasm.memory.buffer);
+  mem.set(encoded, ptr);
+  mem[ptr + encoded.length] = 0;
+  return { ptr, size };
+}
+function readCString(ptr) {
+  if (ptr === 0) return null;
+  const mem = new Uint8Array(wasm.memory.buffer);
+  let end = ptr;
+  while (end < mem.length && mem[end] !== 0) end++;
+  return decoder.decode(mem.subarray(ptr, end));
+}
+function readAndFreeCString(ptr) {
+  if (ptr === 0) return null;
+  const str = readCString(ptr);
+  wasm.monty_string_free(ptr);
+  return str;
+}
+function allocOutPtr() {
+  const ptr = wasm.monty_alloc(4);
+  if (ptr === 0) throw new Error("monty_alloc(4) returned null \u2014 OOM");
+  return {
+    ptr,
+    read() {
+      return new DataView(wasm.memory.buffer).getUint32(ptr, true);
+    },
+    free() {
+      wasm.monty_dealloc(ptr, 4);
+    }
+  };
+}
+var PROGRESS_COMPLETE = 0;
+var PROGRESS_PENDING = 1;
+var PROGRESS_ERROR = 2;
+var PROGRESS_RESOLVE_FUTURES = 3;
+var PROGRESS_OS_CALL = 4;
+var RESULT_OK = 0;
+
+// src/worker_src.js
+var wasm2 = null;
+async function initWasm() {
+  const wasmUrl = new URL("./dart_monty_native.wasm", import.meta.url);
+  wasm2 = await instantiateMonty(wasmUrl);
+  self.postMessage({
+    type: "ready",
+    exports: Object.keys(wasm2).filter((k) => k.startsWith("monty_"))
+  });
+}
+function adaptResultForDart(cabiResultJson, isError) {
+  const parsed = JSON.parse(cabiResultJson);
+  if (isError) {
+    const err = parsed.error && typeof parsed.error === "object" ? parsed.error : { message: parsed.error ? String(parsed.error) : "Unknown error" };
+    return {
+      ok: false,
+      error: err.message || String(err),
+      errorType: err.exc_type || "MontyException",
+      excType: err.exc_type || null,
+      traceback: err.traceback || null
+    };
+  }
+  return {
+    ok: true,
+    value: parsed.value,
+    print_output: parsed.print_output || null
+  };
+}
+function readProgress(id, handle, tag, errMsg) {
+  switch (tag) {
+    case PROGRESS_COMPLETE: {
+      const isErr = wasm2.monty_complete_is_error(handle);
+      const ptr = wasm2.monty_complete_result_json(handle);
+      const json = readAndFreeCString(ptr);
+      if (json) {
+        const adapted = adaptResultForDart(json, isErr === 1);
+        return { type: "result", id, ...adapted, state: adapted.ok ? "complete" : void 0 };
+      }
+      if (isErr === 1) {
+        return {
+          type: "result",
+          id,
+          ok: false,
+          error: "Execution failed (no error context)",
+          errorType: "MontyException"
+        };
+      }
+      return { type: "result", id, ok: true, state: "complete", value: null };
+    }
+    case PROGRESS_PENDING: {
+      const fnName = readAndFreeCString(wasm2.monty_pending_fn_name(handle));
+      const argsJson = readAndFreeCString(wasm2.monty_pending_fn_args_json(handle));
+      const kwargsJson = readAndFreeCString(wasm2.monty_pending_fn_kwargs_json(handle));
+      const callId = wasm2.monty_pending_call_id(handle);
+      const methodCall = wasm2.monty_pending_method_call(handle);
+      return {
+        type: "result",
+        id,
+        ok: true,
+        state: "pending",
+        functionName: fnName,
+        args: argsJson ? JSON.parse(argsJson) : [],
+        kwargs: kwargsJson ? JSON.parse(kwargsJson) : {},
+        callId,
+        methodCall: methodCall === 1
+      };
+    }
+    case PROGRESS_OS_CALL: {
+      const fnName = readAndFreeCString(wasm2.monty_os_call_fn_name(handle));
+      const argsJson = readAndFreeCString(wasm2.monty_os_call_args_json(handle));
+      const kwargsJson = readAndFreeCString(wasm2.monty_os_call_kwargs_json(handle));
+      const callId = wasm2.monty_os_call_id(handle);
+      return {
+        type: "result",
+        id,
+        ok: true,
+        state: "os_call",
+        functionName: fnName,
+        args: argsJson ? JSON.parse(argsJson) : [],
+        kwargs: kwargsJson ? JSON.parse(kwargsJson) : {},
+        callId
+      };
+    }
+    case PROGRESS_RESOLVE_FUTURES: {
+      const idsPtr = wasm2.monty_pending_future_call_ids(handle);
+      const idsJson = readAndFreeCString(idsPtr);
+      return {
+        type: "result",
+        id,
+        ok: true,
+        state: "resolve_futures",
+        pendingCallIds: idsJson ? JSON.parse(idsJson) : []
+      };
+    }
+    case PROGRESS_ERROR:
+      return {
+        type: "result",
+        id,
+        ok: false,
+        error: errMsg || "Unknown error",
+        errorType: "MontyException"
+      };
+    default:
+      return {
+        type: "result",
+        id,
+        ok: false,
+        error: `Unknown progress tag: ${tag}`,
+        errorType: "InternalError"
+      };
+  }
+}
+var activeHandle = null;
+function handleRun(id, code, limits, scriptName) {
+  let cCode = null;
+  let cName = null;
+  let outError = null;
+  let handle;
+  try {
+    outError = allocOutPtr();
+    cCode = allocCString(code);
+    cName = scriptName ? allocCString(scriptName) : null;
+    handle = wasm2.monty_create(cCode.ptr, 0, cName ? cName.ptr : 0, outError.ptr);
+  } catch (e) {
+    if (outError) outError.free();
+    throw e;
+  } finally {
+    if (cCode) wasm2.monty_dealloc(cCode.ptr, cCode.size);
+    if (cName) wasm2.monty_dealloc(cName.ptr, cName.size);
+  }
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: errMsg || "monty_create failed",
+      errorType: "CompileError"
+    });
+    return;
+  }
+  outError.free();
+  if (limits) {
+    if (limits.memory_bytes != null) wasm2.monty_set_memory_limit(handle, limits.memory_bytes);
+    if (limits.timeout_ms != null) wasm2.monty_set_time_limit_ms(handle, BigInt(limits.timeout_ms));
+    if (limits.stack_depth != null) wasm2.monty_set_stack_limit(handle, limits.stack_depth);
+  }
+  let outResult = null;
+  let outErrMsg = null;
+  let resultTag;
+  try {
+    outResult = allocOutPtr();
+    outErrMsg = allocOutPtr();
+    resultTag = wasm2.monty_run(handle, outResult.ptr, outErrMsg.ptr);
+  } catch (e) {
+    if (outResult) outResult.free();
+    if (outErrMsg) outErrMsg.free();
+    wasm2.monty_free(handle);
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  }
+  const resultPtr = outResult.read();
+  const errorPtr = outErrMsg.read();
+  const resultJson = readAndFreeCString(resultPtr);
+  const errorMsg = readAndFreeCString(errorPtr);
+  outResult.free();
+  outErrMsg.free();
+  wasm2.monty_free(handle);
+  if (resultTag === RESULT_OK && resultJson) {
+    const adapted = adaptResultForDart(resultJson, false);
+    self.postMessage({ type: "result", id, ...adapted });
+  } else if (resultJson) {
+    const adapted = adaptResultForDart(resultJson, true);
+    self.postMessage({ type: "result", id, ...adapted });
+  } else {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: errorMsg || "monty_run failed",
+      errorType: "MontyException"
+    });
+  }
+}
+function handleStart(id, code, extFns, limits, scriptName) {
+  if (activeHandle) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  let cCode = null;
+  let cExtFns = null;
+  let cName = null;
+  let outError = null;
+  let handle;
+  try {
+    outError = allocOutPtr();
+    cCode = allocCString(code);
+    cExtFns = extFns && extFns.length > 0 ? allocCString(extFns.join(",")) : null;
+    cName = scriptName ? allocCString(scriptName) : null;
+    handle = wasm2.monty_create(
+      cCode.ptr,
+      cExtFns ? cExtFns.ptr : 0,
+      cName ? cName.ptr : 0,
+      outError.ptr
+    );
+  } catch (e) {
+    if (outError) outError.free();
+    throw e;
+  } finally {
+    if (cCode) wasm2.monty_dealloc(cCode.ptr, cCode.size);
+    if (cExtFns) wasm2.monty_dealloc(cExtFns.ptr, cExtFns.size);
+    if (cName) wasm2.monty_dealloc(cName.ptr, cName.size);
+  }
+  if (handle === 0) {
+    const errPtr2 = outError.read();
+    const errMsg2 = readAndFreeCString(errPtr2);
+    outError.free();
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: errMsg2 || "monty_create failed",
+      errorType: "CompileError"
+    });
+    return;
+  }
+  outError.free();
+  if (limits) {
+    if (limits.memory_bytes != null) wasm2.monty_set_memory_limit(handle, limits.memory_bytes);
+    if (limits.timeout_ms != null) wasm2.monty_set_time_limit_ms(handle, BigInt(limits.timeout_ms));
+    if (limits.stack_depth != null) wasm2.monty_set_stack_limit(handle, limits.stack_depth);
+  }
+  activeHandle = handle;
+  let outErr;
+  let tag;
+  try {
+    outErr = allocOutPtr();
+    tag = wasm2.monty_start(handle, outErr.ptr);
+  } catch (e) {
+    if (outErr) outErr.free();
+    activeHandle = null;
+    wasm2.monty_free(handle);
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  }
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+  let msg;
+  try {
+    msg = readProgress(id, handle, tag, errMsg);
+  } catch (e) {
+    activeHandle = null;
+    wasm2.monty_free(handle);
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    activeHandle = null;
+    wasm2.monty_free(handle);
+  }
+  self.postMessage(msg);
+}
+function handleResume(id, value) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: "No active handle to resume.",
+      errorType: "StateError"
+    });
+    return;
+  }
+  let cVal = null;
+  let outErr = null;
+  let tag;
+  try {
+    cVal = allocCString(JSON.stringify(value));
+    outErr = allocOutPtr();
+    tag = wasm2.monty_resume(activeHandle, cVal.ptr, outErr.ptr);
+  } catch (e) {
+    if (cVal) wasm2.monty_dealloc(cVal.ptr, cVal.size);
+    if (outErr) outErr.free();
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  }
+  wasm2.monty_dealloc(cVal.ptr, cVal.size);
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+function handleResumeWithError(id, errorMessage) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: "No active handle to resume.",
+      errorType: "StateError"
+    });
+    return;
+  }
+  let cErr = null;
+  let outErr = null;
+  let tag;
+  try {
+    cErr = allocCString(errorMessage);
+    outErr = allocOutPtr();
+    tag = wasm2.monty_resume_with_error(activeHandle, cErr.ptr, outErr.ptr);
+  } catch (e) {
+    if (cErr) wasm2.monty_dealloc(cErr.ptr, cErr.size);
+    if (outErr) outErr.free();
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  }
+  wasm2.monty_dealloc(cErr.ptr, cErr.size);
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+function handleResumeAsFuture(id) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: "No active handle for resumeAsFuture.",
+      errorType: "StateError"
+    });
+    return;
+  }
+  const outErr = allocOutPtr();
+  let tag;
+  try {
+    tag = wasm2.monty_resume_as_future(activeHandle, outErr.ptr);
+  } catch (e) {
+    outErr.free();
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  }
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+function handleResolveFutures(id, resultsJson, errorsJson) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: "No active handle for resolveFutures.",
+      errorType: "StateError"
+    });
+    return;
+  }
+  let cResults = null;
+  let cErrors = null;
+  let outErr = null;
+  let tag;
+  try {
+    cResults = allocCString(resultsJson);
+    cErrors = allocCString(errorsJson);
+    outErr = allocOutPtr();
+    tag = wasm2.monty_resume_futures(activeHandle, cResults.ptr, cErrors.ptr, outErr.ptr);
+  } catch (e) {
+    if (cResults) wasm2.monty_dealloc(cResults.ptr, cResults.size);
+    if (cErrors) wasm2.monty_dealloc(cErrors.ptr, cErrors.size);
+    if (outErr) outErr.free();
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  }
+  wasm2.monty_dealloc(cResults.ptr, cResults.size);
+  wasm2.monty_dealloc(cErrors.ptr, cErrors.size);
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+function handleSnapshot(id) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: "No active handle to snapshot.",
+      errorType: "StateError"
+    });
+    return;
+  }
+  const outLen = allocOutPtr();
+  let ptr;
+  try {
+    ptr = wasm2.monty_snapshot(activeHandle, outLen.ptr);
+  } catch (e) {
+    outLen.free();
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  }
+  if (ptr === 0) {
+    outLen.free();
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: "monty_snapshot returned null",
+      errorType: "StateError"
+    });
+    return;
+  }
+  const len = outLen.read();
+  outLen.free();
+  const wasmBytes = new Uint8Array(wasm2.memory.buffer, ptr, len);
+  let copy;
+  try {
+    copy = wasmBytes.slice();
+  } finally {
+    wasm2.monty_bytes_free(ptr, len);
+  }
+  self.postMessage(
+    { type: "result", id, ok: true, snapshotBuffer: copy.buffer },
+    [copy.buffer]
+  );
+}
+function handleRestore(id, dataBase64) {
+  if (activeHandle) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  const binary = atob(dataBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  const outError = allocOutPtr();
+  const ptr = wasm2.monty_alloc(bytes.length);
+  if (ptr === 0) {
+    outError.free();
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: `monty_alloc(${bytes.length}) returned null \u2014 OOM`,
+      errorType: "MemoryError"
+    });
+    return;
+  }
+  new Uint8Array(wasm2.memory.buffer).set(bytes, ptr);
+  let handle;
+  try {
+    handle = wasm2.monty_restore(ptr, bytes.length, outError.ptr);
+  } catch (e) {
+    outError.free();
+    throw e;
+  } finally {
+    wasm2.monty_dealloc(ptr, bytes.length);
+  }
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: errMsg || "monty_restore failed",
+      errorType: "RestoreError"
+    });
+    return;
+  }
+  outError.free();
+  activeHandle = handle;
+  self.postMessage({ type: "result", id, ok: true });
+}
+function handleDispose(id) {
+  if (activeHandle) {
+    wasm2.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage({ type: "result", id, ok: true });
+}
+self.onmessage = (e) => {
+  const {
+    type,
+    id,
+    code,
+    extFns,
+    value,
+    errorMessage,
+    limits,
+    dataBase64,
+    scriptName,
+    resultsJson,
+    errorsJson
+  } = e.data;
+  try {
+    switch (type) {
+      case "run":
+        handleRun(id, code, limits, scriptName);
+        break;
+      case "start":
+        handleStart(id, code, extFns, limits, scriptName);
+        break;
+      case "resume":
+        handleResume(id, value);
+        break;
+      case "resumeWithError":
+        handleResumeWithError(id, errorMessage);
+        break;
+      case "resumeAsFuture":
+        handleResumeAsFuture(id);
+        break;
+      case "resolveFutures":
+        handleResolveFutures(id, resultsJson, errorsJson);
+        break;
+      case "snapshot":
+        handleSnapshot(id);
+        break;
+      case "restore":
+        handleRestore(id, dataBase64);
+        break;
+      case "dispose":
+        handleDispose(id);
+        break;
+      default:
+        self.postMessage({
+          type: "result",
+          id,
+          ok: false,
+          error: `Unknown message type: ${type}`,
+          errorType: "UnknownType"
+        });
+    }
+  } catch (e2) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e2.message || String(e2),
+      errorType: e2 instanceof WebAssembly.RuntimeError ? "Panic" : "InternalError"
+    });
+  }
+};
+initWasm().catch((e) => {
+  self.postMessage({
+    type: "error",
+    message: `WASM init failed: ${e.message}`
+  });
+});

--- a/packages/dart_monty_wasm/js/build.js
+++ b/packages/dart_monty_wasm/js/build.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * build.js — Bundles dart_monty_wasm JS bridge and Worker.
+ *
+ * Phase 3 (v0.8.0): Direct C-ABI — zero npm runtime dependencies.
+ *
+ * 1. esbuild worker_src.js + wasm_glue.js → ../assets/dart_monty_worker.js (ESM)
+ * 2. esbuild bridge.js → ../assets/dart_monty_bridge.js (IIFE)
+ * 3. Copy dart_monty_native.wasm from native/target/ → ../assets/
+ * 4. Run wasm-opt -Oz (if available)
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ASSETS = path.resolve(__dirname, '..', 'assets');
+const NATIVE_TARGET = path.resolve(
+  __dirname, '..', '..', '..', 'native', 'target',
+  'wasm32-wasip1', 'release',
+);
+const WASM_NAME = 'dart_monty_native.wasm';
+
+// Ensure assets directory exists
+fs.mkdirSync(ASSETS, { recursive: true });
+
+// Step 1: Bundle Worker (ESM) — includes wasm_glue.js via import
+console.log('[build] Bundling worker (C-ABI)...');
+execSync(
+  `npx esbuild src/worker_src.js ` +
+    `--bundle --format=esm ` +
+    `--outfile=${path.join(ASSETS, 'dart_monty_worker.js')} ` +
+    `--platform=browser ` +
+    `--external:*.wasm ` +
+    `--log-level=warning`,
+  { cwd: __dirname, stdio: 'inherit' },
+);
+
+// Step 2: Bundle bridge (IIFE)
+console.log('[build] Bundling bridge...');
+execSync(
+  `npx esbuild src/bridge.js ` +
+    `--bundle --format=iife ` +
+    `--outfile=${path.join(ASSETS, 'dart_monty_bridge.js')} ` +
+    `--platform=browser ` +
+    `--log-level=warning`,
+  { cwd: __dirname, stdio: 'inherit' },
+);
+
+// Step 3: Copy WASM binary from native build
+console.log('[build] Copying WASM binary...');
+const wasmSrc = path.join(NATIVE_TARGET, WASM_NAME);
+const wasmDst = path.join(ASSETS, WASM_NAME);
+
+if (!fs.existsSync(wasmSrc)) {
+  console.error(
+    `[build] FATAL: ${wasmSrc} not found.\n` +
+      `  Run: cd native && cargo build --release --target wasm32-wasip1`,
+  );
+  process.exit(1);
+}
+
+fs.copyFileSync(wasmSrc, wasmDst);
+const sizeMB = (fs.statSync(wasmDst).size / 1024 / 1024).toFixed(1);
+console.log(`  Copied ${WASM_NAME} (${sizeMB} MB)`);
+
+// Step 4: Optimize with wasm-opt (optional — skip if not installed)
+try {
+  const wasmOptDst = wasmDst + '.opt';
+  execSync(
+    `wasm-opt -Oz ` +
+      `--enable-bulk-memory --enable-nontrapping-float-to-int ` +
+      `--enable-sign-ext --enable-mutable-globals ` +
+      `${wasmDst} -o ${wasmOptDst}`,
+    { stdio: 'pipe' },
+  );
+  // Replace with optimized version
+  fs.renameSync(wasmOptDst, wasmDst);
+  const optSizeMB = (fs.statSync(wasmDst).size / 1024 / 1024).toFixed(1);
+  console.log(`  Optimized with wasm-opt: ${sizeMB} MB → ${optSizeMB} MB`);
+} catch (_) {
+  console.log('  wasm-opt not found — skipping optimization');
+}
+
+console.log('[build] Done. Assets in ../assets/');
+console.log('[build] Zero npm runtime dependencies.');

--- a/packages/dart_monty_wasm/js/package-lock.json
+++ b/packages/dart_monty_wasm/js/package-lock.json
@@ -1,0 +1,667 @@
+{
+  "name": "dart-monty-wasm-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dart-monty-wasm-bridge",
+      "version": "0.1.0",
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@pydantic/monty": "^0.0.7",
+        "@pydantic/monty-wasm32-wasi": "^0.0.7",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "devDependencies": {
+        "esbuild": "^0.24.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@pydantic/monty": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty/-/monty-0.0.7.tgz",
+      "integrity": "sha512-xC2BbsauHDm6LTfqGHC9HlnUBClW0vJBe9kmSZgTPfqVngV09mPVmdsTDjq5R0ZOxQScZpvInzq+RfgXYQGGGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
+      },
+      "optionalDependencies": {
+        "@pydantic/monty-darwin-arm64": "0.0.7",
+        "@pydantic/monty-darwin-x64": "0.0.7",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.7",
+        "@pydantic/monty-linux-x64-gnu": "0.0.7",
+        "@pydantic/monty-wasm32-wasi": "0.0.7",
+        "@pydantic/monty-win32-x64-msvc": "0.0.7"
+      }
+    },
+    "node_modules/@pydantic/monty-darwin-arm64": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.7.tgz",
+      "integrity": "sha512-+qncYK5TAPys/yn6ZJ6h3Tk1ToBjNYfLmCX1LameHMx9yWDYqk7+uRhJi5Xec5Wz4OARbftkXxEbHhPodr5ehA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
+      }
+    },
+    "node_modules/@pydantic/monty-darwin-x64": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.7.tgz",
+      "integrity": "sha512-R934apWGpZYL1zPZp3zkd7Y9um8OPjKprqkzEq8HnJ5MAKECCIv51rmvMpjf/oT9cnsjOdgE6FcNeTUoeY2hCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
+      }
+    },
+    "node_modules/@pydantic/monty-linux-arm64-gnu": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.7.tgz",
+      "integrity": "sha512-iLLhOjo915y3yuNTiMWmWd8Swra+xlLqAi2lF7Y9ndOMxaH00ayPqxUo26cIM7wiKxvV7ULuHO21UKUpbkOvvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
+      }
+    },
+    "node_modules/@pydantic/monty-linux-x64-gnu": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.7.tgz",
+      "integrity": "sha512-nRaIqM6s4tqc/tX8T5AUKqJbPXDQ7N5uVf+66C46oOxuzaDhbnArFXm8//cpQHwVgaE8fE44K6FnSXz+efT8jA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
+      }
+    },
+    "node_modules/@pydantic/monty-wasm32-wasi": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-wasm32-wasi/-/monty-wasm32-wasi-0.0.7.tgz",
+      "integrity": "sha512-VDBv4j0eF9mG0Nl1CFrNJ+oEB1KacnIGDsk02QrUhS8Y3al0xuQlsweQhui2guVPyvXTWhLXnD4fBrHB5R6wwA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@pydantic/monty-win32-x64-msvc": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.7.tgz",
+      "integrity": "sha512-DVNEpXGIAygZvSCNe26B0w1b6nDeLNcYDY0tfR9v55wPi7GoTLAhO/8LbsjNWV/rYjn4S7pfGqU48XRLegP0wg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/packages/dart_monty_wasm/js/package.json
+++ b/packages/dart_monty_wasm/js/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "dart-monty-wasm-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "description": "JS bridge for dart_monty_wasm — @pydantic/monty WASM Worker",
+  "scripts": {
+    "build": "node build.js"
+  },
+  "dependencies": {
+    "@emnapi/core": "^1.8.1",
+    "@emnapi/runtime": "^1.8.1",
+    "@napi-rs/wasm-runtime": "^1.1.1",
+    "@pydantic/monty": "^0.0.7",
+    "@pydantic/monty-wasm32-wasi": "^0.0.7",
+    "@tybys/wasm-util": "^0.10.1"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0"
+  }
+}

--- a/packages/dart_monty_wasm/js/src/bridge.js
+++ b/packages/dart_monty_wasm/js/src/bridge.js
@@ -1,0 +1,423 @@
+/**
+ * bridge.js — Main-thread bridge between Dart JS interop and Monty WASM Workers.
+ *
+ * Exposes window.DartMontyBridge with methods Dart calls via dart:js_interop.
+ * Each session gets its own Worker hosting a Monty WASM runtime.
+ *
+ * Architecture: Multi-session Worker pool (Phase 2a).
+ * Backward-compatible: init/run/start/resume/etc. without sessionId use
+ * a default session, so existing Dart code works without changes.
+ */
+
+let nextSessionId = 1;
+const sessions = new Map(); // sessionId -> { worker, nextMsgId, pending, timeoutMs }
+let defaultSessionId = null;
+
+// ---------------------------------------------------------------------------
+// Worker URL — resolved once relative to the bridge script location.
+// Falls back to window.location.href if document.currentScript is unavailable
+// (e.g. when loaded dynamically).
+// ---------------------------------------------------------------------------
+
+const _bridgeBase =
+  (typeof document !== 'undefined' && document.currentScript)
+    ? new URL('.', document.currentScript.src).href
+    : window.location.href;
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new session with its own Worker.
+ *
+ * @returns {Promise<number>} sessionId.
+ */
+function createSession() {
+  return new Promise((resolve, reject) => {
+    const sessionId = nextSessionId++;
+    try {
+      // Blob URL trampoline: allows Worker creation when bridge.js is
+      // served from a different origin (e.g. CDN). Direct cross-origin
+      // Worker URLs throw SecurityError; a same-origin Blob proxy avoids it.
+      const workerUrl = new URL('./dart_monty_worker.js', _bridgeBase).href;
+      const blob = new Blob(
+        [`import "${workerUrl}";`],
+        { type: 'application/javascript' },
+      );
+      const blobUrl = URL.createObjectURL(blob);
+      const worker = new Worker(blobUrl, { type: 'module' });
+
+      worker.onerror = (event) => {
+        const session = sessions.get(sessionId);
+        if (session) {
+          // Worker crashed — reject all pending promises
+          for (const req of session.pending.values()) {
+            if (req.timer) clearTimeout(req.timer);
+            req.reject(new Error(`Panic: Worker crashed: ${event.message || event}`));
+          }
+          session.pending.clear();
+          sessions.delete(sessionId);
+          if (defaultSessionId === sessionId) defaultSessionId = null;
+        }
+        // If we haven't resolved yet (during init), reject the create
+        reject(new Error(`Worker failed to start: ${event.message || event}`));
+      };
+
+      worker.onmessage = (e) => {
+        const msg = e.data;
+
+        if (msg.type === 'ready') {
+          URL.revokeObjectURL(blobUrl);
+          sessions.set(sessionId, {
+            worker,
+            nextMsgId: 1,
+            pending: new Map(),
+            timeoutMs: null,
+          });
+          console.log(`[DartMontyBridge] Session ${sessionId} ready`);
+          resolve(sessionId);
+          return;
+        }
+
+        if (msg.type === 'error' && !msg.id) {
+          console.error(`[DartMontyBridge] Session ${sessionId} init error:`, msg.message);
+          reject(new Error(msg.message || 'Worker init failed'));
+          return;
+        }
+
+        // Route responses to pending promises
+        const session = sessions.get(sessionId);
+        if (!session) return;
+        if (msg.id && session.pending.has(msg.id)) {
+          const req = session.pending.get(msg.id);
+          if (req.timer) clearTimeout(req.timer);
+          session.pending.delete(msg.id);
+          req.resolve(msg);
+        }
+      };
+    } catch (e) {
+      reject(new Error(`Failed to create Worker: ${e.message}`));
+    }
+  });
+}
+
+/**
+ * Dispose a session — clear timers, reject pending, terminate Worker.
+ *
+ * @param {number} sessionId
+ */
+function disposeSession(sessionId) {
+  const session = sessions.get(sessionId);
+  if (!session) return;
+  for (const req of session.pending.values()) {
+    if (req.timer) clearTimeout(req.timer);
+    req.reject(new Error('MontyDisposed: Session disposed'));
+  }
+  session.pending.clear();
+  session.worker.terminate();
+  sessions.delete(sessionId);
+  if (defaultSessionId === sessionId) defaultSessionId = null;
+}
+
+// ---------------------------------------------------------------------------
+// Worker communication
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a message to a session's Worker and wait for a response.
+ *
+ * @param {number} sessionId
+ * @param {Object} msg
+ * @param {number|null} timeoutMs — hard timeout (null = no timeout).
+ * @returns {Promise<Object>}
+ */
+function callWorker(sessionId, msg, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const session = sessions.get(sessionId);
+    if (!session) {
+      reject(new Error(`Session ${sessionId} not found`));
+      return;
+    }
+    const msgId = session.nextMsgId++;
+
+    let timer = null;
+    if (timeoutMs != null && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        // Timeout — reject ALL pending promises for this session
+        for (const req of session.pending.values()) {
+          if (req.timer) clearTimeout(req.timer);
+          req.reject(new Error('MontyWorkerError: Execution timed out'));
+        }
+        session.pending.clear();
+        session.worker.terminate();
+        sessions.delete(sessionId);
+        if (defaultSessionId === sessionId) defaultSessionId = null;
+      }, timeoutMs);
+    }
+
+    session.pending.set(msgId, { resolve, reject, timer });
+    session.worker.postMessage({ ...msg, id: msgId });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the session, returning an error JSON string if not found.
+ */
+function getSessionOrError(sessionId) {
+  if (sessionId != null && sessions.has(sessionId)) {
+    return sessions.get(sessionId);
+  }
+  return null;
+}
+
+function notInitializedError() {
+  return JSON.stringify({ ok: false, error: 'Not initialized', errorType: 'InitError' });
+}
+
+/**
+ * Resolve the effective session ID — use explicit or default.
+ */
+function resolveSessionId(sessionId) {
+  if (sessionId != null) return sessionId;
+  return defaultSessionId;
+}
+
+/**
+ * Compute a hard timeout from limitsJson.
+ * Returns null if no timeout specified.
+ */
+function parseHardTimeout(limitsJson) {
+  if (!limitsJson) return null;
+  const limits = typeof limitsJson === 'string' ? JSON.parse(limitsJson) : limitsJson;
+  if (limits.timeout_ms != null) {
+    // Hard backstop = soft timeout + 1 second buffer
+    return limits.timeout_ms + 1000;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API — backward-compatible (sessionId is optional)
+// ---------------------------------------------------------------------------
+
+/**
+ * Initialize the bridge.
+ *
+ * For backward compatibility, creates a default session if none exists.
+ *
+ * @returns {Promise<boolean>} true if Worker loaded WASM successfully.
+ */
+async function init() {
+  if (defaultSessionId != null && sessions.has(defaultSessionId)) return true;
+  try {
+    defaultSessionId = await createSession();
+    return true;
+  } catch (e) {
+    console.error('[DartMontyBridge] Init failed:', e.message);
+    return false;
+  }
+}
+
+/**
+ * Run Python code to completion.
+ *
+ * @param {string} code       Python source code.
+ * @param {string} limitsJson JSON-encoded limits map (optional).
+ * @param {string} scriptName Script name for tracebacks (optional).
+ * @returns {Promise<string>} JSON result.
+ */
+async function run(code, limitsJson, scriptName) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const hardTimeout = parseHardTimeout(limitsJson);
+  if (hardTimeout != null) session.timeoutMs = hardTimeout;
+
+  const limits = limitsJson ? JSON.parse(limitsJson) : null;
+  const msg = { type: 'run', code, limits };
+  if (scriptName) msg.scriptName = scriptName;
+  const result = await callWorker(sid, msg, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
+ * Start iterative execution.
+ *
+ * @param {string} code       Python source code.
+ * @param {string} extFnsJson JSON array of external function names (optional).
+ * @param {string} limitsJson JSON-encoded limits map (optional).
+ * @param {string} scriptName Script name for tracebacks (optional).
+ * @returns {Promise<string>} JSON result.
+ */
+async function start(code, extFnsJson, limitsJson, scriptName) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const hardTimeout = parseHardTimeout(limitsJson);
+  if (hardTimeout != null) session.timeoutMs = hardTimeout;
+
+  const extFns = extFnsJson ? JSON.parse(extFnsJson) : [];
+  const limits = limitsJson ? JSON.parse(limitsJson) : null;
+  const msg = { type: 'start', code, extFns, limits };
+  if (scriptName) msg.scriptName = scriptName;
+  const result = await callWorker(sid, msg, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
+ * Resume a paused execution with a return value.
+ *
+ * @param {string} valueJson JSON-encoded value to return to Python.
+ * @returns {Promise<string>} JSON result.
+ */
+async function resume(valueJson) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const value = JSON.parse(valueJson);
+  const result = await callWorker(sid, { type: 'resume', value }, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
+ * Resume a paused execution with an error.
+ *
+ * @param {string} errorJson JSON-encoded error message string.
+ * @returns {Promise<string>} JSON result.
+ */
+async function resumeWithError(errorJson) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const errorMessage = JSON.parse(errorJson);
+  const result = await callWorker(sid, { type: 'resumeWithError', errorMessage }, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
+ * Resume by creating a future for the pending external function call.
+ *
+ * @returns {Promise<string>} JSON result with state: pending, resolve_futures, or complete.
+ */
+async function resumeAsFuture() {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const result = await callWorker(sid, { type: 'resumeAsFuture' }, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
+ * Resolve pending futures with results and errors.
+ *
+ * @param {string} resultsJson JSON object {"callId": value, ...}.
+ * @param {string} errorsJson  JSON object {"callId": "errorMsg", ...}.
+ * @returns {Promise<string>} JSON result.
+ */
+async function resolveFutures(resultsJson, errorsJson) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const result = await callWorker(
+    sid, { type: 'resolveFutures', resultsJson, errorsJson }, session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
+/**
+ * Capture the current interpreter state as a snapshot.
+ *
+ * @returns {Promise<string>} JSON result with base64-encoded data.
+ */
+async function snapshot() {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) {
+    // Return a raw JS object (not JSON string) — Dart casts to _SnapshotResult.
+    return { ok: false, error: 'Not initialized' };
+  }
+
+  const session = sessions.get(sid);
+  const result = await callWorker(sid, { type: 'snapshot' }, session.timeoutMs);
+  // Return raw JS object — snapshotBuffer is an ArrayBuffer, not JSON-safe.
+  return result;
+}
+
+/**
+ * Restore interpreter state from a base64-encoded snapshot.
+ *
+ * @param {string} dataBase64 Base64-encoded snapshot data.
+ * @returns {Promise<string>} JSON result.
+ */
+async function restore(dataBase64) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const result = await callWorker(sid, { type: 'restore', dataBase64 }, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
+ * Discover available API surface.
+ *
+ * @returns {string} JSON describing bridge state.
+ */
+function discover() {
+  return JSON.stringify({
+    loaded: sessions.size > 0,
+    sessionCount: sessions.size,
+    architecture: 'worker-pool',
+  });
+}
+
+/**
+ * Dispose the default Worker session.
+ *
+ * @returns {Promise<string>} JSON result.
+ */
+async function dispose() {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) {
+    return JSON.stringify({ ok: true });
+  }
+  // Send dispose to worker so it can clean up internal state
+  try {
+    await callWorker(sid, { type: 'dispose' }, 5000);
+  } catch (_) {
+    // Worker may already be dead — that's fine
+  }
+  disposeSession(sid);
+  return JSON.stringify({ ok: true });
+}
+
+// Expose bridge on window for Dart JS interop
+window.DartMontyBridge = {
+  init,
+  run,
+  start,
+  resume,
+  resumeWithError,
+  resumeAsFuture,
+  resolveFutures,
+  snapshot,
+  restore,
+  discover,
+  dispose,
+  // Phase 2 multi-session API
+  createSession,
+  disposeSession,
+  getDefaultSessionId: () => defaultSessionId,
+};
+
+console.log('[DartMontyBridge] Registered on window (Worker pool architecture)');

--- a/packages/dart_monty_wasm/js/src/wasm_glue.js
+++ b/packages/dart_monty_wasm/js/src/wasm_glue.js
@@ -1,0 +1,204 @@
+/**
+ * wasm_glue.js — WASI shim + C-ABI helpers for dart_monty_native.wasm.
+ *
+ * Replaces the entire NAPI-RS runtime + @pydantic/monty npm stack.
+ * Only 6 WASI imports needed: random_get, clock_time_get, fd_write,
+ * environ_get, environ_sizes_get, proc_exit.
+ */
+
+// ---------------------------------------------------------------------------
+// WASI shim
+// ---------------------------------------------------------------------------
+
+/**
+ * Create WASI import namespace for the given WASM memory.
+ *
+ * @param {function} getMemory — returns the WebAssembly.Memory instance.
+ * @returns {Object} wasi_snapshot_preview1 import namespace.
+ */
+function createWasiImports(getMemory) {
+  return {
+    random_get(buf, bufLen) {
+      const mem = new Uint8Array(getMemory().buffer);
+      // Web Crypto throws QuotaExceededError for buffers > 65536 bytes.
+      for (let i = 0; i < bufLen; i += 65536) {
+        const chunk = Math.min(65536, bufLen - i);
+        crypto.getRandomValues(mem.subarray(buf + i, buf + i + chunk));
+      }
+      return 0;
+    },
+
+    // CLOCK_REALTIME = 0, CLOCK_MONOTONIC = 1
+    clock_time_get(id, _precision, out) {
+      const mem = new DataView(getMemory().buffer);
+      let nowNs;
+      if (id === 0) {
+        // CLOCK_REALTIME — Unix epoch nanoseconds (for Python time.time())
+        nowNs = BigInt(Date.now()) * 1000000n;
+      } else {
+        // CLOCK_MONOTONIC — page-relative nanoseconds
+        nowNs = BigInt(Math.round(performance.now() * 1e6));
+      }
+      mem.setBigUint64(out, nowNs, true);
+      return 0;
+    },
+
+    fd_write(fd, iovs, iovsLen, nwritten) {
+      const mem = new DataView(getMemory().buffer);
+      const bytes = new Uint8Array(getMemory().buffer);
+      let totalWritten = 0;
+      const parts = [];
+
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = mem.getUint32(iovs + i * 8, true);
+        const len = mem.getUint32(iovs + i * 8 + 4, true);
+        parts.push(new TextDecoder().decode(bytes.subarray(ptr, ptr + len)));
+        totalWritten += len;
+      }
+
+      const text = parts.join('');
+      if (fd === 1) console.log('[monty]', text);
+      else if (fd === 2) console.warn('[monty]', text);
+
+      mem.setUint32(nwritten, totalWritten, true);
+      return 0;
+    },
+
+    environ_get() { return 0; },
+
+    environ_sizes_get(countOut, bufsizeOut) {
+      const mem = new DataView(getMemory().buffer);
+      mem.setUint32(countOut, 0, true);
+      mem.setUint32(bufsizeOut, 0, true);
+      return 0;
+    },
+
+    proc_exit(code) {
+      throw new Error(`WASI proc_exit called with code ${code}`);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// WASM loader
+// ---------------------------------------------------------------------------
+
+let wasm = null;
+
+/**
+ * Instantiate dart_monty_native.wasm.
+ *
+ * Uses compileStreaming with ArrayBuffer fallback for servers that
+ * don't set the correct application/wasm Content-Type.
+ *
+ * @param {string|URL} wasmUrl
+ * @returns {Promise<WebAssembly.Exports>}
+ */
+export async function instantiateMonty(wasmUrl) {
+  let memory;
+  const wasiImports = createWasiImports(() => memory);
+  const imports = { wasi_snapshot_preview1: wasiImports };
+
+  let instance;
+  try {
+    const result = await WebAssembly.instantiateStreaming(
+      fetch(wasmUrl),
+      imports,
+    );
+    instance = result.instance;
+  } catch (e) {
+    // Fallback: fetch as ArrayBuffer (Content-Type mismatch)
+    if (e instanceof TypeError || (e.message && e.message.includes('Mime'))) {
+      const resp = await fetch(wasmUrl);
+      const bytes = await resp.arrayBuffer();
+      const result = await WebAssembly.instantiate(bytes, imports);
+      instance = result.instance;
+    } else {
+      throw e;
+    }
+  }
+
+  wasm = instance.exports;
+  memory = wasm.memory;
+  return wasm;
+}
+
+/** Get the current WASM exports. Throws if not yet instantiated. */
+export function getExports() {
+  if (!wasm) throw new Error('WASM not instantiated — call instantiateMonty first');
+  return wasm;
+}
+
+// ---------------------------------------------------------------------------
+// String marshalling
+// ---------------------------------------------------------------------------
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+/**
+ * Write a JS string into WASM memory via monty_alloc.
+ * Returns { ptr, size } — caller must free with monty_dealloc(ptr, size).
+ * Throws on OOM.
+ */
+export function allocCString(str) {
+  const encoded = encoder.encode(str);
+  const size = encoded.length + 1;
+  const ptr = wasm.monty_alloc(size);
+  if (ptr === 0) throw new Error(`monty_alloc(${size}) returned null — OOM`);
+  const mem = new Uint8Array(wasm.memory.buffer);
+  mem.set(encoded, ptr);
+  mem[ptr + encoded.length] = 0;
+  return { ptr, size };
+}
+
+/**
+ * Read a NUL-terminated C string from WASM memory.
+ * Returns null if ptr is 0.
+ */
+export function readCString(ptr) {
+  if (ptr === 0) return null;
+  const mem = new Uint8Array(wasm.memory.buffer);
+  let end = ptr;
+  while (end < mem.length && mem[end] !== 0) end++;
+  return decoder.decode(mem.subarray(ptr, end));
+}
+
+/**
+ * Read a C string and free it with monty_string_free.
+ * Returns null if ptr is 0.
+ */
+export function readAndFreeCString(ptr) {
+  if (ptr === 0) return null;
+  const str = readCString(ptr);
+  wasm.monty_string_free(ptr);
+  return str;
+}
+
+/**
+ * Allocate a 4-byte out-pointer slot for wasm32 pointer-out parameters.
+ */
+export function allocOutPtr() {
+  const ptr = wasm.monty_alloc(4);
+  if (ptr === 0) throw new Error('monty_alloc(4) returned null — OOM');
+  return {
+    ptr,
+    read() {
+      return new DataView(wasm.memory.buffer).getUint32(ptr, true);
+    },
+    free() {
+      wasm.monty_dealloc(ptr, 4);
+    },
+  };
+}
+
+// ProgressTag enum (matches native/src/handle.rs)
+export const PROGRESS_COMPLETE = 0;
+export const PROGRESS_PENDING = 1;
+export const PROGRESS_ERROR = 2;
+export const PROGRESS_RESOLVE_FUTURES = 3;
+export const PROGRESS_OS_CALL = 4;
+
+// ResultTag enum
+export const RESULT_OK = 0;
+export const RESULT_ERROR = 1;

--- a/packages/dart_monty_wasm/js/src/worker_src.js
+++ b/packages/dart_monty_wasm/js/src/worker_src.js
@@ -1,0 +1,729 @@
+/**
+ * worker_src.js — Runs dart_monty_native.wasm inside a Web Worker via C-ABI.
+ *
+ * Replaces the NAPI-RS class-based approach with direct calls to the 28
+ * exported C functions. String marshalling via monty_alloc/monty_dealloc.
+ *
+ * Bundled by esbuild into dart_monty_worker.js for the browser.
+ */
+
+import {
+  instantiateMonty,
+  getExports,
+  allocCString,
+  readCString,
+  readAndFreeCString,
+  allocOutPtr,
+  PROGRESS_COMPLETE,
+  PROGRESS_PENDING,
+  PROGRESS_ERROR,
+  PROGRESS_RESOLVE_FUTURES,
+  PROGRESS_OS_CALL,
+  RESULT_OK,
+} from './wasm_glue.js';
+
+let wasm = null;
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+async function initWasm() {
+  const wasmUrl = new URL('./dart_monty_native.wasm', import.meta.url);
+  wasm = await instantiateMonty(wasmUrl);
+  self.postMessage({
+    type: 'ready',
+    exports: Object.keys(wasm).filter((k) => k.startsWith('monty_')),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Error schema adapter (C-ABI → Dart-expected format)
+// ---------------------------------------------------------------------------
+
+/**
+ * Flatten C-ABI result JSON for Dart consumption.
+ *
+ * C-ABI: { value, error: { message, exc_type, traceback }, usage, print_output }
+ * Dart:  { ok, value?, print_output?, error?, errorType?, excType?, traceback? }
+ */
+function adaptResultForDart(cabiResultJson, isError) {
+  const parsed = JSON.parse(cabiResultJson);
+  if (isError) {
+    const err = (parsed.error && typeof parsed.error === 'object')
+      ? parsed.error
+      : { message: parsed.error ? String(parsed.error) : 'Unknown error' };
+    return {
+      ok: false,
+      error: err.message || String(err),
+      errorType: err.exc_type || 'MontyException',
+      excType: err.exc_type || null,
+      traceback: err.traceback || null,
+    };
+  }
+  return {
+    ok: true,
+    value: parsed.value,
+    print_output: parsed.print_output || null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Progress reading (shared by start, resume, resumeAsFuture, resumeFutures)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read progress state from a handle after a C-ABI progress call.
+ * @returns {Object} message payload to send back to main thread.
+ */
+function readProgress(id, handle, tag, errMsg) {
+  switch (tag) {
+    case PROGRESS_COMPLETE: {
+      const isErr = wasm.monty_complete_is_error(handle);
+      const ptr = wasm.monty_complete_result_json(handle);
+      const json = readAndFreeCString(ptr);
+      if (json) {
+        const adapted = adaptResultForDart(json, isErr === 1);
+        return { type: 'result', id, ...adapted, state: adapted.ok ? 'complete' : undefined };
+      }
+      if (isErr === 1) {
+        return {
+          type: 'result', id, ok: false,
+          error: 'Execution failed (no error context)',
+          errorType: 'MontyException',
+        };
+      }
+      return { type: 'result', id, ok: true, state: 'complete', value: null };
+    }
+
+    case PROGRESS_PENDING: {
+      const fnName = readAndFreeCString(wasm.monty_pending_fn_name(handle));
+      const argsJson = readAndFreeCString(wasm.monty_pending_fn_args_json(handle));
+      const kwargsJson = readAndFreeCString(wasm.monty_pending_fn_kwargs_json(handle));
+      const callId = wasm.monty_pending_call_id(handle);
+      const methodCall = wasm.monty_pending_method_call(handle);
+
+      return {
+        type: 'result',
+        id,
+        ok: true,
+        state: 'pending',
+        functionName: fnName,
+        args: argsJson ? JSON.parse(argsJson) : [],
+        kwargs: kwargsJson ? JSON.parse(kwargsJson) : {},
+        callId,
+        methodCall: methodCall === 1,
+      };
+    }
+
+    case PROGRESS_OS_CALL: {
+      const fnName = readAndFreeCString(wasm.monty_os_call_fn_name(handle));
+      const argsJson = readAndFreeCString(wasm.monty_os_call_args_json(handle));
+      const kwargsJson = readAndFreeCString(wasm.monty_os_call_kwargs_json(handle));
+      const callId = wasm.monty_os_call_id(handle);
+
+      return {
+        type: 'result',
+        id,
+        ok: true,
+        state: 'os_call',
+        functionName: fnName,
+        args: argsJson ? JSON.parse(argsJson) : [],
+        kwargs: kwargsJson ? JSON.parse(kwargsJson) : {},
+        callId,
+      };
+    }
+
+    case PROGRESS_RESOLVE_FUTURES: {
+      const idsPtr = wasm.monty_pending_future_call_ids(handle);
+      const idsJson = readAndFreeCString(idsPtr);
+      return {
+        type: 'result',
+        id,
+        ok: true,
+        state: 'resolve_futures',
+        pendingCallIds: idsJson ? JSON.parse(idsJson) : [],
+      };
+    }
+
+    case PROGRESS_ERROR:
+      return {
+        type: 'result',
+        id,
+        ok: false,
+        error: errMsg || 'Unknown error',
+        errorType: 'MontyException',
+      };
+
+    default:
+      return {
+        type: 'result',
+        id,
+        ok: false,
+        error: `Unknown progress tag: ${tag}`,
+        errorType: 'InternalError',
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-session handle state
+// ---------------------------------------------------------------------------
+
+let activeHandle = null;
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+function handleRun(id, code, limits, scriptName) {
+  let cCode = null;
+  let cName = null;
+  let outError = null;
+
+  let handle;
+  try {
+    outError = allocOutPtr();
+    cCode = allocCString(code);
+    cName = scriptName ? allocCString(scriptName) : null;
+    handle = wasm.monty_create(cCode.ptr, 0, cName ? cName.ptr : 0, outError.ptr);
+  } catch (e) {
+    if (outError) outError.free();
+    throw e;
+  } finally {
+    if (cCode) wasm.monty_dealloc(cCode.ptr, cCode.size);
+    if (cName) wasm.monty_dealloc(cName.ptr, cName.size);
+  }
+
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_create failed',
+      errorType: 'CompileError',
+    });
+    return;
+  }
+  outError.free();
+
+  // Apply limits
+  if (limits) {
+    if (limits.memory_bytes != null) wasm.monty_set_memory_limit(handle, limits.memory_bytes);
+    if (limits.timeout_ms != null) wasm.monty_set_time_limit_ms(handle, BigInt(limits.timeout_ms));
+    if (limits.stack_depth != null) wasm.monty_set_stack_limit(handle, limits.stack_depth);
+  }
+
+  let outResult = null;
+  let outErrMsg = null;
+
+  let resultTag;
+  try {
+    outResult = allocOutPtr();
+    outErrMsg = allocOutPtr();
+    resultTag = wasm.monty_run(handle, outResult.ptr, outErrMsg.ptr);
+  } catch (e) {
+    // WebAssembly.RuntimeError = panic trap (panic=abort on wasm32-wasip1)
+    if (outResult) outResult.free();
+    if (outErrMsg) outErrMsg.free();
+    wasm.monty_free(handle);
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+
+  const resultPtr = outResult.read();
+  const errorPtr = outErrMsg.read();
+  const resultJson = readAndFreeCString(resultPtr);
+  const errorMsg = readAndFreeCString(errorPtr);
+  outResult.free();
+  outErrMsg.free();
+  wasm.monty_free(handle);
+
+  if (resultTag === RESULT_OK && resultJson) {
+    const adapted = adaptResultForDart(resultJson, false);
+    self.postMessage({ type: 'result', id, ...adapted });
+  } else if (resultJson) {
+    const adapted = adaptResultForDart(resultJson, true);
+    self.postMessage({ type: 'result', id, ...adapted });
+  } else {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errorMsg || 'monty_run failed',
+      errorType: 'MontyException',
+    });
+  }
+}
+
+function handleStart(id, code, extFns, limits, scriptName) {
+  // Free any abandoned execution before starting a new one.
+  if (activeHandle) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+
+  let cCode = null;
+  let cExtFns = null;
+  let cName = null;
+  let outError = null;
+
+  let handle;
+  try {
+    outError = allocOutPtr();
+    cCode = allocCString(code);
+    cExtFns = extFns && extFns.length > 0 ? allocCString(extFns.join(',')) : null;
+    cName = scriptName ? allocCString(scriptName) : null;
+    handle = wasm.monty_create(
+      cCode.ptr, cExtFns ? cExtFns.ptr : 0, cName ? cName.ptr : 0, outError.ptr,
+    );
+  } catch (e) {
+    if (outError) outError.free();
+    throw e;
+  } finally {
+    if (cCode) wasm.monty_dealloc(cCode.ptr, cCode.size);
+    if (cExtFns) wasm.monty_dealloc(cExtFns.ptr, cExtFns.size);
+    if (cName) wasm.monty_dealloc(cName.ptr, cName.size);
+  }
+
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_create failed',
+      errorType: 'CompileError',
+    });
+    return;
+  }
+  outError.free();
+
+  // Apply limits
+  if (limits) {
+    if (limits.memory_bytes != null) wasm.monty_set_memory_limit(handle, limits.memory_bytes);
+    if (limits.timeout_ms != null) wasm.monty_set_time_limit_ms(handle, BigInt(limits.timeout_ms));
+    if (limits.stack_depth != null) wasm.monty_set_stack_limit(handle, limits.stack_depth);
+  }
+
+  activeHandle = handle;
+
+  let outErr;
+  let tag;
+  try {
+    outErr = allocOutPtr();
+    tag = wasm.monty_start(handle, outErr.ptr);
+  } catch (e) {
+    if (outErr) outErr.free();
+    activeHandle = null;
+    wasm.monty_free(handle);
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+
+  let msg;
+  try {
+    msg = readProgress(id, handle, tag, errMsg);
+  } catch (e) {
+    activeHandle = null;
+    wasm.monty_free(handle);
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    activeHandle = null;
+    wasm.monty_free(handle);
+  }
+  self.postMessage(msg);
+}
+
+function handleResume(id, value) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'No active handle to resume.',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  let cVal = null;
+  let outErr = null;
+
+  let tag;
+  try {
+    cVal = allocCString(JSON.stringify(value));
+    outErr = allocOutPtr();
+    tag = wasm.monty_resume(activeHandle, cVal.ptr, outErr.ptr);
+  } catch (e) {
+    if (cVal) wasm.monty_dealloc(cVal.ptr, cVal.size);
+    if (outErr) outErr.free();
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+  wasm.monty_dealloc(cVal.ptr, cVal.size);
+
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+
+function handleResumeWithError(id, errorMessage) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'No active handle to resume.',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  let cErr = null;
+  let outErr = null;
+
+  let tag;
+  try {
+    cErr = allocCString(errorMessage);
+    outErr = allocOutPtr();
+    tag = wasm.monty_resume_with_error(activeHandle, cErr.ptr, outErr.ptr);
+  } catch (e) {
+    if (cErr) wasm.monty_dealloc(cErr.ptr, cErr.size);
+    if (outErr) outErr.free();
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+  wasm.monty_dealloc(cErr.ptr, cErr.size);
+
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+
+function handleResumeAsFuture(id) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'No active handle for resumeAsFuture.',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  const outErr = allocOutPtr();
+  let tag;
+  try {
+    tag = wasm.monty_resume_as_future(activeHandle, outErr.ptr);
+  } catch (e) {
+    outErr.free();
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+
+function handleResolveFutures(id, resultsJson, errorsJson) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'No active handle for resolveFutures.',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  let cResults = null;
+  let cErrors = null;
+  let outErr = null;
+
+  let tag;
+  try {
+    cResults = allocCString(resultsJson);
+    cErrors = allocCString(errorsJson);
+    outErr = allocOutPtr();
+    tag = wasm.monty_resume_futures(activeHandle, cResults.ptr, cErrors.ptr, outErr.ptr);
+  } catch (e) {
+    if (cResults) wasm.monty_dealloc(cResults.ptr, cResults.size);
+    if (cErrors) wasm.monty_dealloc(cErrors.ptr, cErrors.size);
+    if (outErr) outErr.free();
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+  wasm.monty_dealloc(cResults.ptr, cResults.size);
+  wasm.monty_dealloc(cErrors.ptr, cErrors.size);
+
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg);
+  } catch (e) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+
+function handleSnapshot(id) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'No active handle to snapshot.',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  const outLen = allocOutPtr();
+  let ptr;
+  try {
+    ptr = wasm.monty_snapshot(activeHandle, outLen.ptr);
+  } catch (e) {
+    outLen.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+
+  if (ptr === 0) {
+    outLen.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'monty_snapshot returned null',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  const len = outLen.read();
+  outLen.free();
+
+  // Copy bytes out of WASM memory before freeing.
+  // try/finally ensures WASM buffer is freed even if slice() OOMs.
+  const wasmBytes = new Uint8Array(wasm.memory.buffer, ptr, len);
+  let copy;
+  try {
+    copy = wasmBytes.slice();
+  } finally {
+    wasm.monty_bytes_free(ptr, len);
+  }
+
+  // Transfer ArrayBuffer to main thread (zero-copy move)
+  self.postMessage(
+    { type: 'result', id, ok: true, snapshotBuffer: copy.buffer },
+    [copy.buffer],
+  );
+}
+
+function handleRestore(id, dataBase64) {
+  // Free any abandoned execution before restoring.
+  if (activeHandle) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+
+  // Decode base64 to Uint8Array
+  const binary = atob(dataBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  // Allocate out-pointer first (small, likely to succeed) so that a
+  // subsequent OOM on the large buffer doesn't leak it.
+  const outError = allocOutPtr();
+
+  const ptr = wasm.monty_alloc(bytes.length);
+  if (ptr === 0) {
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: `monty_alloc(${bytes.length}) returned null — OOM`,
+      errorType: 'MemoryError',
+    });
+    return;
+  }
+  new Uint8Array(wasm.memory.buffer).set(bytes, ptr);
+
+  let handle;
+  try {
+    handle = wasm.monty_restore(ptr, bytes.length, outError.ptr);
+  } catch (e) {
+    outError.free();
+    throw e;
+  } finally {
+    wasm.monty_dealloc(ptr, bytes.length);
+  }
+
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_restore failed',
+      errorType: 'RestoreError',
+    });
+    return;
+  }
+  outError.free();
+  activeHandle = handle;
+  self.postMessage({ type: 'result', id, ok: true });
+}
+
+function handleDispose(id) {
+  if (activeHandle) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage({ type: 'result', id, ok: true });
+}
+
+// ---------------------------------------------------------------------------
+// Message dispatch
+// ---------------------------------------------------------------------------
+
+self.onmessage = (e) => {
+  const { type, id, code, extFns, value, errorMessage, limits,
+    dataBase64, scriptName, resultsJson, errorsJson } = e.data;
+  try {
+    switch (type) {
+      case 'run':
+        handleRun(id, code, limits, scriptName);
+        break;
+      case 'start':
+        handleStart(id, code, extFns, limits, scriptName);
+        break;
+      case 'resume':
+        handleResume(id, value);
+        break;
+      case 'resumeWithError':
+        handleResumeWithError(id, errorMessage);
+        break;
+      case 'resumeAsFuture':
+        handleResumeAsFuture(id);
+        break;
+      case 'resolveFutures':
+        handleResolveFutures(id, resultsJson, errorsJson);
+        break;
+      case 'snapshot':
+        handleSnapshot(id);
+        break;
+      case 'restore':
+        handleRestore(id, dataBase64);
+        break;
+      case 'dispose':
+        handleDispose(id);
+        break;
+      default:
+        self.postMessage({
+          type: 'result', id, ok: false,
+          error: `Unknown message type: ${type}`,
+          errorType: 'UnknownType',
+        });
+    }
+  } catch (e) {
+    // Catch-all for WebAssembly.RuntimeError (panic trap) or other crashes
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: e instanceof WebAssembly.RuntimeError ? 'Panic' : 'InternalError',
+    });
+  }
+};
+
+// Boot
+initWasm().catch((e) => {
+  self.postMessage({
+    type: 'error',
+    message: `WASM init failed: ${e.message}`,
+  });
+});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   collection: ^1.18.0
   dinja: ^1.0.0
   ffi: ^2.1.3
+  file: ^7.0.0
   hooks: ^1.0.2
   meta: ^1.11.0
   path: ^1.8.0

--- a/spike/web_test/bin/main.dart
+++ b/spike/web_test/bin/main.dart
@@ -92,8 +92,7 @@ Future<void> main() async {
       (await _montyStart(
         'result = fetch("https://example.com")'.toJS,
         '["fetch"]'.toJS,
-      ).toDart)
-          .toDart,
+      ).toDart).toDart,
     );
     print('  start() => ${s1['state']}');
 

--- a/spike/web_test/package.json
+++ b/spike/web_test/package.json
@@ -13,7 +13,7 @@
     "@emnapi/runtime": "^1.8.1",
     "@napi-rs/wasm-runtime": "^1.1.1",
     "@pydantic/monty": "^0.0.7",
-    "@pydantic/monty-wasm32-wasi": "^0.0.7",
+    "@pydantic/monty-wasm32-wasi": "^0.0.11",
     "@tybys/wasm-util": "^0.10.1"
   },
   "devDependencies": {

--- a/test/bridge/src/bridge/default_monty_bridge_test.dart
+++ b/test/bridge/src/bridge/default_monty_bridge_test.dart
@@ -618,12 +618,14 @@ void main() {
     });
 
     test('invokes registered handler and resumes with result', () async {
-      bridge.registerOsCallHandler((call) async {
-        if (call.operationName == 'os.getenv') {
-          return 'production';
-        }
-        return null;
-      });
+      bridge.registerOsCallHandler(
+        _TestOsCallHandler((call) async {
+          if (call.operationName == 'os.getenv') {
+            return 'production';
+          }
+          return null;
+        }),
+      );
 
       mock
         ..enqueueProgress(
@@ -655,9 +657,11 @@ void main() {
     });
 
     test('handler exception resumes with error', () async {
-      bridge.registerOsCallHandler((call) async {
-        throw StateError('disk on fire');
-      });
+      bridge.registerOsCallHandler(
+        _TestOsCallHandler((call) async {
+          throw StateError('disk on fire');
+        }),
+      );
 
       mock
         ..enqueueProgress(
@@ -688,7 +692,33 @@ void main() {
     test('registerOsCallHandler after dispose throws StateError', () {
       bridge.dispose();
       expect(
-        () => bridge.registerOsCallHandler((_) async => null),
+        () => bridge.registerOsCallHandler(
+          _TestOsCallHandler((_) async => null),
+        ),
+        throwsStateError,
+      );
+    });
+
+    test('bridge.dispose() disposes registered OsCallHandler', () {
+      final handler = _DisposableOsCallHandler();
+      bridge
+        ..registerOsCallHandler(handler)
+        ..dispose();
+
+      expect(handler.disposed, isTrue);
+      expect(handler.disposeCount, 1);
+    });
+
+    test('bridge.dispose() without handler registered does not throw', () {
+      // No handler registered — dispose should be a clean no-op.
+      bridge.dispose();
+
+      // Calling again (already disposed) should not double-dispose.
+      // registerOsCallHandler should throw since disposed.
+      expect(
+        () => bridge.registerOsCallHandler(
+          _DisposableOsCallHandler(),
+        ),
         throwsStateError,
       );
     });
@@ -1273,6 +1303,28 @@ class _ThrowingOnResumePlatform extends MockMontyPlatform {
   Future<MontyProgress> resume(Object? returnValue) async {
     // ignore: only_throw_errors – test intentionally throws non-Exception objects.
     throw throwOnResume;
+  }
+}
+
+class _TestOsCallHandler extends OsCallHandler {
+  _TestOsCallHandler(this._fn);
+  final Future<Object?> Function(MontyOsCall) _fn;
+
+  @override
+  Future<Object?> handle(MontyOsCall call) => _fn(call);
+}
+
+class _DisposableOsCallHandler extends OsCallHandler {
+  bool disposed = false;
+  int disposeCount = 0;
+
+  @override
+  Future<Object?> handle(MontyOsCall call) => Future.value();
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+    disposeCount++;
   }
 }
 

--- a/test/bridge/src/os_call/env_os_call_handler_test.dart
+++ b/test/bridge/src/os_call/env_os_call_handler_test.dart
@@ -1,0 +1,73 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  MontyOsCall fakeOsCall(String op, [List<MontyValue> args = const []]) =>
+      MontyOsCall(operationName: op, arguments: args);
+
+  group('EnvOsCallHandler', () {
+    late EnvOsCallHandler handler;
+
+    setUp(() {
+      handler = EnvOsCallHandler({
+        'APP_ENV': 'production',
+        'DEBUG': '0',
+      });
+    });
+
+    test('os.getenv returns value from provided map', () async {
+      final result = await handler.handle(
+        fakeOsCall('os.getenv', [const MontyString('APP_ENV')]),
+      );
+
+      expect(result, 'production');
+    });
+
+    test('os.getenv returns null for missing key', () async {
+      final result = await handler.handle(
+        fakeOsCall('os.getenv', [const MontyString('NONEXISTENT')]),
+      );
+
+      expect(result, isNull);
+    });
+
+    test('os.getenv returns default when key missing', () async {
+      final result = await handler.handle(
+        fakeOsCall('os.getenv', [
+          const MontyString('NONEXISTENT'),
+          const MontyString('fallback'),
+        ]),
+      );
+
+      expect(result, 'fallback');
+    });
+
+    test('os.environ returns full map', () async {
+      final result = await handler.handle(fakeOsCall('os.environ'));
+
+      expect(result, isA<Map<String, String>>());
+      final map = result! as Map<String, String>;
+      expect(map['APP_ENV'], 'production');
+      expect(map['DEBUG'], '0');
+      expect(map.length, 2);
+    });
+
+    test('provided map does not leak host Platform.environment', () async {
+      // The handler only exposes the injected map.
+      final result = await handler.handle(fakeOsCall('os.environ'));
+      final map = result! as Map<String, String>;
+
+      // Should not contain typical host-only env vars.
+      expect(map.containsKey('HOME'), isFalse);
+      expect(map.containsKey('PATH'), isFalse);
+    });
+
+    test('unknown os.* operation throws', () {
+      expect(
+        () => handler.handle(fakeOsCall('os.listdir')),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}

--- a/test/bridge/src/os_call/memory_fs_contract_test.dart
+++ b/test/bridge/src/os_call/memory_fs_contract_test.dart
@@ -1,0 +1,11 @@
+import 'package:dart_monty/dart_monty_bridge.dart';
+
+import 'shared_fs_handler_contract.dart';
+
+void main() {
+  runFsHandlerContract(
+    'MemoryFsOsCallHandler',
+    createHandler: () async => MemoryFsOsCallHandler(),
+    rootPath: '/sandbox',
+  );
+}

--- a/test/bridge/src/os_call/memory_fs_os_call_handler_test.dart
+++ b/test/bridge/src/os_call/memory_fs_os_call_handler_test.dart
@@ -1,0 +1,387 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late MemoryFsOsCallHandler handler;
+
+  setUp(() {
+    handler = MemoryFsOsCallHandler();
+  });
+
+  MontyOsCall pathCall(
+    String op,
+    List<MontyValue> args, {
+    Map<String, MontyValue>? kwargs,
+  }) => MontyOsCall(operationName: op, arguments: args, kwargs: kwargs);
+
+  group('MemoryFsOsCallHandler', () {
+    // -- File CRUD --
+
+    test('write_text + read_text round-trip', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          const MontyString('/sandbox/test.txt'),
+          const MontyString('hello world'),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.read_text', [
+          const MontyString('/sandbox/test.txt'),
+        ]),
+      );
+
+      expect(result, 'hello world');
+    });
+
+    test('write_bytes + read_bytes round-trip', () async {
+      await handler.handle(
+        pathCall('Path.write_bytes', [
+          const MontyString('/sandbox/data.bin'),
+          const MontyList([MontyInt(72), MontyInt(105)]),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.read_bytes', [
+          const MontyString('/sandbox/data.bin'),
+        ]),
+      );
+
+      expect(result, [72, 105]);
+    });
+
+    test('read_text on missing file throws', () async {
+      expect(
+        () => handler.handle(
+          pathCall('Path.read_text', [
+            const MontyString('/sandbox/missing.txt'),
+          ]),
+        ),
+        throwsA(isA<OsCallFileNotFoundError>()),
+      );
+    });
+
+    test('write_text creates intermediate directories', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          const MontyString('/sandbox/a/b/c/deep.txt'),
+          const MontyString('deep'),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.read_text', [
+          const MontyString('/sandbox/a/b/c/deep.txt'),
+        ]),
+      );
+
+      expect(result, 'deep');
+    });
+
+    // -- Directory --
+
+    test('mkdir creates directory', () async {
+      handler.writeFile('/sandbox/placeholder', '');
+
+      await handler.handle(
+        pathCall('Path.mkdir', [
+          const MontyString('/sandbox/newdir'),
+        ]),
+      );
+      final isDir = await handler.handle(
+        pathCall('Path.is_dir', [
+          const MontyString('/sandbox/newdir'),
+        ]),
+      );
+
+      expect(isDir, isTrue);
+    });
+
+    test('mkdir with parents=true creates nested', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [const MontyString('/sandbox/a/b/c')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+      final isDir = await handler.handle(
+        pathCall('Path.is_dir', [
+          const MontyString('/sandbox/a/b/c'),
+        ]),
+      );
+
+      expect(isDir, isTrue);
+    });
+
+    test('mkdir with exist_ok=true on existing dir is noop', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [const MontyString('/sandbox/dir')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+
+      // Should not throw.
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [const MontyString('/sandbox/dir')],
+          kwargs: {'exist_ok': const MontyBool(true)},
+        ),
+      );
+    });
+
+    test('mkdir without exist_ok on existing dir throws', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [const MontyString('/sandbox/dir')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+
+      expect(
+        () => handler.handle(
+          pathCall('Path.mkdir', [const MontyString('/sandbox/dir')]),
+        ),
+        throwsA(isA<OsCallException>()),
+      );
+    });
+
+    test('iterdir lists files and subdirs', () async {
+      handler
+        ..writeFile('/sandbox/dir/a.txt', 'a')
+        ..writeFile('/sandbox/dir/b.txt', 'b');
+
+      final result = await handler.handle(
+        pathCall('Path.iterdir', [
+          const MontyString('/sandbox/dir'),
+        ]),
+      );
+
+      expect(result, isA<List<MontyPath>>());
+      final paths = (result! as List<MontyPath>).map((p) => p.value).toList()
+        ..sort();
+      expect(paths, hasLength(2));
+      expect(paths[0], contains('a.txt'));
+      expect(paths[1], contains('b.txt'));
+    });
+
+    test('iterdir on missing dir throws', () {
+      expect(
+        () => handler.handle(
+          pathCall('Path.iterdir', [
+            const MontyString('/sandbox/nope'),
+          ]),
+        ),
+        throwsA(isA<OsCallFileNotFoundError>()),
+      );
+    });
+
+    // -- Queries --
+
+    test('Path.exists true for existing file', () async {
+      handler.writeFile('/sandbox/x.txt', 'x');
+      final result = await handler.handle(
+        pathCall('Path.exists', [
+          const MontyString('/sandbox/x.txt'),
+        ]),
+      );
+
+      expect(result, isTrue);
+    });
+
+    test('Path.exists false for missing path', () async {
+      final result = await handler.handle(
+        pathCall('Path.exists', [
+          const MontyString('/sandbox/nope'),
+        ]),
+      );
+
+      expect(result, isFalse);
+    });
+
+    test('Path.is_file true for file, false for dir', () async {
+      handler.writeFile('/sandbox/f.txt', 'f');
+
+      expect(
+        await handler.handle(
+          pathCall('Path.is_file', [
+            const MontyString('/sandbox/f.txt'),
+          ]),
+        ),
+        isTrue,
+      );
+      expect(
+        await handler.handle(
+          pathCall('Path.is_file', [
+            const MontyString('/sandbox'),
+          ]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('Path.is_dir true for dir, false for file', () async {
+      handler.writeFile('/sandbox/f.txt', 'f');
+
+      expect(
+        await handler.handle(
+          pathCall('Path.is_dir', [
+            const MontyString('/sandbox'),
+          ]),
+        ),
+        isTrue,
+      );
+      expect(
+        await handler.handle(
+          pathCall('Path.is_dir', [
+            const MontyString('/sandbox/f.txt'),
+          ]),
+        ),
+        isFalse,
+      );
+    });
+
+    // -- Mutations --
+
+    test('unlink removes file', () async {
+      handler.writeFile('/sandbox/kill.txt', 'bye');
+      await handler.handle(
+        pathCall('Path.unlink', [
+          const MontyString('/sandbox/kill.txt'),
+        ]),
+      );
+
+      expect(handler.exists('/sandbox/kill.txt'), isFalse);
+    });
+
+    test('unlink on missing file throws', () {
+      expect(
+        () => handler.handle(
+          pathCall('Path.unlink', [
+            const MontyString('/sandbox/ghost.txt'),
+          ]),
+        ),
+        throwsA(isA<OsCallFileNotFoundError>()),
+      );
+    });
+
+    test('rmdir removes empty directory', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [const MontyString('/sandbox/empty')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+      await handler.handle(
+        pathCall('Path.rmdir', [
+          const MontyString('/sandbox/empty'),
+        ]),
+      );
+
+      expect(handler.exists('/sandbox/empty'), isFalse);
+    });
+
+    test('rename moves file', () async {
+      handler.writeFile('/sandbox/old.txt', 'content');
+      final result = await handler.handle(
+        pathCall('Path.rename', [
+          const MontyString('/sandbox/old.txt'),
+          const MontyString('/sandbox/new.txt'),
+        ]),
+      );
+
+      expect(result, '/sandbox/new.txt');
+      expect(handler.exists('/sandbox/old.txt'), isFalse);
+      expect(handler.readFile('/sandbox/new.txt'), 'content');
+    });
+
+    // -- Path operations --
+
+    test('Path.resolve returns path string', () async {
+      final result = await handler.handle(
+        pathCall('Path.resolve', [
+          const MontyString('/sandbox/test.txt'),
+        ]),
+      );
+
+      expect(result, '/sandbox/test.txt');
+    });
+
+    test('Path.absolute returns path string', () async {
+      final result = await handler.handle(
+        pathCall('Path.absolute', [
+          const MontyString('/sandbox/test.txt'),
+        ]),
+      );
+
+      expect(result, '/sandbox/test.txt');
+    });
+
+    // -- Return type contracts (parity with native) --
+
+    test('write_text returns int (content length)', () async {
+      final result = await handler.handle(
+        pathCall('Path.write_text', [
+          const MontyString('/sandbox/len.txt'),
+          const MontyString('hello'),
+        ]),
+      );
+
+      expect(result, isA<int>());
+      expect(result, 5);
+    });
+
+    test('write_bytes returns int (byte count)', () async {
+      final result = await handler.handle(
+        pathCall('Path.write_bytes', [
+          const MontyString('/sandbox/len.bin'),
+          const MontyList([MontyInt(1), MontyInt(2), MontyInt(3)]),
+        ]),
+      );
+
+      expect(result, isA<int>());
+      expect(result, 3);
+    });
+
+    test('read_bytes returns List<int>', () async {
+      handler.writeFileBytes('/sandbox/bytes.bin', [65, 66, 67]);
+      final result = await handler.handle(
+        pathCall('Path.read_bytes', [
+          const MontyString('/sandbox/bytes.bin'),
+        ]),
+      );
+
+      expect(result, isA<List<int>>());
+      expect(result, [65, 66, 67]);
+    });
+
+    test('iterdir returns List<MontyPath>', () async {
+      handler.writeFile('/sandbox/ls/x.txt', 'x');
+      final result = await handler.handle(
+        pathCall('Path.iterdir', [
+          const MontyString('/sandbox/ls'),
+        ]),
+      );
+
+      expect(result, isA<List<MontyPath>>());
+    });
+
+    // -- Dart-side API --
+
+    test('writeFile and readFile work from Dart', () {
+      handler.writeFile('/data/test.json', '{"a": 1}');
+      expect(handler.readFile('/data/test.json'), '{"a": 1}');
+    });
+
+    test('exists() checks both files and directories', () {
+      handler.writeFile('/data/file.txt', 'f');
+      expect(handler.exists('/data/file.txt'), isTrue);
+      expect(handler.exists('/data'), isTrue);
+      expect(handler.exists('/nope'), isFalse);
+    });
+  });
+}

--- a/test/bridge/src/os_call/router_os_call_handler_test.dart
+++ b/test/bridge/src/os_call/router_os_call_handler_test.dart
@@ -1,0 +1,150 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  MontyOsCall fakeOsCall(String op) => MontyOsCall(
+    operationName: op,
+    arguments: const [],
+  );
+
+  group('RouterOsCallHandler', () {
+    test('routes Path.* to filesystem handler', () async {
+      final router = RouterOsCallHandler({
+        'Path.': _StubHandler('fs'),
+        'os.': _StubHandler('env'),
+      });
+
+      final result = await router.handle(fakeOsCall('Path.exists'));
+      expect(result, 'fs');
+    });
+
+    test('routes os.* to environment handler', () async {
+      final router = RouterOsCallHandler({
+        'Path.': _StubHandler('fs'),
+        'os.': _StubHandler('env'),
+      });
+
+      final result = await router.handle(fakeOsCall('os.getenv'));
+      expect(result, 'env');
+    });
+
+    test('unknown prefix throws UnsupportedError', () {
+      final router = RouterOsCallHandler({
+        'Path.': _StubHandler('fs'),
+      });
+
+      expect(
+        () => router.handle(fakeOsCall('socket.connect')),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('custom fallback handler receives unknown operations', () async {
+      final router = RouterOsCallHandler(
+        {'Path.': _StubHandler('fs')},
+        fallback: _StubHandler('fallback'),
+      );
+
+      final result = await router.handle(fakeOsCall('socket.connect'));
+      expect(result, 'fallback');
+    });
+
+    test('dispose() disposes all child handlers', () async {
+      final fs = _StubHandler('fs');
+      final env = _StubHandler('env');
+      final fallback = _StubHandler('fallback');
+      final router = RouterOsCallHandler(
+        {'Path.': fs, 'os.': env},
+        fallback: fallback,
+      );
+
+      await router.dispose();
+
+      expect(fs.disposed, isTrue);
+      expect(env.disposed, isTrue);
+      expect(fallback.disposed, isTrue);
+    });
+
+    test('routes date.*/datetime.* to time handler', () async {
+      final time = _StubHandler('time');
+      final router = RouterOsCallHandler({
+        'Path.': _StubHandler('fs'),
+        'date.': time,
+        'datetime.': time,
+      });
+
+      expect(await router.handle(fakeOsCall('date.today')), 'time');
+      expect(await router.handle(fakeOsCall('datetime.now')), 'time');
+    });
+
+    test('multiple prefixes can map to same handler', () async {
+      final shared = _StubHandler('shared');
+      final router = RouterOsCallHandler({
+        'date.': shared,
+        'datetime.': shared,
+      });
+
+      // Both should work and share the same handler.
+      expect(await router.handle(fakeOsCall('date.today')), 'shared');
+      expect(await router.handle(fakeOsCall('datetime.now')), 'shared');
+
+      // Dispose should only be called once despite two prefix entries.
+      await router.dispose();
+      expect(shared.disposeCount, 1);
+    });
+
+    test('empty prefix map throws on any call', () {
+      final router = RouterOsCallHandler({});
+
+      expect(
+        () => router.handle(fakeOsCall('Path.exists')),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('longest prefix match wins', () async {
+      final broad = _StubHandler('broad');
+      final specific = _StubHandler('specific');
+      final router = RouterOsCallHandler({
+        'Path.': broad,
+        'Path.read_': specific,
+      });
+
+      // 'Path.read_text' matches both — longest prefix wins.
+      expect(await router.handle(fakeOsCall('Path.read_text')), 'specific');
+      // 'Path.exists' only matches 'Path.'.
+      expect(await router.handle(fakeOsCall('Path.exists')), 'broad');
+    });
+
+    test('handlerFor returns registered handler', () {
+      final fs = _StubHandler('fs');
+      final router = RouterOsCallHandler({'Path.': fs});
+
+      expect(router.handlerFor('Path.'), same(fs));
+      expect(router.handlerFor('os.'), isNull);
+    });
+
+    test('dispose() with empty handlers map does not throw', () async {
+      final router = RouterOsCallHandler({});
+      await router.dispose();
+    });
+  });
+}
+
+class _StubHandler extends OsCallHandler {
+  _StubHandler(this.tag);
+
+  final String tag;
+  bool disposed = false;
+  int disposeCount = 0;
+
+  @override
+  Future<Object?> handle(MontyOsCall call) => Future.value(tag);
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+    disposeCount++;
+  }
+}

--- a/test/bridge/src/os_call/sandboxed_native_fs_contract_test.dart
+++ b/test/bridge/src/os_call/sandboxed_native_fs_contract_test.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:dart_monty/src/bridge/os_call/sandboxed_native_fs_handler.dart';
+import 'package:test/test.dart';
+
+import 'shared_fs_handler_contract.dart';
+
+void main() {
+  // Create once for the entire suite — each test gets a fresh handler
+  // but the root dir persists (tests create/delete their own files).
+  final root = Directory.systemTemp.createTempSync('monty_contract_');
+  final rootPath = root.resolveSymbolicLinksSync();
+
+  tearDownAll(() => root.deleteSync(recursive: true));
+
+  runFsHandlerContract(
+    'SandboxedNativeFsHandler',
+    createHandler: () async => SandboxedNativeFsHandler(root: root),
+    rootPath: rootPath,
+  );
+}

--- a/test/bridge/src/os_call/sandboxed_native_fs_test.dart
+++ b/test/bridge/src/os_call/sandboxed_native_fs_test.dart
@@ -1,0 +1,314 @@
+import 'dart:io';
+
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty/src/bridge/os_call/sandboxed_native_fs_handler.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late Directory root;
+  late String rootPath;
+  late SandboxedNativeFsHandler handler;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('monty_sandbox_test_');
+    // Resolve symlinks so paths match on macOS (/var -> /private/var).
+    rootPath = root.resolveSymbolicLinksSync();
+    handler = SandboxedNativeFsHandler(root: root);
+  });
+
+  tearDown(() {
+    root.deleteSync(recursive: true);
+  });
+
+  MontyOsCall pathCall(
+    String op,
+    List<MontyValue> args, {
+    Map<String, MontyValue>? kwargs,
+  }) => MontyOsCall(operationName: op, arguments: args, kwargs: kwargs);
+
+  group('SandboxedNativeFsHandler', () {
+    // -- Basic FS operations (same contract as VFS) --
+
+    test('write_text + read_text round-trip', () async {
+      // Create the file first.
+      final f = File('$rootPath/test.txt')..writeAsStringSync('hello');
+      expect(f.existsSync(), isTrue);
+
+      final result = await handler.handle(
+        pathCall('Path.read_text', [
+          MontyString('$rootPath/test.txt'),
+        ]),
+      );
+
+      expect(result, 'hello');
+    });
+
+    test('write_text creates file inside sandbox', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/new.txt'),
+          const MontyString('content'),
+        ]),
+      );
+
+      expect(File('$rootPath/new.txt').readAsStringSync(), 'content');
+    });
+
+    test('write_text returns int (content length)', () async {
+      final result = await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/len.txt'),
+          const MontyString('hello'),
+        ]),
+      );
+
+      expect(result, 5);
+    });
+
+    test('write_bytes + read_bytes round-trip', () async {
+      await handler.handle(
+        pathCall('Path.write_bytes', [
+          MontyString('$rootPath/data.bin'),
+          const MontyList([MontyInt(65), MontyInt(66)]),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.read_bytes', [
+          MontyString('$rootPath/data.bin'),
+        ]),
+      );
+
+      expect(result, [65, 66]);
+    });
+
+    test('mkdir + iterdir', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [MontyString('$rootPath/sub')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/sub/a.txt'),
+          const MontyString('a'),
+        ]),
+      );
+
+      final result = await handler.handle(
+        pathCall('Path.iterdir', [
+          MontyString('$rootPath/sub'),
+        ]),
+      );
+
+      expect(result, isA<List<MontyPath>>());
+      expect((result! as List<MontyPath>).first.value, contains('a.txt'));
+    });
+
+    test('Path.exists true for file, false for missing', () async {
+      File('$rootPath/x.txt').writeAsStringSync('x');
+
+      expect(
+        await handler.handle(
+          pathCall('Path.exists', [
+            MontyString('$rootPath/x.txt'),
+          ]),
+        ),
+        isTrue,
+      );
+      expect(
+        await handler.handle(
+          pathCall('Path.exists', [
+            MontyString('$rootPath/nope.txt'),
+          ]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('unlink removes file', () async {
+      File('$rootPath/del.txt').writeAsStringSync('bye');
+      await handler.handle(
+        pathCall('Path.unlink', [
+          MontyString('$rootPath/del.txt'),
+        ]),
+      );
+
+      expect(File('$rootPath/del.txt').existsSync(), isFalse);
+    });
+
+    test('rename moves file', () async {
+      File('$rootPath/old.txt').writeAsStringSync('moved');
+      final result = await handler.handle(
+        pathCall('Path.rename', [
+          MontyString('$rootPath/old.txt'),
+          MontyString('$rootPath/new.txt'),
+        ]),
+      );
+
+      expect(result, '$rootPath/new.txt');
+      expect(File('$rootPath/old.txt').existsSync(), isFalse);
+      expect(File('$rootPath/new.txt').readAsStringSync(), 'moved');
+    });
+
+    // -- Security tests --
+
+    group('security', () {
+      test('path traversal via ../ is rejected', () {
+        expect(
+          () => handler.handle(
+            pathCall('Path.read_text', [
+              MontyString('$rootPath/../../../etc/passwd'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+
+      test('path traversal via /../ in middle is rejected', () {
+        expect(
+          () => handler.handle(
+            pathCall('Path.read_text', [
+              MontyString('$rootPath/sub/../../etc/passwd'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+
+      test('absolute path outside root is rejected', () {
+        expect(
+          () => handler.handle(
+            pathCall('Path.read_text', [
+              const MontyString('/etc/passwd'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+
+      test(
+        'path that startsWith root prefix but is different dir is '
+        'rejected',
+        () {
+          // e.g., root=/tmp/sandbox, path=/tmp/sandboxevil/etc/passwd
+          // This is the exact edge case from review comment #9.
+          final evilDir = Directory('${rootPath}evil')..createSync();
+          addTearDown(() {
+            if (evilDir.existsSync()) evilDir.deleteSync(recursive: true);
+          });
+
+          File('${evilDir.path}/secret.txt').writeAsStringSync('stolen');
+
+          expect(
+            () => handler.handle(
+              pathCall('Path.read_text', [
+                MontyString('${rootPath}evil/secret.txt'),
+              ]),
+            ),
+            throwsA(isA<OsCallPermissionError>()),
+          );
+        },
+      );
+
+      test('symlink inside sandbox pointing outside is rejected', () {
+        // Create a symlink inside the sandbox that points to /tmp.
+        final link = Link('$rootPath/escape_link')..createSync('/tmp');
+
+        expect(link.existsSync(), isTrue);
+
+        expect(
+          () => handler.handle(
+            pathCall('Path.read_text', [
+              MontyString('$rootPath/escape_link'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+
+      test('symlink chain escaping sandbox is rejected', () {
+        // Create a file outside the sandbox.
+        final outsideDir = Directory.systemTemp.createTempSync(
+          'monty_outside_',
+        );
+        addTearDown(() => outsideDir.deleteSync(recursive: true));
+
+        File('${outsideDir.path}/secret.txt').writeAsStringSync('stolen');
+
+        // Symlink inside sandbox -> outside file.
+        Link(
+          '$rootPath/chain_link',
+        ).createSync('${outsideDir.path}/secret.txt');
+
+        expect(
+          () => handler.handle(
+            pathCall('Path.read_text', [
+              MontyString('$rootPath/chain_link'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+
+      test('Path.resolve on symlink outside sandbox is rejected', () {
+        final outsideDir = Directory.systemTemp.createTempSync(
+          'monty_resolve_',
+        );
+        addTearDown(() => outsideDir.deleteSync(recursive: true));
+
+        Link('$rootPath/resolve_link').createSync(outsideDir.path);
+
+        expect(
+          () => handler.handle(
+            pathCall('Path.resolve', [
+              MontyString('$rootPath/resolve_link'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+
+      test('normalize removes redundant separators', () async {
+        File('$rootPath/norm.txt').writeAsStringSync('ok');
+
+        // Double slashes should normalize and still work.
+        final result = await handler.handle(
+          pathCall('Path.read_text', [
+            MontyString('$rootPath//norm.txt'),
+          ]),
+        );
+
+        expect(result, 'ok');
+      });
+
+      test('write to path outside sandbox is rejected', () {
+        expect(
+          () => handler.handle(
+            pathCall('Path.write_text', [
+              const MontyString('/tmp/escape.txt'),
+              const MontyString('pwned'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+
+      test('rename target outside sandbox is rejected', () {
+        File('$rootPath/src.txt').writeAsStringSync('data');
+
+        expect(
+          () => handler.handle(
+            pathCall('Path.rename', [
+              MontyString('$rootPath/src.txt'),
+              const MontyString('/tmp/escaped.txt'),
+            ]),
+          ),
+          throwsA(isA<OsCallPermissionError>()),
+        );
+      });
+    });
+  });
+}

--- a/test/bridge/src/os_call/shared_fs_handler_contract.dart
+++ b/test/bridge/src/os_call/shared_fs_handler_contract.dart
@@ -1,0 +1,373 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+/// Runs the shared FS handler contract against any [OsCallHandler].
+///
+/// Both `MemoryFsOsCallHandler` and `SandboxedNativeFsHandler` must
+/// pass this identical suite, proving behavioral parity.
+///
+/// [name] is used as the test group label.
+/// [createHandler] returns a fresh handler for each test.
+/// [rootPath] is the base directory path the handler operates in.
+/// [cleanUp] is called in tearDown to release resources.
+void runFsHandlerContract(
+  String name, {
+  required Future<OsCallHandler> Function() createHandler,
+  required String rootPath,
+  Future<void> Function()? cleanUp,
+}) {
+  late OsCallHandler handler;
+
+  setUp(() async {
+    handler = await createHandler();
+  });
+
+  tearDown(() async {
+    await handler.dispose();
+    await cleanUp?.call();
+  });
+
+  MontyOsCall pathCall(
+    String op,
+    List<MontyValue> args, {
+    Map<String, MontyValue>? kwargs,
+  }) => MontyOsCall(operationName: op, arguments: args, kwargs: kwargs);
+
+  group('$name FS contract', () {
+    // -- File CRUD --
+
+    test('write_text + read_text round-trip', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/test.txt'),
+          const MontyString('hello world'),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.read_text', [
+          MontyString('$rootPath/test.txt'),
+        ]),
+      );
+      expect(result, 'hello world');
+    });
+
+    test('write_bytes + read_bytes round-trip', () async {
+      await handler.handle(
+        pathCall('Path.write_bytes', [
+          MontyString('$rootPath/data.bin'),
+          const MontyList([MontyInt(72), MontyInt(105)]),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.read_bytes', [
+          MontyString('$rootPath/data.bin'),
+        ]),
+      );
+      expect(result, [72, 105]);
+    });
+
+    test('write_text returns int (content length)', () async {
+      final result = await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/len.txt'),
+          const MontyString('hello'),
+        ]),
+      );
+      expect(result, isA<int>());
+      expect(result, 5);
+    });
+
+    test('write_bytes returns int (byte count)', () async {
+      final result = await handler.handle(
+        pathCall('Path.write_bytes', [
+          MontyString('$rootPath/len.bin'),
+          const MontyList([MontyInt(1), MontyInt(2), MontyInt(3)]),
+        ]),
+      );
+      expect(result, isA<int>());
+      expect(result, 3);
+    });
+
+    test('read_bytes returns List<int>', () async {
+      await handler.handle(
+        pathCall('Path.write_bytes', [
+          MontyString('$rootPath/bytes.bin'),
+          const MontyList([MontyInt(65), MontyInt(66), MontyInt(67)]),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.read_bytes', [
+          MontyString('$rootPath/bytes.bin'),
+        ]),
+      );
+      expect(result, isA<List<int>>());
+      expect(result, [65, 66, 67]);
+    });
+
+    // -- Directory --
+
+    test('mkdir creates directory', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [MontyString('$rootPath/newdir')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+      final isDir = await handler.handle(
+        pathCall('Path.is_dir', [
+          MontyString('$rootPath/newdir'),
+        ]),
+      );
+      expect(isDir, isTrue);
+    });
+
+    test('mkdir with parents=true creates nested', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [MontyString('$rootPath/a/b/c')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+      final isDir = await handler.handle(
+        pathCall('Path.is_dir', [
+          MontyString('$rootPath/a/b/c'),
+        ]),
+      );
+      expect(isDir, isTrue);
+    });
+
+    test('mkdir with exist_ok=true on existing dir is noop', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [MontyString('$rootPath/existdir')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+      // Should not throw.
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [MontyString('$rootPath/existdir')],
+          kwargs: {'exist_ok': const MontyBool(true)},
+        ),
+      );
+    });
+
+    test('iterdir lists files', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/ls/a.txt'),
+          const MontyString('a'),
+        ]),
+      );
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/ls/b.txt'),
+          const MontyString('b'),
+        ]),
+      );
+
+      final result = await handler.handle(
+        pathCall('Path.iterdir', [
+          MontyString('$rootPath/ls'),
+        ]),
+      );
+      expect(result, isA<List<MontyPath>>());
+      final paths = (result! as List<MontyPath>).map((p) => p.value).toList()
+        ..sort();
+      expect(paths, hasLength(2));
+      expect(paths[0], contains('a.txt'));
+      expect(paths[1], contains('b.txt'));
+    });
+
+    test('iterdir returns List<MontyPath>', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/lsdir/x.txt'),
+          const MontyString('x'),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.iterdir', [
+          MontyString('$rootPath/lsdir'),
+        ]),
+      );
+      expect(result, isA<List<MontyPath>>());
+    });
+
+    // -- Queries --
+
+    test('Path.exists true for existing file', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/exists.txt'),
+          const MontyString('yes'),
+        ]),
+      );
+      final result = await handler.handle(
+        pathCall('Path.exists', [
+          MontyString('$rootPath/exists.txt'),
+        ]),
+      );
+      expect(result, isTrue);
+    });
+
+    test('Path.exists false for missing path', () async {
+      final result = await handler.handle(
+        pathCall('Path.exists', [
+          MontyString('$rootPath/nope.txt'),
+        ]),
+      );
+      expect(result, isFalse);
+    });
+
+    test('Path.is_file true for file, false for dir', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/f.txt'),
+          const MontyString('f'),
+        ]),
+      );
+      expect(
+        await handler.handle(
+          pathCall('Path.is_file', [
+            MontyString('$rootPath/f.txt'),
+          ]),
+        ),
+        isTrue,
+      );
+      expect(
+        await handler.handle(
+          pathCall('Path.is_file', [
+            MontyString(rootPath),
+          ]),
+        ),
+        isFalse,
+      );
+    });
+
+    test('Path.is_dir true for dir, false for file', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/d.txt'),
+          const MontyString('d'),
+        ]),
+      );
+      expect(
+        await handler.handle(
+          pathCall('Path.is_dir', [
+            MontyString(rootPath),
+          ]),
+        ),
+        isTrue,
+      );
+      expect(
+        await handler.handle(
+          pathCall('Path.is_dir', [
+            MontyString('$rootPath/d.txt'),
+          ]),
+        ),
+        isFalse,
+      );
+    });
+
+    // -- Mutations --
+
+    test('unlink removes file', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/kill.txt'),
+          const MontyString('bye'),
+        ]),
+      );
+      await handler.handle(
+        pathCall('Path.unlink', [
+          MontyString('$rootPath/kill.txt'),
+        ]),
+      );
+      final exists = await handler.handle(
+        pathCall('Path.exists', [
+          MontyString('$rootPath/kill.txt'),
+        ]),
+      );
+      expect(exists, isFalse);
+    });
+
+    test('rmdir removes empty directory', () async {
+      await handler.handle(
+        pathCall(
+          'Path.mkdir',
+          [MontyString('$rootPath/emptydir')],
+          kwargs: {'parents': const MontyBool(true)},
+        ),
+      );
+      await handler.handle(
+        pathCall('Path.rmdir', [
+          MontyString('$rootPath/emptydir'),
+        ]),
+      );
+      final exists = await handler.handle(
+        pathCall('Path.exists', [
+          MontyString('$rootPath/emptydir'),
+        ]),
+      );
+      expect(exists, isFalse);
+    });
+
+    test('rename moves file', () async {
+      await handler.handle(
+        pathCall('Path.write_text', [
+          MontyString('$rootPath/old.txt'),
+          const MontyString('moved'),
+        ]),
+      );
+      final newPath = await handler.handle(
+        pathCall('Path.rename', [
+          MontyString('$rootPath/old.txt'),
+          MontyString('$rootPath/new.txt'),
+        ]),
+      );
+      expect(newPath, '$rootPath/new.txt');
+
+      final oldExists = await handler.handle(
+        pathCall('Path.exists', [
+          MontyString('$rootPath/old.txt'),
+        ]),
+      );
+      expect(oldExists, isFalse);
+
+      final content = await handler.handle(
+        pathCall('Path.read_text', [
+          MontyString('$rootPath/new.txt'),
+        ]),
+      );
+      expect(content, 'moved');
+    });
+
+    // -- Path operations --
+
+    test('Path.resolve returns a path string', () async {
+      final result = await handler.handle(
+        pathCall('Path.resolve', [
+          MontyString('$rootPath/any.txt'),
+        ]),
+      );
+      expect(result, isA<String>());
+      expect(result! as String, contains('any.txt'));
+    });
+
+    test('Path.absolute returns a path string', () async {
+      final result = await handler.handle(
+        pathCall('Path.absolute', [
+          MontyString('$rootPath/any.txt'),
+        ]),
+      );
+      expect(result, isA<String>());
+      expect(result! as String, contains('any.txt'));
+    });
+  });
+}

--- a/test/bridge/src/os_call/time_os_call_handler_test.dart
+++ b/test/bridge/src/os_call/time_os_call_handler_test.dart
@@ -1,0 +1,101 @@
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  MontyOsCall fakeOsCall(String op) => MontyOsCall(
+    operationName: op,
+    arguments: const [],
+  );
+
+  group('TimeOsCallHandler', () {
+    test('date.today returns date map with __type', () async {
+      final handler = TimeOsCallHandler();
+      final result =
+          (await handler.handle(fakeOsCall('date.today')))!
+              as Map<String, Object?>;
+
+      expect(result['__type'], 'date');
+      expect(result['year'], isA<int>());
+      expect(result['month'], isA<int>());
+      expect(result['day'], isA<int>());
+      expect(result.containsKey('hour'), isFalse);
+    });
+
+    test('datetime.now returns datetime map with __type', () async {
+      final handler = TimeOsCallHandler();
+      final result =
+          (await handler.handle(fakeOsCall('datetime.now')))!
+              as Map<String, Object?>;
+
+      expect(result['__type'], 'datetime');
+      expect(result['year'], isA<int>());
+      expect(result['month'], isA<int>());
+      expect(result['day'], isA<int>());
+      expect(result['hour'], isA<int>());
+      expect(result['minute'], isA<int>());
+      expect(result['second'], isA<int>());
+      expect(result['microsecond'], isA<int>());
+      expect(result['offset_seconds'], isA<int>());
+      expect(result['timezone_name'], isA<String>());
+    });
+
+    test('injected clock is used (frozen time)', () async {
+      final frozen = DateTime(2026, 3, 15, 10, 30, 45, 123, 456);
+      final handler = TimeOsCallHandler(clock: () => frozen);
+
+      final date =
+          (await handler.handle(fakeOsCall('date.today')))!
+              as Map<String, Object?>;
+      expect(date['year'], 2026);
+      expect(date['month'], 3);
+      expect(date['day'], 15);
+
+      final dt =
+          (await handler.handle(fakeOsCall('datetime.now')))!
+              as Map<String, Object?>;
+      expect(dt['year'], 2026);
+      expect(dt['hour'], 10);
+      expect(dt['minute'], 30);
+      expect(dt['second'], 45);
+    });
+
+    test('unknown date/datetime operation throws', () {
+      final handler = TimeOsCallHandler();
+
+      expect(
+        () => handler.handle(fakeOsCall('date.yesterday')),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => handler.handle(fakeOsCall('datetime.utcnow')),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('default clock uses DateTime.now', () async {
+      final handler = TimeOsCallHandler();
+      final before = DateTime.now();
+      final result =
+          (await handler.handle(fakeOsCall('datetime.now')))!
+              as Map<String, Object?>;
+      final after = DateTime.now();
+
+      expect(result['year'], before.year);
+      // Day should be within the range of the test run.
+      expect(result['day'], greaterThanOrEqualTo(before.day));
+      expect(result['day'], lessThanOrEqualTo(after.day));
+    });
+
+    test('timezone offset populated correctly', () async {
+      final frozen = DateTime(2026, 6, 15, 12);
+      final handler = TimeOsCallHandler(clock: () => frozen);
+
+      final result =
+          (await handler.handle(fakeOsCall('datetime.now')))!
+              as Map<String, Object?>;
+      expect(result['offset_seconds'], frozen.timeZoneOffset.inSeconds);
+      expect(result['timezone_name'], frozen.timeZoneName);
+    });
+  });
+}

--- a/test/ffi/integration/python_ladder_runner.dart
+++ b/test/ffi/integration/python_ladder_runner.dart
@@ -15,10 +15,12 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
 import 'package:dart_monty/dart_monty_ffi.dart';
 
 Future<void> main() async {
   final bindings = NativeBindingsFfi();
+  final osCallHandler = createDefaultOsCallHandler();
   final fixtureDir = Directory('test/fixtures/python_ladder');
   final tierFiles =
       fixtureDir
@@ -35,7 +37,7 @@ Future<void> main() async {
         .cast<Map<String, dynamic>>();
 
     for (final fixture in fixtures) {
-      final result = await _runFixture(bindings, fixture);
+      final result = await _runFixture(bindings, fixture, osCallHandler);
       stdout.writeln(jsonEncode(result));
     }
   }
@@ -44,16 +46,20 @@ Future<void> main() async {
 Future<Map<String, dynamic>> _runFixture(
   NativeBindingsFfi bindings,
   Map<String, dynamic> fixture,
+  OsCallHandler osCallHandler,
 ) async {
   final id = fixture['id'] as int;
   final code = fixture['code'] as String;
   final expectError = fixture['expectError'] as bool? ?? false;
+  final osCall = fixture['osCall'] as bool? ?? false;
   final xfail = fixture['xfail'] as String?;
   final monty = MontyFfi(bindings: bindings);
 
   Map<String, dynamic> result;
   try {
-    if (fixture['externalFunctions'] != null) {
+    if (osCall) {
+      result = await _runOsCall(monty, fixture, osCallHandler);
+    } else if (fixture['externalFunctions'] != null) {
       result = await _runIterative(monty, fixture);
     } else if (expectError) {
       result = await _runExpectError(monty, id, code);
@@ -83,6 +89,56 @@ Future<Map<String, dynamic>> _runSimple(
   final result = await monty.run(code);
 
   return {'id': id, 'ok': true, 'value': result.value};
+}
+
+Future<Map<String, dynamic>> _runOsCall(
+  MontyFfi monty,
+  Map<String, dynamic> fixture,
+  OsCallHandler osCallHandler,
+) async {
+  final id = fixture['id'] as int;
+  final code = fixture['code'] as String;
+  final expectError = fixture['expectError'] as bool? ?? false;
+
+  var progress = await monty.start(code);
+
+  try {
+    while (progress is! MontyComplete) {
+      if (progress is MontyOsCall) {
+        try {
+          final result = await osCallHandler.handle(progress);
+          progress = await monty.resume(result);
+        } on Object catch (e) {
+          progress = await monty.resumeWithError(e.toString());
+        }
+      } else if (progress is MontyPending) {
+        progress = await monty.resumeWithError(
+          'Unexpected external function: ${progress.functionName}',
+        );
+      } else {
+        return {
+          'id': id,
+          'ok': false,
+          'error': 'Unexpected progress: $progress',
+        };
+      }
+    }
+  } on MontyScriptError catch (e) {
+    if (expectError) {
+      return {'id': id, 'ok': true, 'error': e.message};
+    }
+    return {'id': id, 'ok': false, 'error': e.message};
+  }
+
+  if (expectError) {
+    final error = progress.result.error;
+    if (error != null) {
+      return {'id': id, 'ok': true, 'error': error.message};
+    }
+    return {'id': id, 'ok': false, 'error': 'Expected error but succeeded'};
+  }
+
+  return {'id': id, 'ok': true, 'value': progress.result.value};
 }
 
 Future<Map<String, dynamic>> _runExpectError(

--- a/test/platform/monty_session_test.dart
+++ b/test/platform/monty_session_test.dart
@@ -1,4 +1,5 @@
 import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
 import 'package:dart_monty/dart_monty_testing.dart';
 import 'package:test/test.dart';
 
@@ -1136,6 +1137,143 @@ void main() {
       );
     });
 
+    group('OsCallHandler lifecycle', () {
+      test('session.dispose() disposes OsCallHandler', () {
+        final handler = _MockOsCallHandler();
+        MontySession(platform: mock, osCallHandler: handler).dispose();
+
+        expect(handler.disposed, isTrue);
+        expect(handler.disposeCount, 1);
+      });
+
+      test('run() dispatches OsCall through handler', () async {
+        final handler = _MockOsCallHandler(
+          onHandle: (call) async => 'file content',
+        );
+        final s = MontySession(platform: mock, osCallHandler: handler);
+
+        mock
+          ..enqueueProgress(
+            const MontyPending(
+              functionName: '__restore_state__',
+              arguments: [],
+            ),
+          )
+          ..enqueueProgress(
+            const MontyOsCall(
+              operationName: 'Path.read_text',
+              arguments: [MontyString('/sandbox/test.txt')],
+              callId: 1,
+            ),
+          )
+          ..enqueueProgress(
+            MontyPending(
+              functionName: '__persist_state__',
+              arguments: [_toMontyDict(const {})],
+            ),
+          )
+          ..enqueueProgress(
+            const MontyComplete(
+              result: MontyResult(usage: _usage),
+            ),
+          );
+
+        await s.run('open("/sandbox/test.txt")');
+
+        // Handler was invoked and resume received the handler's return value.
+        expect(handler.handleCount, 1);
+        expect(mock.resumeReturnValues, contains('file content'));
+
+        s.dispose();
+      });
+
+      test('run() catches handler error and resumes with error', () async {
+        final handler = _MockOsCallHandler(
+          onHandle: (call) async => throw StateError('disk on fire'),
+        );
+        final s = MontySession(platform: mock, osCallHandler: handler);
+
+        mock
+          ..enqueueProgress(
+            const MontyPending(
+              functionName: '__restore_state__',
+              arguments: [],
+            ),
+          )
+          ..enqueueProgress(
+            const MontyOsCall(
+              operationName: 'Path.write_text',
+              arguments: [MontyString('/sandbox/out.txt')],
+              callId: 1,
+            ),
+          )
+          ..enqueueProgress(
+            MontyPending(
+              functionName: '__persist_state__',
+              arguments: [_toMontyDict(const {})],
+            ),
+          )
+          ..enqueueProgress(
+            const MontyComplete(
+              result: MontyResult(usage: _usage),
+            ),
+          );
+
+        await s.run('write("/sandbox/out.txt")');
+
+        expect(mock.resumeErrorMessages, hasLength(1));
+        expect(mock.resumeErrorMessages.first, contains('disk on fire'));
+
+        s.dispose();
+      });
+
+      test('run() catches OsCallFileNotFoundError', () async {
+        final handler = _MockOsCallHandler(
+          onHandle: (call) async => throw const OsCallFileNotFoundError(
+            'Path.read_text',
+            'No such file: /sandbox/missing.txt',
+          ),
+        );
+        final s = MontySession(platform: mock, osCallHandler: handler);
+
+        mock
+          ..enqueueProgress(
+            const MontyPending(
+              functionName: '__restore_state__',
+              arguments: [],
+            ),
+          )
+          ..enqueueProgress(
+            const MontyOsCall(
+              operationName: 'Path.read_text',
+              arguments: [MontyString('/sandbox/missing.txt')],
+              callId: 1,
+            ),
+          )
+          ..enqueueProgress(
+            MontyPending(
+              functionName: '__persist_state__',
+              arguments: [_toMontyDict(const {})],
+            ),
+          )
+          ..enqueueProgress(
+            const MontyComplete(
+              result: MontyResult(usage: _usage),
+            ),
+          );
+
+        await s.run('open("/sandbox/missing.txt")');
+
+        expect(mock.resumeErrorMessages, hasLength(1));
+        expect(
+          mock.resumeErrorMessages.first,
+          contains('FileNotFoundError'),
+        );
+
+        s.dispose();
+      });
+    });
+
     group('extractAssignmentTargets', () {
       test('finds simple assignments', () {
         expect(
@@ -1272,6 +1410,28 @@ class _ThrowingMockPlatform extends MockMontyPlatform {
   Future<MontyProgress> resumeWithError(String errorMessage) async {
     if (throwOnResumeWithError != null) throw throwOnResumeWithError!;
     return super.resumeWithError(errorMessage);
+  }
+}
+
+class _MockOsCallHandler extends OsCallHandler {
+  _MockOsCallHandler({this.onHandle});
+
+  final Future<Object?> Function(MontyOsCall)? onHandle;
+  bool disposed = false;
+  int disposeCount = 0;
+  int handleCount = 0;
+
+  @override
+  Future<Object?> handle(MontyOsCall call) {
+    handleCount++;
+    if (onHandle != null) return onHandle!(call);
+    return Future.value();
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposed = true;
+    disposeCount++;
   }
 }
 

--- a/test/wasm/integration/python_ladder_runner.dart
+++ b/test/wasm/integration/python_ladder_runner.dart
@@ -80,6 +80,7 @@ const _tierFiles = [
   'fixtures/tier_17_json_module.json',
   'fixtures/tier_18_datetime_module.json',
   'fixtures/tier_19_lifecycle_errors.json',
+  'fixtures/tier_20_oscall.json',
 ];
 
 // ---------------------------------------------------------------------------
@@ -103,14 +104,37 @@ void _output(Map<String, dynamic> result) {
 // ---------------------------------------------------------------------------
 
 Future<void> main() async {
+  try {
+    await _runLadder();
+  } catch (e, st) {
+    print('LADDER_ERROR:Unhandled exception in main: $e');
+    print('LADDER_STACKTRACE:$st');
+    print('LADDER_DONE');
+  }
+}
+
+Future<void> _runLadder() async {
   print('=== WASM Python Ladder Runner ===');
 
-  final ok = (await _montyInit().toDart).toDart;
-  if (!ok) {
-    print('LADDER_ERROR:Monty Worker init failed');
+  late final bool ok;
+  try {
+    ok = (await _montyInit().toDart).toDart;
+  } catch (e, st) {
+    print('LADDER_ERROR:DartMontyBridge.init() threw: $e');
+    print('LADDER_STACKTRACE:$st');
     print('LADDER_DONE');
+
     return;
   }
+
+  if (!ok) {
+    print('LADDER_ERROR:Monty Worker init returned false');
+    print('LADDER_DONE');
+
+    return;
+  }
+
+  print('LADDER_INFO:Worker initialized successfully');
 
   for (final tierFile in _tierFiles) {
     try {
@@ -132,8 +156,9 @@ Future<void> main() async {
         final result = await _runFixture(fixture);
         _output(result);
       }
-    } catch (e) {
+    } catch (e, st) {
       print('LADDER_ERROR:Failed to load $tierFile: $e');
+      print('LADDER_STACKTRACE:$st');
     }
   }
 
@@ -144,11 +169,14 @@ Future<Map<String, dynamic>> _runFixture(Map<String, dynamic> fixture) async {
   final id = fixture['id'] as int;
   final code = fixture['code'] as String;
   final expectError = fixture['expectError'] as bool? ?? false;
+  final osCall = fixture['osCall'] as bool? ?? false;
   final xfail = fixture['xfail'] as String?;
 
   Map<String, dynamic> result;
   try {
-    if (fixture['externalFunctions'] != null) {
+    if (osCall) {
+      result = await _runOsCall(fixture);
+    } else if (fixture['externalFunctions'] != null) {
       result = await _runIterative(fixture);
       // Iterative path returns ok/error directly — flip for expectError.
       if (expectError) {
@@ -179,6 +207,101 @@ Future<Map<String, dynamic>> _runFixture(Map<String, dynamic> fixture) async {
     }
   }
   return result;
+}
+
+/// Handles OsCall fixtures using start/resume with a built-in handler
+/// for date/datetime operations. Path operations on web are skipped
+/// (nativeOnly). Environment operations are not available on web.
+Future<Map<String, dynamic>> _runOsCall(Map<String, dynamic> fixture) async {
+  final id = fixture['id'] as int;
+  final code = fixture['code'] as String;
+  final expectError = fixture['expectError'] as bool? ?? false;
+
+  var state = _parseResult((await _montyStart(code.toJS).toDart).toDart);
+
+  if (state['ok'] != true) {
+    if (expectError) return {'id': id, 'ok': true, 'error': state['error']};
+
+    return {'id': id, 'ok': false, 'error': state['error']};
+  }
+
+  while (state['state'] != 'complete') {
+    if (state['ok'] != true) {
+      if (expectError) return {'id': id, 'ok': true, 'error': state['error']};
+
+      return {'id': id, 'ok': false, 'error': state['error']};
+    }
+
+    if (state['state'] == 'os_call') {
+      final fnName = state['functionName'] as String;
+      final osResult = _handleOsCall(fnName);
+      if (osResult == null) {
+        state = _parseResult(
+          (await _montyResumeWithError(
+            jsonEncode('PermissionError: $fnName not available on web').toJS,
+          ).toDart).toDart,
+        );
+      } else {
+        state = _parseResult(
+          (await _montyResume(jsonEncode(osResult).toJS).toDart).toDart,
+        );
+      }
+    } else if (state['state'] == 'pending') {
+      state = _parseResult(
+        (await _montyResumeWithError(
+          jsonEncode('Unexpected external function').toJS,
+        ).toDart).toDart,
+      );
+    } else {
+      return {
+        'id': id,
+        'ok': false,
+        'error': 'Unexpected state: ${state['state']}',
+      };
+    }
+  }
+
+  if (expectError) {
+    if (state['ok'] == false || state['error'] != null) {
+      return {'id': id, 'ok': true, 'error': state['error']};
+    }
+
+    return {'id': id, 'ok': false, 'error': 'Expected error but succeeded'};
+  }
+
+  if (state['ok'] != true) {
+    return {'id': id, 'ok': false, 'error': state['error']};
+  }
+
+  return {'id': id, 'ok': true, 'value': state['value']};
+}
+
+/// Built-in OsCall handler for the WASM ladder runner.
+/// Handles date/datetime operations. Returns null for unsupported operations.
+Object? _handleOsCall(String fnName) {
+  final now = DateTime.now();
+
+  return switch (fnName) {
+    'date.today' => {
+      '__type': 'date',
+      'year': now.year,
+      'month': now.month,
+      'day': now.day,
+    },
+    'datetime.now' => {
+      '__type': 'datetime',
+      'year': now.year,
+      'month': now.month,
+      'day': now.day,
+      'hour': now.hour,
+      'minute': now.minute,
+      'second': now.second,
+      'microsecond': now.microsecond,
+      'offset_seconds': now.timeZoneOffset.inSeconds,
+      'timezone_name': now.timeZoneName,
+    },
+    _ => null,
+  };
 }
 
 Future<Map<String, dynamic>> _runSimple(int id, String code) async {

--- a/test/wasm/integration/vfs_demo.dart
+++ b/test/wasm/integration/vfs_demo.dart
@@ -1,0 +1,283 @@
+// Standalone JS-compiled demo, not a package:test file.
+// ignore_for_file: avoid_print, lines_longer_than_80_chars, avoid_catches_without_on_clauses, prefer_foreach, discarded_futures, unnecessary_lambdas, cast_nullable_to_non_nullable
+/// Interactive VFS Demo — shows Python↔VFS round-trip in the browser.
+///
+/// Compiled to JS, exposes functions to the HTML UI via window.VfsDemo.
+///
+/// Build:
+///   dart compile js test/wasm/integration/vfs_demo.dart \
+///     -o test/wasm/integration/web/vfs_demo.dart.js
+library;
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+
+// ---------------------------------------------------------------------------
+// JS interop — WASM bridge
+// ---------------------------------------------------------------------------
+
+@JS('DartMontyBridge.init')
+external JSPromise<JSBoolean> _bridgeInit();
+
+@JS('DartMontyBridge.start')
+external JSPromise<JSString> _bridgeStart(JSString code);
+
+@JS('DartMontyBridge.resume')
+external JSPromise<JSString> _bridgeResume(JSString valueJson);
+
+@JS('DartMontyBridge.resumeWithError')
+external JSPromise<JSString> _bridgeResumeWithError(JSString errorJson);
+
+// ---------------------------------------------------------------------------
+// JS interop — expose API to HTML
+// ---------------------------------------------------------------------------
+
+@JS('window.VfsDemo')
+external set _vfsDemo(JSObject obj);
+
+@JS('window._onOsCall')
+external void _jsOnOsCall(JSString jsonPayload);
+
+@JS('window._onReady')
+external void _jsOnReady();
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+late MemoryFsOsCallHandler _vfs;
+late TimeOsCallHandler _time;
+final _osCallLog = <Map<String, dynamic>>[];
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+Map<String, dynamic> _parse(String json) =>
+    jsonDecode(json) as Map<String, dynamic>;
+
+bool _isOsCall(String? fn) {
+  if (fn == null) return false;
+  return fn.startsWith('Path.') ||
+      fn.startsWith('date.') ||
+      fn.startsWith('datetime.');
+}
+
+Future<Object?> _handleOsCall(Map<String, dynamic> state) async {
+  final op = state['functionName'] as String;
+  final rawArgs = state['args'] as List? ?? [];
+  final args = rawArgs.map(MontyValue.fromJson).toList();
+
+  Map<String, MontyValue>? kwargs;
+  final rawKwargs = state['kwargs'] as Map<String, dynamic>?;
+  if (rawKwargs != null) {
+    kwargs = rawKwargs.map((k, v) => MapEntry(k, MontyValue.fromJson(v)));
+  }
+
+  final call = MontyOsCall(
+    operationName: op,
+    arguments: args,
+    kwargs: kwargs,
+  );
+
+  final sw = Stopwatch()..start();
+  Object? result;
+
+  if (op.startsWith('Path.')) {
+    result = await _vfs.handle(call);
+  } else if (op.startsWith('date.') || op.startsWith('datetime.')) {
+    result = await _time.handle(call);
+  } else {
+    throw UnsupportedError('Unhandled os_call: $op');
+  }
+
+  sw.stop();
+
+  // Log the os_call for the UI.
+  final logEntry = {
+    'op': op,
+    'args': rawArgs.map((a) => a.toString()).toList(),
+    'result': _summarize(result),
+    'durationMs': sw.elapsedMilliseconds,
+  };
+  _osCallLog.add(logEntry);
+
+  // Notify the HTML UI in real-time.
+  try {
+    _jsOnOsCall(jsonEncode(logEntry).toJS);
+  } catch (_) {
+    // _onOsCall not defined — OK in headless mode.
+  }
+
+  return result;
+}
+
+String _summarize(Object? value) {
+  if (value == null) return 'null';
+  final s = value.toString();
+  return s.length > 80 ? '${s.substring(0, 77)}...' : s;
+}
+
+Future<Map<String, dynamic>> _runWithVfs(String code) async {
+  _osCallLog.clear();
+  _vfs = MemoryFsOsCallHandler();
+  _time = TimeOsCallHandler();
+
+  // Mount any pre-staged files (set by mountFile before run).
+  for (final entry in _stagedFiles.entries) {
+    _vfs.writeFile(entry.key, entry.value);
+  }
+
+  var state = _parse((await _bridgeStart(code.toJS).toDart).toDart);
+
+  while (state['state'] != 'complete') {
+    if (state['ok'] != true) return state;
+
+    if (state['state'] == 'pending' &&
+        _isOsCall(state['functionName'] as String?)) {
+      try {
+        final result = await _handleOsCall(state);
+        state = _parse(
+          (await _bridgeResume(jsonEncode(result).toJS).toDart).toDart,
+        );
+      } on Object catch (e) {
+        state = _parse(
+          (await _bridgeResumeWithError(
+            jsonEncode(e.toString()).toJS,
+          ).toDart).toDart,
+        );
+      }
+    } else {
+      return {
+        'ok': false,
+        'error': 'Unexpected state: ${state['state']}',
+      };
+    }
+  }
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// File staging (mount files before run)
+// ---------------------------------------------------------------------------
+
+final _stagedFiles = <String, String>{};
+
+void _mountFile(String path, String content) {
+  _stagedFiles[path] = content;
+}
+
+void _clearMounts() {
+  _stagedFiles.clear();
+}
+
+// ---------------------------------------------------------------------------
+// API exposed to HTML via window.VfsDemo
+// ---------------------------------------------------------------------------
+
+/// Returns a JSON object:
+/// { ok, value?, error?, osCallLog, files }
+Future<String> _apiRun(String code) async {
+  final result = await _runWithVfs(code);
+
+  // Collect VFS file tree after execution.
+  final files = _collectFiles();
+
+  return jsonEncode({
+    'ok': result['ok'],
+    if (result['value'] != null) 'value': result['value'],
+    if (result['error'] != null) 'error': result['error'],
+    'osCallLog': _osCallLog,
+    'files': files,
+  });
+}
+
+List<Map<String, dynamic>> _collectFiles() {
+  final files = <Map<String, dynamic>>[];
+  void walk(String dirPath) {
+    try {
+      final entries = _listDir(dirPath);
+      for (final entry in entries) {
+        if (_vfs.exists(entry)) {
+          // Check if it's a file by trying to read it.
+          try {
+            final content = _vfs.readFile(entry);
+            files.add({
+              'path': entry,
+              'type': 'file',
+              'size': content.length,
+              'preview': content.length > 200
+                  ? '${content.substring(0, 197)}...'
+                  : content,
+            });
+          } catch (_) {
+            // It's a directory.
+            files.add({'path': entry, 'type': 'dir'});
+            walk(entry);
+          }
+        }
+      }
+    } catch (_) {
+      // Not a directory or doesn't exist.
+    }
+  }
+
+  // Walk from common roots.
+  for (final root in ['/', '/sandbox']) {
+    walk(root);
+  }
+  return files;
+}
+
+List<String> _listDir(String path) {
+  try {
+    final call = MontyOsCall(
+      operationName: 'Path.iterdir',
+      arguments: [MontyString(path)],
+    );
+    // Synchronous-ish: the VFS handle returns Future.value.
+    final completer = <String>[];
+    _vfs.handle(call).then((r) {
+      if (r is List) completer.addAll(r.cast<String>());
+    });
+    return completer;
+  } catch (_) {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main — wire up JS API and initialize
+// ---------------------------------------------------------------------------
+
+Future<void> main() async {
+  // Expose API to HTML.
+  final api = <String, JSFunction>{
+    'run': ((JSString code) => _apiRun(
+      code.toDart,
+    ).then((r) => r.toJS).toJS).toJS,
+    'mountFile': ((JSString path, JSString content) {
+      _mountFile(path.toDart, content.toDart);
+    }).toJS,
+    'clearMounts': (() => _clearMounts()).toJS,
+  }.jsify();
+  _vfsDemo = api as JSObject;
+
+  // Initialize WASM bridge.
+  final ok = (await _bridgeInit().toDart).toDart;
+  if (!ok) {
+    print('VFS_DEMO_ERROR: WASM init failed');
+    return;
+  }
+
+  print('VFS Demo ready');
+  try {
+    _jsOnReady();
+  } catch (_) {
+    // _onReady not defined — OK in headless mode.
+  }
+}

--- a/test/wasm/integration/vfs_runner.dart
+++ b/test/wasm/integration/vfs_runner.dart
@@ -1,0 +1,284 @@
+// Standalone JS-compiled runner, not a package:test file.
+// ignore_for_file: avoid_print, unnecessary_raw_strings, lines_longer_than_80_chars
+/// WASM VFS Integration Test — proves full Python→WASM→OsCall→VFS→Python.
+///
+/// Compiled to JS, runs in headless Chrome with COOP/COEP headers.
+/// Handles Path.* os_calls locally using MemoryFsOsCallHandler.
+///
+/// Build:
+///   dart compile js test/wasm/integration/vfs_runner.dart \
+///     -o test/wasm/integration/web/vfs_runner.dart.js
+library;
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
+
+// ---------------------------------------------------------------------------
+// JS interop bindings for DartMontyBridge (instance-based)
+// ---------------------------------------------------------------------------
+
+@JS('DartMontyBridge')
+extension type _DartMontyBridge._(JSObject _) implements JSObject {
+  external _DartMontyBridge();
+  external JSPromise<JSBoolean> init();
+  external JSPromise<JSString> start(JSString code);
+  external JSPromise<JSString> resume(JSString valueJson);
+  external JSPromise<JSString> resumeWithError(JSString errorJson);
+}
+
+late _DartMontyBridge _bridge;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Map<String, dynamic> _parse(String json) =>
+    jsonDecode(json) as Map<String, dynamic>;
+
+void _pass(String name) => print('VFS_PASS:$name');
+void _fail(String name, String reason) => print('VFS_FAIL:$name:$reason');
+
+// ---------------------------------------------------------------------------
+// VFS handler — runs entirely in Dart (compiled to JS)
+// ---------------------------------------------------------------------------
+
+/// Shared VFS instance across all tests. Reset per test.
+late MemoryFsOsCallHandler _vfs;
+late TimeOsCallHandler _time;
+
+/// Known os_call prefixes.
+bool _isOsCall(String? functionName) {
+  if (functionName == null) return false;
+  return functionName.startsWith('Path.') ||
+      functionName.startsWith('date.') ||
+      functionName.startsWith('datetime.');
+}
+
+/// Handles an os_call by dispatching to the appropriate handler.
+/// Returns the JSON-encoded result to pass to resume().
+Future<Object?> _handleOsCall(Map<String, dynamic> state) async {
+  final op = state['functionName'] as String;
+  final rawArgs = state['args'] as List? ?? [];
+
+  // Parse args from raw JSON values into MontyValue.
+  final args = rawArgs.map(MontyValue.fromJson).toList();
+
+  // Parse kwargs if present.
+  Map<String, MontyValue>? kwargs;
+  final rawKwargs = state['kwargs'] as Map<String, dynamic>?;
+  if (rawKwargs != null) {
+    kwargs = rawKwargs.map((k, v) => MapEntry(k, MontyValue.fromJson(v)));
+  }
+
+  final call = MontyOsCall(
+    operationName: op,
+    arguments: args,
+    kwargs: kwargs,
+  );
+
+  if (op.startsWith('Path.')) {
+    return _vfs.handle(call);
+  } else if (op.startsWith('date.') || op.startsWith('datetime.')) {
+    return _time.handle(call);
+  }
+  throw UnsupportedError('Unhandled os_call: $op');
+}
+
+/// Runs Python code through the WASM bridge, handling os_calls locally.
+///
+/// Returns the final result map from the bridge.
+Future<Map<String, dynamic>> _runWithVfs(String code) async {
+  var state = _parse(
+    (await _bridge.start(code.toJS).toDart).toDart,
+  );
+
+  while (state['state'] != 'complete') {
+    if (state['ok'] != true) return state;
+
+    if (state['state'] == 'pending' &&
+        _isOsCall(state['functionName'] as String?)) {
+      try {
+        final result = await _handleOsCall(state);
+        state = _parse(
+          (await _bridge.resume(jsonEncode(result).toJS).toDart).toDart,
+        );
+      } on Object catch (e) {
+        state = _parse(
+          (await _bridge
+                  .resumeWithError(
+                    jsonEncode(e.toString()).toJS,
+                  )
+                  .toDart)
+              .toDart,
+        );
+      }
+    } else {
+      _fail('loop', 'Unexpected state: ${jsonEncode(state)}');
+      return state;
+    }
+  }
+
+  return state;
+}
+
+// ---------------------------------------------------------------------------
+// Test cases
+// ---------------------------------------------------------------------------
+
+/// Test 1: Write a file with pathlib, read it back.
+Future<void> _testWriteRead() async {
+  _vfs = MemoryFsOsCallHandler();
+
+  const code = r"""
+from pathlib import Path
+Path('/sandbox/test.txt').write_text('hello from WASM')
+Path('/sandbox/test.txt').read_text()
+""";
+
+  final result = await _runWithVfs(code);
+  if (result['ok'] == true && result['value'] == 'hello from WASM') {
+    _pass('write_read');
+  } else {
+    _fail('write_read', 'Expected "hello from WASM", got ${result['value']}');
+  }
+}
+
+/// Test 2: Path.exists on missing file returns False.
+Future<void> _testPathExists() async {
+  _vfs = MemoryFsOsCallHandler();
+
+  const code = r"""
+from pathlib import Path
+Path('/sandbox/nope.txt').exists()
+""";
+
+  final result = await _runWithVfs(code);
+  if (result['ok'] == true && result['value'] == false) {
+    _pass('path_exists_false');
+  } else {
+    _fail('path_exists_false', 'Expected false, got ${result['value']}');
+  }
+}
+
+/// Test 3: mkdir + iterdir round-trip.
+Future<void> _testMkdirIterdir() async {
+  _vfs = MemoryFsOsCallHandler();
+
+  const code = r"""
+from pathlib import Path
+d = Path('/sandbox/mydir')
+d.mkdir(parents=True)
+Path('/sandbox/mydir/a.txt').write_text('a')
+Path('/sandbox/mydir/b.txt').write_text('b')
+sorted([p.name for p in d.iterdir()])
+""";
+
+  final result = await _runWithVfs(code);
+  if (result['ok'] == true) {
+    final value = result['value'];
+    if (value is List && value.length == 2) {
+      _pass('mkdir_iterdir');
+    } else {
+      _fail('mkdir_iterdir', 'Expected [a.txt, b.txt], got $value');
+    }
+  } else {
+    _fail('mkdir_iterdir', 'Error: ${result['error']}');
+  }
+}
+
+/// Test 4: Write JSON config, read and parse it.
+Future<void> _testJsonConfig() async {
+  _vfs = MemoryFsOsCallHandler();
+
+  // Pre-populate VFS from Dart side.
+  _vfs.writeFile('/sandbox/config.json', '{"api_key": "abc123", "retries": 3}');
+
+  const code = r"""
+import json
+from pathlib import Path
+config = json.loads(Path('/sandbox/config.json').read_text())
+{'key': config['api_key'], 'retries': config['retries']}
+""";
+
+  final result = await _runWithVfs(code);
+  if (result['ok'] == true) {
+    final value = result['value'] as Map?;
+    if (value != null && value['key'] == 'abc123' && value['retries'] == 3) {
+      _pass('json_config');
+    } else {
+      _fail('json_config', 'Expected {key: abc123, retries: 3}, got $value');
+    }
+  } else {
+    _fail('json_config', 'Error: ${result['error']}');
+  }
+}
+
+/// Test 5: Data pipeline — read input, process, write output, return stats.
+Future<void> _testDataPipeline() async {
+  _vfs = MemoryFsOsCallHandler();
+
+  // Pre-populate input from Dart.
+  _vfs.writeFile(
+    '/sandbox/input.csv',
+    'name,score\nalice,95\nbob,87\ncarol,92',
+  );
+
+  const code = r"""
+from pathlib import Path
+lines = Path('/sandbox/input.csv').read_text().strip().split('\n')
+rows = [l.split(',') for l in lines[1:]]
+scores = [int(r[1]) for r in rows]
+avg = sum(scores) / len(scores)
+Path('/sandbox/output.txt').write_text(f'avg:{avg:.1f}')
+{'count': len(rows), 'top': max(rows, key=lambda r: int(r[1]))[0]}
+""";
+
+  final result = await _runWithVfs(code);
+  if (result['ok'] == true) {
+    final value = result['value'] as Map?;
+    if (value != null && value['count'] == 3 && value['top'] == 'alice') {
+      // Also verify the output file was written to VFS.
+      final output = _vfs.readFile('/sandbox/output.txt');
+      if (output == 'avg:91.3') {
+        _pass('data_pipeline');
+      } else {
+        _fail(
+          'data_pipeline',
+          'output.txt: expected "avg:91.3", got "$output"',
+        );
+      }
+    } else {
+      _fail('data_pipeline', 'Expected {count: 3, top: alice}, got $value');
+    }
+  } else {
+    _fail('data_pipeline', 'Error: ${result['error']}');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+Future<void> main() async {
+  print('=== WASM VFS Integration Tests ===');
+
+  _bridge = _DartMontyBridge();
+  _time = TimeOsCallHandler();
+  final ok = (await _bridge.init().toDart).toDart;
+  if (!ok) {
+    print('VFS_ERROR:Init failed');
+    print('VFS_DONE');
+    return;
+  }
+
+  await _testWriteRead();
+  await _testPathExists();
+  await _testMkdirIterdir();
+  await _testJsonConfig();
+  await _testDataPipeline();
+
+  print('VFS_DONE');
+}

--- a/test/wasm/integration/web/vfs.html
+++ b/test/wasm/integration/web/vfs.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>dart_monty_wasm VFS Integration Test</title>
+</head>
+<body>
+  <h1>dart_monty_wasm VFS Integration Test</h1>
+  <pre id="output"></pre>
+  <script src="dart_monty_bridge.js"></script>
+  <script src="vfs_runner.dart.js"></script>
+</body>
+</html>

--- a/test/wasm/integration/web/vfs_demo.html
+++ b/test/wasm/integration/web/vfs_demo.html
@@ -1,0 +1,643 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dart_monty VFS Playground</title>
+  <style>
+    :root {
+      --bg: #1a1b26;
+      --surface: #24283b;
+      --surface2: #2f3447;
+      --border: #3b4261;
+      --text: #c0caf5;
+      --text-dim: #565f89;
+      --accent: #7aa2f7;
+      --green: #9ece6a;
+      --yellow: #e0af68;
+      --red: #f7768e;
+      --orange: #ff9e64;
+      --cyan: #7dcfff;
+      --mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      padding: 12px 20px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    header h1 {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--accent);
+    }
+
+    header .tag {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-weight: 500;
+    }
+
+    .tag-wasm { background: #2d3a5e; color: var(--cyan); }
+    .tag-vfs { background: #2d3e2d; color: var(--green); }
+
+    #status {
+      margin-left: auto;
+      font-size: 12px;
+      color: var(--text-dim);
+    }
+
+    #status.ready { color: var(--green); }
+    #status.running { color: var(--yellow); }
+    #status.error { color: var(--red); }
+
+    .main {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      gap: 1px;
+      background: var(--border);
+      overflow: hidden;
+    }
+
+    .panel {
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .panel-header {
+      padding: 8px 12px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-dim);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+
+    .panel-header .count {
+      background: var(--surface2);
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+    }
+
+    .panel-body {
+      flex: 1;
+      overflow: auto;
+      padding: 0;
+    }
+
+    /* Code editor */
+    #editor {
+      width: 100%;
+      height: 100%;
+      background: transparent;
+      color: var(--text);
+      border: none;
+      resize: none;
+      padding: 12px;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.6;
+      outline: none;
+      tab-size: 4;
+    }
+
+    .editor-panel .panel-header {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .btn-group { display: flex; gap: 6px; }
+
+    .btn {
+      padding: 4px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--surface2);
+      color: var(--text);
+      font-size: 11px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+
+    .btn:hover { border-color: var(--accent); }
+
+    .btn-run {
+      background: #1a3a1a;
+      border-color: var(--green);
+      color: var(--green);
+      font-weight: 600;
+    }
+
+    .btn-run:hover { background: #2a4a2a; }
+    .btn-run:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* File tree */
+    .file-entry {
+      padding: 6px 12px;
+      font-family: var(--mono);
+      font-size: 12px;
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+    }
+
+    .file-entry:hover { background: var(--surface2); }
+    .file-entry.selected { background: var(--surface2); border-left: 2px solid var(--accent); }
+
+    .file-icon { margin-right: 6px; }
+    .file-size { float: right; color: var(--text-dim); font-size: 11px; }
+
+    .file-preview {
+      padding: 12px;
+      font-family: var(--mono);
+      font-size: 12px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: var(--text-dim);
+    }
+
+    .empty-state {
+      padding: 24px;
+      text-align: center;
+      color: var(--text-dim);
+      font-size: 13px;
+    }
+
+    /* OS Call log */
+    .oscall-entry {
+      padding: 6px 12px;
+      font-family: var(--mono);
+      font-size: 11px;
+      border-bottom: 1px solid var(--border);
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 8px;
+      align-items: baseline;
+    }
+
+    .oscall-op {
+      color: var(--cyan);
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .oscall-args {
+      color: var(--text-dim);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .oscall-time {
+      color: var(--text-dim);
+      font-size: 10px;
+      white-space: nowrap;
+    }
+
+    /* Output */
+    #output {
+      padding: 12px;
+      font-family: var(--mono);
+      font-size: 13px;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .output-value { color: var(--green); }
+    .output-error { color: var(--red); }
+    .output-info { color: var(--text-dim); font-size: 12px; }
+
+    /* Mount panel */
+    .mount-bar {
+      padding: 6px 12px;
+      display: flex;
+      gap: 6px;
+      border-top: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    .mount-bar input {
+      flex: 1;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 4px 8px;
+      font-family: var(--mono);
+      font-size: 11px;
+      outline: none;
+    }
+
+    .mount-bar input:focus { border-color: var(--accent); }
+
+    /* Examples dropdown */
+    select {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 4px 8px;
+      font-size: 11px;
+      cursor: pointer;
+      outline: none;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>dart_monty VFS Playground</h1>
+    <span class="tag tag-wasm">WASM</span>
+    <span class="tag tag-vfs">VFS</span>
+    <select id="examples">
+      <option value="">Load example...</option>
+      <option value="hello">Hello VFS</option>
+      <option value="config">Config File Injection</option>
+      <option value="pipeline">Data Pipeline</option>
+      <option value="datetime">Date &amp; Time</option>
+      <option value="explorer">File Explorer</option>
+    </select>
+    <span id="status">Initializing WASM...</span>
+  </header>
+
+  <div class="main">
+    <!-- Top-left: Python editor -->
+    <div class="panel editor-panel">
+      <div class="panel-header">
+        <span>Python Code</span>
+        <div class="btn-group">
+          <button class="btn btn-run" id="runBtn" disabled>Run</button>
+        </div>
+      </div>
+      <div class="panel-body">
+        <textarea id="editor" spellcheck="false">from pathlib import Path
+
+# Write a file to the virtual filesystem
+Path('/sandbox/hello.txt').write_text('Hello from Python in WASM!')
+
+# Read it back
+content = Path('/sandbox/hello.txt').read_text()
+
+# Create a directory and list it
+Path('/sandbox/data').mkdir(parents=True)
+Path('/sandbox/data/a.txt').write_text('alpha')
+Path('/sandbox/data/b.txt').write_text('beta')
+files = sorted([p.name for p in Path('/sandbox/data').iterdir()])
+
+{'content': content, 'files': files}</textarea>
+      </div>
+    </div>
+
+    <!-- Top-right: OS Call log -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>OS Call Log</span>
+        <span class="count" id="callCount">0</span>
+      </div>
+      <div class="panel-body" id="callLog">
+        <div class="empty-state">Run code to see OS calls intercepted in real-time</div>
+      </div>
+    </div>
+
+    <!-- Bottom-left: Files -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Virtual Filesystem</span>
+        <span class="count" id="fileCount">0</span>
+      </div>
+      <div class="panel-body" id="fileTree">
+        <div class="empty-state">VFS is empty. Run code or mount files below.</div>
+      </div>
+      <div class="mount-bar">
+        <input type="text" id="mountPath" placeholder="/sandbox/input.csv" />
+        <input type="text" id="mountContent" placeholder="file content..." />
+        <button class="btn" id="mountBtn">Mount</button>
+      </div>
+    </div>
+
+    <!-- Bottom-right: Output -->
+    <div class="panel">
+      <div class="panel-header">Output</div>
+      <div class="panel-body" id="output">
+        <div class="empty-state">Python result will appear here</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Load WASM bridge first -->
+  <script src="dart_monty_bridge.js"></script>
+  <!-- Load compiled Dart VFS demo -->
+  <script src="vfs_demo.dart.js"></script>
+  <script>
+    // -----------------------------------------------------------------------
+    // State
+    // -----------------------------------------------------------------------
+    let callCount = 0;
+    let ready = false;
+
+    const $ = (s) => document.getElementById(s);
+    const editor = $('editor');
+    const runBtn = $('runBtn');
+    const status = $('status');
+    const callLog = $('callLog');
+    const fileTree = $('fileTree');
+    const output = $('output');
+
+    // -----------------------------------------------------------------------
+    // OS Call callback — called from Dart in real-time
+    // -----------------------------------------------------------------------
+    window._onOsCall = function(jsonStr) {
+      const entry = JSON.parse(jsonStr);
+      callCount++;
+      $('callCount').textContent = callCount;
+
+      if (callCount === 1) callLog.innerHTML = '';
+
+      const div = document.createElement('div');
+      div.className = 'oscall-entry';
+      div.innerHTML = `
+        <span class="oscall-op">${entry.op}</span>
+        <span class="oscall-args">${(entry.args || []).join(', ')}</span>
+        <span class="oscall-time">${entry.durationMs}ms</span>
+      `;
+      callLog.appendChild(div);
+      callLog.scrollTop = callLog.scrollHeight;
+    };
+
+    // -----------------------------------------------------------------------
+    // Ready callback
+    // -----------------------------------------------------------------------
+    window._onReady = function() {
+      ready = true;
+      status.textContent = 'Ready';
+      status.className = 'ready';
+      runBtn.disabled = false;
+    };
+
+    // -----------------------------------------------------------------------
+    // Run
+    // -----------------------------------------------------------------------
+    async function run() {
+      if (!ready || !window.VfsDemo) return;
+
+      runBtn.disabled = true;
+      status.textContent = 'Running...';
+      status.className = 'running';
+      callCount = 0;
+      $('callCount').textContent = '0';
+      callLog.innerHTML = '';
+      output.innerHTML = '';
+      fileTree.innerHTML = '';
+
+      try {
+        const resultPromise = window.VfsDemo.run(editor.value);
+        const resultJson = await resultPromise;
+        const result = JSON.parse(resultJson);
+
+        // Output
+        if (result.ok) {
+          output.innerHTML = `<div class="output-value">${formatValue(result.value)}</div>
+<div class="output-info">${result.osCallLog.length} OS calls</div>`;
+        } else {
+          output.innerHTML = `<div class="output-error">${result.error}</div>`;
+        }
+
+        // File tree
+        renderFiles(result.files || []);
+
+        status.textContent = result.ok ? 'Done' : 'Error';
+        status.className = result.ok ? 'ready' : 'error';
+      } catch (e) {
+        output.innerHTML = `<div class="output-error">${e}</div>`;
+        status.textContent = 'Error';
+        status.className = 'error';
+      }
+
+      runBtn.disabled = false;
+    }
+
+    function formatValue(v) {
+      if (v === null || v === undefined) return 'None';
+      if (typeof v === 'object') return JSON.stringify(v, null, 2);
+      return String(v);
+    }
+
+    function renderFiles(files) {
+      if (files.length === 0) {
+        fileTree.innerHTML = '<div class="empty-state">No files in VFS</div>';
+        $('fileCount').textContent = '0';
+        return;
+      }
+
+      $('fileCount').textContent = files.filter(f => f.type === 'file').length;
+      fileTree.innerHTML = '';
+
+      for (const f of files) {
+        if (f.type !== 'file') continue;
+        const div = document.createElement('div');
+        div.className = 'file-entry';
+        div.innerHTML = `
+          <span class="file-icon">${f.type === 'dir' ? '\ud83d\udcc1' : '\ud83d\udcc4'}</span>
+          ${f.path}
+          <span class="file-size">${f.size}B</span>
+        `;
+        div.onclick = () => {
+          document.querySelectorAll('.file-entry').forEach(e => e.classList.remove('selected'));
+          div.classList.add('selected');
+          output.innerHTML = `<div class="output-info">${f.path} (${f.size} bytes)</div>
+<div class="output-value">${escapeHtml(f.preview)}</div>`;
+        };
+        fileTree.appendChild(div);
+      }
+    }
+
+    function escapeHtml(s) {
+      const div = document.createElement('div');
+      div.textContent = s;
+      return div.innerHTML;
+    }
+
+    // -----------------------------------------------------------------------
+    // Mount files
+    // -----------------------------------------------------------------------
+    $('mountBtn').onclick = function() {
+      const path = $('mountPath').value.trim();
+      const content = $('mountContent').value;
+      if (!path || !window.VfsDemo) return;
+      window.VfsDemo.mountFile(path, content);
+      $('mountPath').value = '';
+      $('mountContent').value = '';
+    };
+
+    // -----------------------------------------------------------------------
+    // Examples
+    // -----------------------------------------------------------------------
+    const examples = {
+      hello: `from pathlib import Path
+
+# Write a file to the virtual filesystem
+Path('/sandbox/hello.txt').write_text('Hello from Python in WASM!')
+
+# Read it back
+content = Path('/sandbox/hello.txt').read_text()
+
+# Create a directory and list it
+Path('/sandbox/data').mkdir(parents=True)
+Path('/sandbox/data/a.txt').write_text('alpha')
+Path('/sandbox/data/b.txt').write_text('beta')
+files = sorted([p.name for p in Path('/sandbox/data').iterdir()])
+
+{'content': content, 'files': files}`,
+
+      config: `import json
+from pathlib import Path
+
+# Read a config file injected from Dart/JS
+# (click Mount below to add /sandbox/config.json first)
+config = json.loads(Path('/sandbox/config.json').read_text())
+
+# Process it
+result = {
+    'api_key': config.get('api_key', 'missing'),
+    'retries': config.get('retries', 0),
+    'debug': config.get('debug', False),
+}
+result`,
+
+      pipeline: `from pathlib import Path
+
+# Read CSV input (mount /sandbox/input.csv first, or use default)
+try:
+    raw = Path('/sandbox/input.csv').read_text()
+except:
+    # Default data if not mounted
+    raw = 'name,score\\nalice,95\\nbob,87\\ncarol,92\\ndave,78'
+    Path('/sandbox/input.csv').write_text(raw)
+
+# Parse
+lines = raw.strip().split('\\n')
+header = lines[0].split(',')
+rows = [l.split(',') for l in lines[1:]]
+
+# Compute
+scores = [int(r[1]) for r in rows]
+avg = sum(scores) / len(scores)
+top = max(rows, key=lambda r: int(r[1]))
+
+# Write summary
+summary = f"Students: {len(rows)}\\nAverage: {avg:.1f}\\nTop: {top[0]} ({top[1]})"
+Path('/sandbox/summary.txt').write_text(summary)
+
+# Write sorted leaderboard
+ranked = sorted(rows, key=lambda r: int(r[1]), reverse=True)
+board = '\\n'.join(f"{i+1}. {r[0]}: {r[1]}" for i, r in enumerate(ranked))
+Path('/sandbox/leaderboard.txt').write_text(board)
+
+{'average': avg, 'top': top[0], 'files_written': 2}`,
+
+      datetime: `from datetime import date, datetime
+
+today = date.today()
+now = datetime.now()
+
+{
+    'date': f'{today.year}-{today.month:02d}-{today.day:02d}',
+    'time': f'{now.hour:02d}:{now.minute:02d}:{now.second:02d}',
+    'year': today.year,
+    'weekday': ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'][today.weekday()],
+}`,
+
+      explorer: `from pathlib import Path
+
+# Build a directory structure
+base = Path('/sandbox/project')
+base.mkdir(parents=True)
+
+# Source files
+(base / 'src').mkdir()
+(base / 'src' / 'main.py').write_text('print("hello world")')
+(base / 'src' / 'utils.py').write_text('def add(a, b): return a + b')
+
+# Config
+(base / 'config.json').write_text('{"debug": true, "port": 8080}')
+
+# Docs
+(base / 'docs').mkdir()
+(base / 'docs' / 'README.md').write_text('# My Project\\nA demo of the VFS.')
+
+# Count everything
+all_files = []
+def walk(d):
+    for p in sorted(d.iterdir()):
+        if p.is_file():
+            all_files.append(str(p))
+        elif p.is_dir():
+            walk(p)
+
+walk(base)
+{'files': all_files, 'count': len(all_files)}`,
+    };
+
+    $('examples').onchange = function() {
+      const key = this.value;
+      if (key && examples[key]) {
+        editor.value = examples[key];
+        // Pre-mount files for config example
+        if (key === 'config' && window.VfsDemo) {
+          window.VfsDemo.clearMounts();
+          window.VfsDemo.mountFile(
+            '/sandbox/config.json',
+            '{"api_key": "sk-abc123", "retries": 3, "debug": true}'
+          );
+        }
+      }
+      this.value = '';
+    };
+
+    // -----------------------------------------------------------------------
+    // Keyboard shortcut
+    // -----------------------------------------------------------------------
+    editor.addEventListener('keydown', (e) => {
+      // Ctrl/Cmd+Enter to run
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        run();
+      }
+      // Tab inserts spaces
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const start = editor.selectionStart;
+        editor.value = editor.value.substring(0, start) + '    ' + editor.value.substring(editor.selectionEnd);
+        editor.selectionStart = editor.selectionEnd = start + 4;
+      }
+    });
+
+    runBtn.onclick = run;
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Replaces monolithic OsCallHandler with composable handler hierarchy: `RouterOsCallHandler` dispatches by operation prefix to `MemoryFsOsCallHandler` (cross-platform VFS), `SandboxedNativeFsHandler` (chrooted real FS), `EnvOsCallHandler`, and `TimeOsCallHandler`
- Integrates OsCall dispatch into `DefaultMontyBridge` and `MontySession.run()` with full error handling
- Adds lifecycle audit (Section F in `docs/lifecycles.md`) — 8 findings, all OK/by-design, no open issues
- Fixes `NativeBindingsFfi.create()` to throw `MontyScriptError` for parse errors
- Adds interactive VFS Playground demo, WASM integration runner, and comprehensive test coverage

## Test plan

- [ ] `dart test` — 1343 unit tests pass (0 failures)
- [ ] `dart test --run-skipped --tags=ladder` — 199 ladder tests pass (0 failures)
- [ ] `dart test --run-skipped --tags=integration test/ffi/integration/smoke_test.dart` — 8/9 pass (snapshot round-trip is pre-existing native issue)
- [ ] `dart analyze` — clean
- [ ] Security tests: path traversal, symlink escape, sandbox prefix collision all rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)