### PR TITLE
feat: AgentSession — unified stateful execution with tools and plugins

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: Compile vfs_demo.dart
         working-directory: example/web
         run: dart compile js bin/vfs_demo.dart -o web/vfs_demo.dart.js
+      - name: Compile agent_demo.dart
+        working-directory: example/web
+        run: dart compile js bin/agent_demo.dart -o web/agent_demo.dart.js
 
       # ── Assemble site ────────────────────────────────────────────────
       - name: Copy WASM binary

--- a/dcm_options.yaml
+++ b/dcm_options.yaml
@@ -58,6 +58,8 @@ dcm:
           - "lib/src/bridge/os_call/memory_fs_provider.dart"
           - "lib/src/bridge/os_call/sandboxed_fs_provider.dart"
           - "lib/src/bridge/os_call/env_os_provider.dart"
+          # State wrapping: code gen accesses known-valid indices
+          - "lib/src/bridge/agent_session.dart"
           # Mock tracking lists: only accessed after recording calls
           - "lib/src/platform/mock_monty_platform.dart"
           # Guarded by isEmpty/isNotEmpty/length checks before access
@@ -222,6 +224,8 @@ dcm:
           - "test/**"
           # Lazy-initialized sorted prefixes for longest-prefix-first matching
           - "lib/src/bridge/os_call/os_provider.dart"
+          # Bridge initialized in constructor body (needs _monty.platform)
+          - "lib/src/bridge/agent_session.dart"
     - avoid-dynamic:
         exclude:
           - "test/**"
@@ -249,6 +253,8 @@ dcm:
           - "lib/src/bridge/bridge/host_param.dart"
           - "lib/src/bridge/bridge/plugin_registry.dart"
           - "lib/src/bridge/plugins/sandbox_plugin.dart"
+          # State wrapping + result extraction: non-null guaranteed by event type
+          - "lib/src/bridge/agent_session.dart"
           - "lib/src/bridge/os_call/default_sandbox_os_native.dart"
           - "lib/src/bridge/os_call/fs_provider.dart"
           - "lib/src/bridge/os_call/memory_fs_provider.dart"

--- a/example/web/bin/agent_demo.dart
+++ b/example/web/bin/agent_demo.dart
@@ -1,0 +1,417 @@
+// Standalone JS-compiled demo, not a package:test file.
+// ignore_for_file: avoid_print, use_null_aware_elements
+/// Interactive AgentSession Demo — shows stateful Python execution with host
+/// functions, filesystem access, and real-time bridge event streaming.
+///
+/// Compiled to JS, exposes functions to the HTML UI via window.AgentDemo.
+///
+/// Build:
+///   dart compile js example/web/bin/agent_demo.dart \
+///     -o example/web/web/agent_demo.dart.js
+library;
+
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+
+// ---------------------------------------------------------------------------
+// JS interop — expose API to HTML
+// ---------------------------------------------------------------------------
+
+@JS('window.AgentDemo')
+external set _agentDemo(JSObject obj);
+
+@JS('window._onEvent')
+external void _jsOnEvent(JSString jsonPayload);
+
+@JS('window._onReady')
+external void _jsOnReady();
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+AgentSession? _session;
+bool _initialized = false;
+
+// ---------------------------------------------------------------------------
+// Host functions — demo tools callable from Python
+// ---------------------------------------------------------------------------
+
+final _demoHostFunctions = <HostFunction>[
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'echo',
+      description: 'Returns the message uppercased.',
+      params: [
+        HostParam(
+          name: 'msg',
+          type: HostParamType.string,
+          description: 'Message to echo back uppercased.',
+        ),
+      ],
+    ),
+    handler: (args) async {
+      final msg = args['msg']! as String;
+      return msg.toUpperCase();
+    },
+  ),
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'add_numbers',
+      description: 'Returns the sum of two numbers.',
+      params: [
+        HostParam(
+          name: 'a',
+          type: HostParamType.number,
+          description: 'First number.',
+        ),
+        HostParam(
+          name: 'b',
+          type: HostParamType.number,
+          description: 'Second number.',
+        ),
+      ],
+    ),
+    handler: (args) async {
+      final a = args['a']! as num;
+      final b = args['b']! as num;
+      return a + b;
+    },
+  ),
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'get_time',
+      description: 'Returns the current time as an ISO 8601 string.',
+    ),
+    handler: (_) async {
+      return DateTime.now().toIso8601String();
+    },
+  ),
+
+  // Key-value store — persistent memory across calls
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'kv_set',
+      description: 'Store a value in the key-value store.',
+      params: [
+        HostParam(name: 'key', type: HostParamType.string),
+        HostParam(name: 'value', type: HostParamType.any),
+      ],
+    ),
+    handler: (args) async {
+      _kvStore[args['key']! as String] = args['value'];
+      return null;
+    },
+  ),
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'kv_get',
+      description: 'Retrieve a value from the key-value store.',
+      params: [
+        HostParam(name: 'key', type: HostParamType.string),
+      ],
+    ),
+    handler: (args) async {
+      return _kvStore[args['key']! as String];
+    },
+  ),
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'kv_list',
+      description: 'List all keys in the key-value store.',
+    ),
+    handler: (_) async {
+      return _kvStore.keys.toList();
+    },
+  ),
+
+  // Simulated HTTP fetch
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'fetch_json',
+      description: 'Fetch JSON data from a URL (simulated).',
+      params: [
+        HostParam(name: 'url', type: HostParamType.string),
+      ],
+    ),
+    handler: (args) async {
+      final url = args['url']! as String;
+      // Simulated API responses
+      if (url.contains('users')) {
+        return [
+          {'name': 'Alice', 'age': 30, 'role': 'engineer'},
+          {'name': 'Bob', 'age': 25, 'role': 'designer'},
+          {'name': 'Charlie', 'age': 35, 'role': 'manager'},
+        ];
+      }
+      if (url.contains('weather')) {
+        return {'city': 'San Francisco', 'temp': 68, 'condition': 'sunny'};
+      }
+      return {'error': 'Unknown endpoint', 'url': url};
+    },
+  ),
+
+  // Log output
+  HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'log',
+      description: 'Log a message to the events panel.',
+      params: [
+        HostParam(name: 'msg', type: HostParamType.string),
+      ],
+    ),
+    handler: (args) async {
+      // The event will be visible in the bridge events panel
+      return null;
+    },
+  ),
+];
+
+final _kvStore = <String, Object?>{};
+
+
+// ---------------------------------------------------------------------------
+// Initialization
+// ---------------------------------------------------------------------------
+
+Future<bool> _init() async {
+  if (_initialized) return true;
+
+  try {
+    final os = OsProvider.compose({
+      'Path.': MemoryFsProvider(),
+      'date.': TimeOsProvider(),
+      'datetime.': TimeOsProvider(),
+    });
+
+    _session = AgentSession(os: os);
+
+    _demoHostFunctions.forEach(_session!.register);
+
+    _initialized = true;
+    return true;
+  } on Object catch (e) {
+    print('AgentDemo init error: $e');
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Execute Python code with event streaming
+// ---------------------------------------------------------------------------
+
+Future<String> _execute(String code) async {
+  if (_session == null) {
+    return jsonEncode({'ok': false, 'error': 'Session not initialized'});
+  }
+
+  final events = <Map<String, dynamic>>[];
+
+  try {
+    final eventStream = _session!.executeStream(code);
+    Object? resultValue;
+    String? resultError;
+    String? printOutput;
+
+    await for (final event in eventStream) {
+      final eventMap = _eventToMap(event);
+      events.add(eventMap);
+
+      // Notify HTML UI in real-time.
+      try {
+        _jsOnEvent(jsonEncode(eventMap).toJS);
+      } on Object catch (_) {
+        // _onEvent not defined — OK in headless mode.
+      }
+
+      // Capture terminal events.
+      if (event is BridgeRunFinished) {
+        resultValue = event.value;
+        printOutput = event.printOutput;
+      } else if (event is BridgeRunError) {
+        resultError = event.message;
+        printOutput = event.printOutput;
+      }
+    }
+
+    return jsonEncode({
+      'ok': resultError == null,
+      if (resultValue != null) 'value': resultValue,
+      if (resultError != null) 'error': resultError,
+      if (printOutput != null) 'printOutput': printOutput,
+      'events': events,
+    });
+  } on Object catch (e) {
+    return jsonEncode({
+      'ok': false,
+      'error': e.toString(),
+      'events': events,
+    });
+  }
+}
+
+Map<String, dynamic> _eventToMap(BridgeEvent event) {
+  return switch (event) {
+    BridgeRunStarted(:final threadId, :final runId) => {
+      'type': 'RunStarted',
+      'threadId': threadId,
+      'runId': runId,
+    },
+    BridgeRunFinished(
+      :final threadId,
+      :final runId,
+      :final value,
+      :final printOutput,
+    ) =>
+      {
+        'type': 'RunFinished',
+        'threadId': threadId,
+        'runId': runId,
+        if (value != null) 'value': '$value',
+        if (printOutput != null) 'printOutput': printOutput,
+      },
+    BridgeRunError(:final message, :final printOutput) => {
+      'type': 'RunError',
+      'message': message,
+      if (printOutput != null) 'printOutput': printOutput,
+    },
+    BridgeStepStarted(:final stepId) => {
+      'type': 'StepStarted',
+      'stepId': stepId,
+    },
+    BridgeStepFinished(:final stepId) => {
+      'type': 'StepFinished',
+      'stepId': stepId,
+    },
+    BridgeToolCallStart(:final callId, :final name) => {
+      'type': 'ToolCallStart',
+      'callId': callId,
+      'name': name,
+    },
+    BridgeToolCallArgs(:final callId, :final delta) => {
+      'type': 'ToolCallArgs',
+      'callId': callId,
+      'delta': delta,
+    },
+    BridgeToolCallEnd(:final callId) => {
+      'type': 'ToolCallEnd',
+      'callId': callId,
+    },
+    BridgeToolCallResult(:final callId, :final result) => {
+      'type': 'ToolCallResult',
+      'callId': callId,
+      'result': result,
+    },
+    BridgeTextStart(:final messageId) => {
+      'type': 'TextStart',
+      'messageId': messageId,
+    },
+    BridgeTextContent(:final messageId, :final delta) => {
+      'type': 'TextContent',
+      'messageId': messageId,
+      'delta': delta,
+    },
+    BridgeTextEnd(:final messageId) => {
+      'type': 'TextEnd',
+      'messageId': messageId,
+    },
+    BridgeOsCallStart(
+      :final callId,
+      :final operationName,
+      :final argumentSummary,
+    ) =>
+      {
+        'type': 'OsCallStart',
+        'callId': callId,
+        'operationName': operationName,
+        if (argumentSummary != null) 'argumentSummary': argumentSummary,
+      },
+    BridgeOsCallResult(:final callId, :final result, :final durationMs) => {
+      'type': 'OsCallResult',
+      'callId': callId,
+      'result': result,
+      if (durationMs != null) 'durationMs': durationMs,
+    },
+    BridgeEventLoopWaiting() => {'type': 'EventLoopWaiting'},
+    BridgeEventLoopResumed(:final event) => {
+      'type': 'EventLoopResumed',
+      'event': event,
+    },
+    BridgeUiRendered(:final schema) => {
+      'type': 'UiRendered',
+      'schema': schema,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State & schemas accessors
+// ---------------------------------------------------------------------------
+
+String _getState() {
+  if (_session == null) return '{}';
+  return jsonEncode(_session!.state);
+}
+
+String _getSchemas() {
+  if (_session == null) return '[]';
+  final schemas = _session!.schemas
+      .where(
+        (s) => s.name != '__restore_state__' && s.name != '__persist_state__',
+      )
+      .map(
+        (s) => {
+          'name': s.name,
+          'description': s.description,
+          'inputSchema': s.toJsonSchema(),
+        },
+      )
+      .toList();
+  return jsonEncode(schemas);
+}
+
+void _clearState() {
+  _session?.clearState();
+}
+
+Future<void> _dispose() async {
+  await _session?.dispose();
+  _session = null;
+  _initialized = false;
+}
+
+// ---------------------------------------------------------------------------
+// Main — wire up JS API and initialize
+// ---------------------------------------------------------------------------
+
+Future<void> main() async {
+  // Expose API to HTML.
+  final api = <String, JSFunction>{
+    'init': (() => _init().then((ok) => ok.toJS).toJS).toJS,
+    'execute': ((JSString code) => _execute(
+      code.toDart,
+    ).then((r) => r.toJS).toJS).toJS,
+    'getState': (() => _getState().toJS).toJS,
+    'getSchemas': (() => _getSchemas().toJS).toJS,
+    'clearState': _clearState.toJS,
+    'dispose': (() => _dispose().then((_) => null).toJS).toJS,
+  }.jsify();
+  // jsify() returns JSObject? but we know our non-empty map produces one.
+  _agentDemo = api! as JSObject;
+
+  // Auto-initialize session.
+  final ok = await _init();
+  if (!ok) {
+    print('AGENT_DEMO_ERROR: init failed');
+    return;
+  }
+
+  print('AgentDemo ready');
+  try {
+    _jsOnReady();
+  } on Object catch (_) {
+    // _onReady not defined — OK in headless mode.
+  }
+}

--- a/example/web/web/agent.html
+++ b/example/web/web/agent.html
@@ -1,0 +1,684 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dart_monty AgentSession Demo</title>
+  <style>
+    :root {
+      --bg: #1a1b26;
+      --surface: #24283b;
+      --surface2: #2f3447;
+      --border: #3b4261;
+      --text: #c0caf5;
+      --text-dim: #565f89;
+      --accent: #7aa2f7;
+      --green: #9ece6a;
+      --yellow: #e0af68;
+      --red: #f7768e;
+      --orange: #ff9e64;
+      --cyan: #7dcfff;
+      --purple: #bb9af7;
+      --mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    header {
+      padding: 12px 20px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    header h1 {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--accent);
+    }
+
+    header .tag {
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-weight: 500;
+    }
+
+    .tag-agent { background: #3d2d5e; color: var(--purple); }
+    .tag-wasm { background: #2d3a5e; color: var(--cyan); }
+    .tag-stateful { background: #2d3e2d; color: var(--green); }
+
+    #status {
+      margin-left: auto;
+      font-size: 12px;
+      color: var(--text-dim);
+    }
+
+    #status.ready { color: var(--green); }
+    #status.running { color: var(--yellow); }
+    #status.error { color: var(--red); }
+
+    .main {
+      flex: 1;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr;
+      gap: 1px;
+      background: var(--border);
+      overflow: hidden;
+    }
+
+    .panel {
+      background: var(--surface);
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .panel-header {
+      padding: 8px 12px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-dim);
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+
+    .panel-header .count {
+      background: var(--surface2);
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+    }
+
+    .panel-body {
+      flex: 1;
+      overflow: auto;
+      padding: 0;
+    }
+
+    /* Code editor */
+    #editor {
+      width: 100%;
+      height: 100%;
+      background: transparent;
+      color: var(--text);
+      border: none;
+      resize: none;
+      padding: 12px;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.6;
+      outline: none;
+      tab-size: 4;
+    }
+
+    .editor-panel .panel-header {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    .btn-group { display: flex; gap: 6px; }
+
+    .btn {
+      padding: 4px 12px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--surface2);
+      color: var(--text);
+      font-size: 11px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+
+    .btn:hover { border-color: var(--accent); }
+
+    .btn-run {
+      background: #1a3a1a;
+      border-color: var(--green);
+      color: var(--green);
+      font-weight: 600;
+    }
+
+    .btn-run:hover { background: #2a4a2a; }
+    .btn-run:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    .btn-clear {
+      background: #3a1a1a;
+      border-color: var(--red);
+      color: var(--red);
+    }
+
+    .btn-clear:hover { background: #4a2a2a; }
+
+    /* Result & State panels */
+    .result-section {
+      padding: 12px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .result-section:last-child { border-bottom: none; }
+
+    .result-label {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-dim);
+      margin-bottom: 4px;
+    }
+
+    .result-value {
+      font-family: var(--mono);
+      font-size: 13px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: var(--green);
+    }
+
+    .result-error {
+      font-family: var(--mono);
+      font-size: 13px;
+      white-space: pre-wrap;
+      word-break: break-all;
+      color: var(--red);
+    }
+
+    .result-print {
+      font-family: var(--mono);
+      font-size: 12px;
+      white-space: pre-wrap;
+      color: var(--text-dim);
+    }
+
+    /* State panel */
+    .state-entry {
+      padding: 4px 12px;
+      font-family: var(--mono);
+      font-size: 12px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      gap: 8px;
+    }
+
+    .state-key {
+      color: var(--cyan);
+      font-weight: 600;
+      min-width: 80px;
+    }
+
+    .state-val {
+      color: var(--text);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* Events panel */
+    .event-entry {
+      padding: 4px 12px;
+      font-family: var(--mono);
+      font-size: 11px;
+      border-bottom: 1px solid var(--border);
+      display: grid;
+      grid-template-columns: 100px 1fr;
+      gap: 8px;
+      align-items: baseline;
+    }
+
+    .event-type {
+      font-weight: 600;
+      white-space: nowrap;
+    }
+
+    .event-type-run { color: var(--green); }
+    .event-type-tool { color: var(--purple); }
+    .event-type-os { color: var(--cyan); }
+    .event-type-text { color: var(--yellow); }
+    .event-type-error { color: var(--red); }
+    .event-type-step { color: var(--orange); }
+
+    .event-detail {
+      color: var(--text-dim);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    /* Tools panel */
+    .tool-entry {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .tool-name {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--purple);
+      font-weight: 600;
+    }
+
+    .tool-desc {
+      font-size: 11px;
+      color: var(--text-dim);
+      margin-top: 2px;
+    }
+
+    .tool-params {
+      font-family: var(--mono);
+      font-size: 10px;
+      color: var(--text-dim);
+      margin-top: 4px;
+    }
+
+    .tool-param-name { color: var(--cyan); }
+    .tool-param-type { color: var(--orange); }
+
+    .empty-state {
+      padding: 24px;
+      text-align: center;
+      color: var(--text-dim);
+      font-size: 13px;
+    }
+
+    /* Examples dropdown */
+    select {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 4px 8px;
+      font-size: 11px;
+      cursor: pointer;
+      outline: none;
+    }
+
+    /* Bottom panel sub-tabs */
+    .tab-bar {
+      display: flex;
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+
+    .tab-btn {
+      padding: 6px 14px;
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-dim);
+      background: transparent;
+      border: none;
+      border-bottom: 2px solid transparent;
+      cursor: pointer;
+      font-family: inherit;
+    }
+
+    .tab-btn:hover { color: var(--text); }
+    .tab-btn.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+    .tab-content { display: none; flex: 1; overflow: auto; }
+    .tab-content.active { display: block; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>dart_monty AgentSession Demo</h1>
+    <span class="tag tag-agent">Agent</span>
+    <span class="tag tag-wasm">WASM</span>
+    <span class="tag tag-stateful">Stateful</span>
+    <select id="examples">
+      <option value="">Load example...</option>
+      <option value="stateful">Stateful Variables</option>
+      <option value="tools">Host Functions</option>
+      <option value="kvstore">Key-Value Store</option>
+      <option value="fetch">HTTP Fetch</option>
+      <option value="filesystem">Filesystem I/O</option>
+      <option value="template" disabled>Jinja Templates (soon)</option>
+      <option value="sandbox" disabled>Child Sandboxes (soon)</option>
+      <option value="msgbus" disabled>Message Bus (soon)</option>
+      <option value="combined">Combined Demo</option>
+    </select>
+    <span id="status">Initializing WASM...</span>
+  </header>
+
+  <div class="main">
+    <!-- Top-left: Python editor -->
+    <div class="panel editor-panel">
+      <div class="panel-header">
+        <span>Python Code</span>
+        <div class="btn-group">
+          <button class="btn btn-clear" id="clearBtn">Clear State</button>
+          <button class="btn btn-run" id="runBtn" disabled>Execute</button>
+        </div>
+      </div>
+      <div class="panel-body">
+        <textarea id="editor" spellcheck="false"># Variables persist across executions.
+# Run this, then run the next example.
+x = 42
+greeting = "hello"
+x</textarea>
+      </div>
+    </div>
+
+    <!-- Top-right: Result + State -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Result &amp; State</span>
+        <span class="count" id="stateCount">0 vars</span>
+      </div>
+      <div class="panel-body" id="resultPanel">
+        <div id="resultArea">
+          <div class="empty-state">Execute code to see the result</div>
+        </div>
+        <div id="stateArea" style="border-top: 1px solid var(--border);">
+          <div class="result-section">
+            <div class="result-label">Session State</div>
+            <div id="stateList" class="result-print">No variables yet</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Bottom-left: Events log -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Bridge Events</span>
+        <span class="count" id="eventCount">0</span>
+      </div>
+      <div class="panel-body" id="eventLog">
+        <div class="empty-state">Run code to see bridge events in real-time</div>
+      </div>
+    </div>
+
+    <!-- Bottom-right: Tools / Info -->
+    <div class="panel">
+      <div class="tab-bar">
+        <button class="tab-btn active" data-tab="tools">Tools</button>
+        <button class="tab-btn" data-tab="help">Help</button>
+      </div>
+      <div class="tab-content active" id="tab-tools">
+        <div class="empty-state">Loading tool schemas...</div>
+      </div>
+      <div class="tab-content" id="tab-help">
+        <div style="padding: 16px; font-size: 13px; line-height: 1.6;">
+          <p style="margin-bottom: 12px;"><strong style="color: var(--accent);">AgentSession</strong> combines a Monty bridge, host functions, OS providers, and variable persistence into one API.</p>
+          <p style="margin-bottom: 12px; color: var(--text-dim);"><strong style="color: var(--cyan);">Stateful:</strong> Variables defined in one execution persist to the next. Click "Clear State" to reset.</p>
+          <p style="margin-bottom: 12px; color: var(--text-dim);"><strong style="color: var(--purple);">Host Functions:</strong> Python can call Dart-defined tools: <code style="color: var(--purple);">echo(msg)</code>, <code style="color: var(--purple);">add_numbers(a, b)</code>, <code style="color: var(--purple);">get_time()</code>.</p>
+          <p style="margin-bottom: 12px; color: var(--text-dim);"><strong style="color: var(--green);">Filesystem:</strong> pathlib works via MemoryFsProvider: <code style="color: var(--green);">Path('/sandbox/f.txt').write_text(...)</code></p>
+          <p style="color: var(--text-dim);"><strong style="color: var(--yellow);">Events:</strong> Every bridge event streams in real-time to the Events panel.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- COOP/COEP for SharedArrayBuffer (required by WASM worker) -->
+  <script src="coi-serviceworker.js"></script>
+
+  <!-- Dart callbacks — MUST be defined before agent_demo.dart.js loads -->
+  <script>
+    let _eventCount = 0;
+    let _ready = false;
+
+    window._onEvent = function(jsonStr) {
+      const event = JSON.parse(jsonStr);
+      _eventCount++;
+      const el = document.getElementById('eventLog');
+      const countEl = document.getElementById('eventCount');
+      if (!el || !countEl) return;
+      countEl.textContent = _eventCount;
+      if (_eventCount === 1) el.innerHTML = '';
+
+      const div = document.createElement('div');
+      div.className = 'event-entry';
+
+      const typeClass = getEventTypeClass(event.type);
+      let detail = getEventDetail(event);
+
+      div.innerHTML = '<span class="event-type ' + typeClass + '">' + event.type + '</span><span class="event-detail">' + escapeHtml(detail) + '</span>';
+      el.appendChild(div);
+      el.scrollTop = el.scrollHeight;
+    };
+
+    window._onReady = function() {
+      _ready = true;
+      const s = document.getElementById('status');
+      const b = document.getElementById('runBtn');
+      if (s) { s.textContent = 'Ready'; s.className = 'ready'; }
+      if (b) { b.disabled = false; }
+      renderTools();
+    };
+
+    function getEventTypeClass(type) {
+      if (type.startsWith('Run')) return 'event-type-run';
+      if (type.startsWith('Tool')) return 'event-type-tool';
+      if (type.startsWith('OsCall')) return 'event-type-os';
+      if (type.startsWith('Text')) return 'event-type-text';
+      if (type.startsWith('Step')) return 'event-type-step';
+      if (type === 'RunError') return 'event-type-error';
+      return '';
+    }
+
+    function getEventDetail(event) {
+      switch (event.type) {
+        case 'RunStarted': return 'thread=' + event.threadId;
+        case 'RunFinished': return event.value ? 'value=' + event.value : 'done';
+        case 'RunError': return event.message;
+        case 'ToolCallStart': return event.name + '()';
+        case 'ToolCallArgs': return event.delta;
+        case 'ToolCallResult': return event.result;
+        case 'OsCallStart': return event.operationName + (event.argumentSummary ? ' ' + event.argumentSummary : '');
+        case 'OsCallResult': return event.result + (event.durationMs != null ? ' [' + event.durationMs + 'ms]' : '');
+        case 'TextContent': return event.delta;
+        default: return JSON.stringify(event);
+      }
+    }
+
+    function escapeHtml(s) {
+      const d = document.createElement('div');
+      d.textContent = s;
+      return d.innerHTML;
+    }
+  </script>
+
+  <!-- Load WASM bridge, then compiled Dart agent demo -->
+  <script src="dart_monty_bridge.js"></script>
+  <script src="agent_demo.dart.js"></script>
+
+  <!-- UI wiring -->
+  <script>
+    const $ = (s) => document.getElementById(s);
+    const editor = $('editor');
+    const runBtn = $('runBtn');
+    const status = $('status');
+    const eventLog = $('eventLog');
+    const resultArea = $('resultArea');
+    const stateList = $('stateList');
+    const stateCount = $('stateCount');
+
+    async function run() {
+      if (!_ready || !window.AgentDemo) return;
+      runBtn.disabled = true;
+      status.textContent = 'Running...';
+      status.className = 'running';
+      _eventCount = 0;
+      $('eventCount').textContent = '0';
+      eventLog.innerHTML = '';
+      resultArea.innerHTML = '';
+
+      try {
+        const resultPromise = window.AgentDemo.execute(editor.value);
+        const resultJson = await resultPromise;
+        const result = JSON.parse(resultJson);
+
+        if (result.ok) {
+          let html = '';
+          if (result.value != null) {
+            html += '<div class="result-section"><div class="result-label">Value</div><div class="result-value">' + escapeHtml(formatValue(result.value)) + '</div></div>';
+          }
+          if (result.printOutput) {
+            html += '<div class="result-section"><div class="result-label">Print Output</div><div class="result-print">' + escapeHtml(result.printOutput) + '</div></div>';
+          }
+          if (!html) {
+            html = '<div class="result-section"><div class="result-value">None</div></div>';
+          }
+          resultArea.innerHTML = html;
+        } else {
+          resultArea.innerHTML = '<div class="result-section"><div class="result-label">Error</div><div class="result-error">' + escapeHtml(result.error) + '</div></div>';
+          if (result.printOutput) {
+            resultArea.innerHTML += '<div class="result-section"><div class="result-label">Print Output</div><div class="result-print">' + escapeHtml(result.printOutput) + '</div></div>';
+          }
+        }
+
+        status.textContent = result.ok ? 'Done' : 'Error';
+        status.className = result.ok ? 'ready' : 'error';
+
+        // Refresh state display.
+        refreshState();
+      } catch (e) {
+        resultArea.innerHTML = '<div class="result-section"><div class="result-error">' + escapeHtml(String(e)) + '</div></div>';
+        status.textContent = 'Error';
+        status.className = 'error';
+      }
+      runBtn.disabled = false;
+    }
+
+    function refreshState() {
+      if (!window.AgentDemo) return;
+      try {
+        const stateJson = window.AgentDemo.getState();
+        const state = JSON.parse(stateJson);
+        const keys = Object.keys(state);
+        stateCount.textContent = keys.length + ' var' + (keys.length !== 1 ? 's' : '');
+
+        if (keys.length === 0) {
+          stateList.textContent = 'No variables';
+          return;
+        }
+
+        let html = '';
+        for (const key of keys) {
+          html += '<div class="state-entry"><span class="state-key">' + escapeHtml(key) + '</span><span class="state-val">' + escapeHtml(formatValue(state[key])) + '</span></div>';
+        }
+        stateList.innerHTML = html;
+      } catch (e) {
+        stateList.textContent = 'Error reading state';
+      }
+    }
+
+    function renderTools() {
+      if (!window.AgentDemo) return;
+      const toolsEl = $('tab-tools');
+      try {
+        const schemasJson = window.AgentDemo.getSchemas();
+        const schemas = JSON.parse(schemasJson);
+
+        if (schemas.length === 0) {
+          toolsEl.innerHTML = '<div class="empty-state">No tools registered</div>';
+          return;
+        }
+
+        let html = '';
+        for (const tool of schemas) {
+          html += '<div class="tool-entry">';
+          html += '<div class="tool-name">' + escapeHtml(tool.name) + '</div>';
+          html += '<div class="tool-desc">' + escapeHtml(tool.description) + '</div>';
+          const props = tool.inputSchema && tool.inputSchema.properties;
+          if (props) {
+            const paramKeys = Object.keys(props);
+            if (paramKeys.length > 0) {
+              html += '<div class="tool-params">';
+              for (const pName of paramKeys) {
+                const p = props[pName];
+                html += '<span class="tool-param-name">' + escapeHtml(pName) + '</span>';
+                if (p.type) html += ': <span class="tool-param-type">' + escapeHtml(p.type) + '</span>';
+                if (p.description) html += ' &mdash; ' + escapeHtml(p.description);
+                html += '<br>';
+              }
+              html += '</div>';
+            }
+          }
+          html += '</div>';
+        }
+        toolsEl.innerHTML = html;
+      } catch (e) {
+        toolsEl.innerHTML = '<div class="empty-state">Error loading schemas</div>';
+      }
+    }
+
+    function formatValue(v) {
+      if (v === null || v === undefined) return 'None';
+      if (typeof v === 'object') return JSON.stringify(v, null, 2);
+      return String(v);
+    }
+
+    // Tab switching
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        $('tab-' + btn.dataset.tab).classList.add('active');
+      });
+    });
+
+    // Examples
+    const examples = {
+      stateful: "# Variables persist across executions.\n# Run this, then run another example — x and greeting survive.\nx = 42\ngreeting = \"hello\"\ndata = [1, 2, 3]\nx",
+      tools: "# Call Dart host functions from Python\nmsg = echo(\"hello from python\")\nresult = add_numbers(17, 25)\ntimestamp = get_time()\n\n{'echoed': msg, 'sum': result, 'time': timestamp}",
+      kvstore: "# Key-value store — persistent memory\nkv_set('user', 'Alice')\nkv_set('score', 95)\nkv_set('tags', ['python', 'dart', 'monty'])\n\nall_keys = kv_list()\nuser = kv_get('user')\nscore = kv_get('score')\n\n{'keys': all_keys, 'user': user, 'score': score}",
+      fetch: "# Simulated HTTP fetch\nusers = fetch_json('https://api.example.com/users')\nweather = fetch_json('https://api.example.com/weather')\n\ntop_user = users[0]['name']\n\n{'users': len(users), 'top': top_user, 'temp': weather['temp']}",
+      filesystem: "from pathlib import Path\n\n# Write files to the virtual filesystem\nPath('/sandbox/notes.txt').write_text('Remember: variables persist!')\nPath('/sandbox/data').mkdir(parents=True, exist_ok=True)\nPath('/sandbox/data/scores.csv').write_text('name,score\\nalice,95\\nbob,87')\n\n# Read back\ncontent = Path('/sandbox/notes.txt').read_text()\ncsv_data = Path('/sandbox/data/scores.csv').read_text()\n\n{'notes': content, 'csv': csv_data}",
+      template: "# Jinja2 templates via DinjaTemplatePlugin\ngreeting = dinja_render('greeting', name='Alice', place='Monty Sandbox')\nreport = dinja_render('report', title='Q3 Sales', date='2026-04-11', content='Revenue up 15%')\n\n{'greeting': greeting, 'report': report}",
+      sandbox: "# Spawn isolated child interpreters\n# Each child has its own VFS and state\nchild1 = sandbox_spawn('x = 1 + 1\\nx')\nchild2 = sandbox_spawn('y = 2 * 3\\ny')\nchild3 = sandbox_spawn('import math\\nmath.factorial(5)')\n\n[sandbox_output(child1), sandbox_output(child2), sandbox_output(child3)]",
+      msgbus: "# Inter-sandbox messaging via MessageBusPlugin\nbus_publish('alerts', 'System healthy')\nbus_publish('alerts', 'Disk 80% full')\nbus_publish('metrics', 42)\n\nalerts = bus_history('alerts')\nmetrics = bus_history('metrics')\n\n{'alerts': alerts, 'metrics': metrics}",
+      combined: "# Full demo: state + tools + filesystem\nfrom pathlib import Path\n\ntimestamp = get_time()\nPath('/sandbox/log.txt').write_text(f'Run at: {timestamp}')\n\ntry:\n    msg = f'x was {x}, greeting was {greeting}'\nexcept NameError:\n    msg = 'No prior state — run Stateful first'\n\ntotal = add_numbers(100, 200)\nkv_set('last_run', timestamp)\n\n{'message': msg, 'total': total, 'logged_at': timestamp}",
+    };
+
+    $('examples').onchange = function() {
+      const key = this.value;
+      if (key && examples[key]) {
+        editor.value = examples[key];
+      }
+      this.value = '';
+    };
+
+    // Clear state button
+    $('clearBtn').onclick = function() {
+      if (!window.AgentDemo) return;
+      window.AgentDemo.clearState();
+      refreshState();
+    };
+
+    // Keyboard shortcuts
+    editor.addEventListener('keydown', (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') { e.preventDefault(); run(); }
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const start = editor.selectionStart;
+        editor.value = editor.value.substring(0, start) + '    ' + editor.value.substring(editor.selectionEnd);
+        editor.selectionStart = editor.selectionEnd = start + 4;
+      }
+    });
+
+    runBtn.onclick = run;
+  </script>
+</body>
+</html>

--- a/lib/dart_monty_bridge.dart
+++ b/lib/dart_monty_bridge.dart
@@ -4,6 +4,7 @@
 /// event loop support, and a plugin system for modular host function bundles.
 library;
 
+export 'src/bridge/agent_session.dart';
 export 'src/bridge/bridge/bridge_event.dart';
 export 'src/bridge/bridge/bridge_middleware.dart';
 export 'src/bridge/bridge/event_loop_bridge.dart';

--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -1,0 +1,339 @@
+import 'dart:async';
+
+import 'package:dart_monty/src/bridge/bridge/bridge_event.dart';
+import 'package:dart_monty/src/bridge/bridge/default_monty_bridge.dart';
+import 'package:dart_monty/src/bridge/bridge/host_function.dart';
+import 'package:dart_monty/src/bridge/bridge/host_function_schema.dart';
+import 'package:dart_monty/src/bridge/bridge/host_param.dart';
+import 'package:dart_monty/src/bridge/bridge/host_param_type.dart';
+import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
+import 'package:dart_monty/src/bridge/bridge/monty_plugin.dart';
+import 'package:dart_monty/src/bridge/bridge/plugin_registry.dart';
+import 'package:dart_monty/src/bridge/os_call/os_provider.dart';
+import 'package:dart_monty/src/monty.dart';
+import 'package:dart_monty/src/platform/bridge_logger.dart';
+import 'package:dart_monty/src/platform/monty_exception.dart';
+import 'package:dart_monty/src/platform/monty_resource_usage.dart';
+import 'package:dart_monty/src/platform/monty_result.dart';
+import 'package:dart_monty/src/platform/monty_value.dart';
+
+/// Matches simple assignment targets: `identifier = ...`
+final _assignmentPattern = RegExp(r'^([a-zA-Z]\w*)\s*=[^=]', multiLine: true);
+
+/// Python keywords that start statements (not expressions).
+const _statementPrefixes = [
+  'if ',
+  'for ',
+  'while ',
+  'with ',
+  'try:',
+  'def ',
+  'class ',
+  'import ',
+  'from ',
+  'raise ',
+  'return ',
+  'pass',
+  'break',
+  'continue',
+  'assert ',
+];
+
+const _restoreFn = '__restore_state__';
+const _persistFn = '__persist_state__';
+
+/// High-level agent session — stateful Python execution with tools and plugins.
+///
+/// Combines `MontyBridge`, `PluginRegistry`, OS providers, and variable
+/// persistence into a single API. Variables persist across `execute()` calls.
+/// All registered plugins and host functions are available to Python code.
+///
+/// ```dart
+/// final session = AgentSession(
+///   os: OsProvider(),
+///   plugins: [SandboxPlugin(), MessageBusPlugin()],
+/// );
+///
+/// await session.execute('x = 42');
+/// final result = await session.execute('x + 1');
+/// print(result.value); // 43
+///
+/// // Tool schemas for LLM integration
+/// final tools = session.schemas;
+///
+/// await session.dispose();
+/// ```
+class AgentSession {
+  /// Creates an agent session with optional OS provider, plugins, limits,
+  /// and logger.
+  AgentSession({
+    OsProvider? os,
+    List<MontyPlugin>? plugins,
+    BridgeLogger? logger,
+  }) : _monty = Monty(os: os) {
+    _bridge = DefaultMontyBridge(
+      platform: _monty.platform,
+      useFutures: false,
+      logger: logger,
+    );
+
+    if (os != null) _bridge.registerOs(os);
+
+    _registerStateHostFunctions();
+
+    if (plugins != null && plugins.isNotEmpty) {
+      _registry = PluginRegistry();
+      plugins.forEach(_registry!.register);
+    }
+  }
+
+  static const _zeroUsage = MontyResourceUsage(
+    memoryBytesUsed: 0,
+    timeElapsedMs: 0,
+    stackDepthUsed: 0,
+  );
+
+  final Monty _monty;
+  late final DefaultMontyBridge _bridge;
+  PluginRegistry? _registry;
+  bool _attached = false;
+  bool _disposed = false;
+  Map<String, Object?> _sessionState = {};
+
+  /// All registered tool schemas — feed these to an LLM as tool definitions.
+  List<HostFunctionSchema> get schemas => _bridge.schemas;
+
+  /// The underlying bridge — for advanced use (middleware, direct execute).
+  MontyBridge get bridge => _bridge;
+
+  /// The current persisted Python state.
+  Map<String, Object?> get state => Map.from(_sessionState);
+
+  /// Registers an additional host function.
+  void register(HostFunction function) {
+    _checkNotDisposed();
+    _bridge.register(function);
+  }
+
+  /// Executes Python [code] with state persistence and full tool access.
+  ///
+  /// Variables defined in [code] persist for subsequent `execute()` calls.
+  /// All registered host functions and plugins are callable from Python.
+  ///
+  /// Returns the [MontyResult] from execution.
+  Future<MontyResult> execute(String code) async {
+    _checkNotDisposed();
+    await _ensureAttached();
+
+    final wrappedCode = _wrapWithState(code);
+    final events = await _bridge.execute(wrappedCode).toList();
+
+    return _extractResult(events);
+  }
+
+  /// Executes [code] and returns the stream of bridge events.
+  ///
+  /// Use this when you need real-time event streaming (tool calls, text
+  /// output, lifecycle events) rather than just the final result.
+  Stream<BridgeEvent> executeStream(String code) {
+    _checkNotDisposed();
+    // Can't await _ensureAttached in a sync method that returns Stream.
+    // Caller must ensure plugins are attached before first use.
+    final wrappedCode = _wrapWithState(code);
+
+    return _bridge.execute(wrappedCode);
+  }
+
+  /// Clears all persisted Python state.
+  void clearState() {
+    _checkNotDisposed();
+    _sessionState = {};
+  }
+
+  /// Releases all resources.
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    _bridge.dispose();
+    await _monty.dispose();
+  }
+
+  // ---------------------------------------------------------------------------
+  // State host functions
+  // ---------------------------------------------------------------------------
+
+  void _registerStateHostFunctions() {
+    _bridge
+      ..register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: _restoreFn,
+            description: 'Internal: restore session state',
+          ),
+          handler: (_) async => _sessionState,
+        ),
+      )
+      ..register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: _persistFn,
+            description: 'Internal: persist session state',
+            params: [HostParam(name: 'state', type: HostParamType.any)],
+          ),
+          handler: (args) async {
+            final captured = args['state'];
+            if (captured is Map<String, Object?>) {
+              _sessionState = captured;
+            }
+
+            return null;
+          },
+        ),
+      );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Code wrapping (state persistence)
+  // ---------------------------------------------------------------------------
+
+  String _wrapWithState(String userCode) {
+    final restore = _generateRestore();
+    final persist = _generatePersist(userCode);
+    final (processed, hasResult) = _captureLastExpression(userCode);
+
+    final buf = StringBuffer(restore)
+      ..write('\n')
+      ..write(processed)
+      ..write('\n')
+      ..write(persist);
+
+    if (hasResult) {
+      buf.write('\n__r');
+    }
+
+    return buf.toString();
+  }
+
+  String _generateRestore() {
+    final buf = StringBuffer('__d = $_restoreFn()');
+    for (final key in _sessionState.keys) {
+      buf.write('\n$key = __d["$key"]');
+    }
+
+    return buf.toString();
+  }
+
+  String _generatePersist(String userCode) {
+    final names = <String>{
+      ..._sessionState.keys,
+      ..._extractAssignmentTargets(userCode),
+    };
+
+    if (names.isEmpty) {
+      return '$_persistFn({})';
+    }
+
+    final buf = StringBuffer('__d2 = {}');
+    for (final name in names) {
+      buf
+        ..write('\ntry:')
+        ..write('\n    __d2["$name"] = $name')
+        ..write('\nexcept Exception:')
+        ..write('\n    pass');
+    }
+    buf.write('\n$_persistFn(__d2)');
+
+    return buf.toString();
+  }
+
+  static (String, bool) _captureLastExpression(String userCode) {
+    final lines = userCode.split('\n');
+    var lastIdx = -1;
+    for (var i = lines.length - 1; i >= 0; i--) {
+      final trimmed = lines[i].trim();
+      if (trimmed.isNotEmpty && !trimmed.startsWith('#')) {
+        lastIdx = i;
+        break;
+      }
+    }
+    if (lastIdx < 0) return (userCode, false);
+    if (!_isExpression(lines[lastIdx])) return (userCode, false);
+
+    lines[lastIdx] = '__r = (${lines[lastIdx]})';
+
+    return (lines.join('\n'), true);
+  }
+
+  static bool _isExpression(String line) {
+    final trimmed = line.trim();
+    if (trimmed.isEmpty || trimmed.startsWith('#')) return false;
+    for (final prefix in _statementPrefixes) {
+      if (trimmed.startsWith(prefix) || trimmed == prefix.trim()) return false;
+    }
+    if (_assignmentPattern.hasMatch(trimmed)) return false;
+
+    return true;
+  }
+
+  static Set<String> _extractAssignmentTargets(String code) {
+    final names = <String>{};
+    for (final line in code.split('\n')) {
+      if (line.isNotEmpty && line[0] != ' ' && line[0] != '\t') {
+        for (final segment in line.split(';')) {
+          final match = _assignmentPattern.firstMatch(segment.trimLeft());
+          if (match != null) {
+            final name = match.group(1)!;
+            if (!name.startsWith('_')) {
+              names.add(name);
+            }
+          }
+        }
+      }
+    }
+
+    return names;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  Future<void> _ensureAttached() async {
+    if (!_attached && _registry != null) {
+      await _registry!.attachTo(_bridge);
+      _attached = true;
+    }
+  }
+
+  MontyResult _extractResult(List<BridgeEvent> events) {
+    for (final event in events.reversed) {
+      if (event is BridgeRunFinished) {
+        final value = event.value != null
+            ? MontyValue.fromDart(event.value)
+            : null;
+
+        return MontyResult(
+          value: value,
+          usage: _zeroUsage,
+          printOutput: event.printOutput,
+        );
+      }
+      if (event is BridgeRunError) {
+        return MontyResult(
+          error: event.exception ?? MontyException(message: event.message),
+          usage: _zeroUsage,
+          printOutput: event.printOutput,
+        );
+      }
+    }
+
+    // Should not happen — bridge always emits a terminal event.
+    throw StateError('No terminal event in bridge execution');
+  }
+
+  void _checkNotDisposed() {
+    if (_disposed) {
+      throw StateError('AgentSession has been disposed');
+    }
+  }
+}

--- a/test/bridge/integration/agent_session_test.dart
+++ b/test/bridge/integration/agent_session_test.dart
@@ -1,0 +1,256 @@
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+/// Integration tests for AgentSession — requires the native Monty library.
+///
+/// Run with:
+/// ```bash
+/// dart test --run-skipped --tags=integration test/bridge/integration/agent_session_test.dart
+/// ```
+void main() {
+  group('AgentSession stateful execution', () {
+    late AgentSession session;
+
+    setUp(() {
+      session = AgentSession();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('simple expression', () async {
+      final result = await session.execute('2 + 2');
+
+      expect(result.value?.dartValue, 4);
+    });
+
+    test('variables persist across execute() calls', () async {
+      await session.execute('x = 42');
+      await session.execute('y = x * 2');
+      final result = await session.execute('x + y');
+
+      expect(result.value?.dartValue, 126);
+    });
+
+    test('string variables persist', () async {
+      await session.execute('name = "monty"');
+      final result = await session.execute('name.upper()');
+
+      expect(result.value?.dartValue, 'MONTY');
+    });
+
+    test('list variables persist', () async {
+      await session.execute('data = [1, 2, 3]');
+      await session.execute('data.append(4)');
+      final result = await session.execute('sum(data)');
+
+      expect(result.value?.dartValue, 10);
+    });
+
+    test('dict variables persist', () async {
+      await session.execute('config = {"debug": True, "level": 5}');
+      final result = await session.execute('config["debug"]');
+
+      expect(result.value?.dartValue, true);
+    });
+
+    test('clearState() resets all variables', () async {
+      await session.execute('x = 42');
+      session.clearState();
+      final result = await session.execute('x');
+
+      expect(result.error, isNotNull);
+    });
+
+    test('multiple types in state', () async {
+      await session.execute('a = 1; b = 2.5; c = "hello"; d = True');
+      final result = await session.execute('[a, b, c, d]');
+
+      expect(result.value?.dartValue, [1, 2.5, 'hello', true]);
+    });
+  });
+
+  group('AgentSession with host functions', () {
+    late AgentSession session;
+
+    setUp(() {
+      session = AgentSession();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('registered host function callable from Python', () async {
+      session.register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'double_it',
+            description: 'Doubles a number',
+            params: [HostParam(name: 'n', type: HostParamType.integer)],
+          ),
+          handler: (args) async => (args['n']! as int) * 2,
+        ),
+      );
+
+      final result = await session.execute('double_it(21)');
+
+      expect(result.value?.dartValue, 42);
+    });
+
+    test('host function result persists in state', () async {
+      session.register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'get_data',
+            description: 'Returns sample data',
+          ),
+          handler: (_) async => [1, 2, 3, 4, 5],
+        ),
+      );
+
+      await session.execute('data = get_data()');
+      final result = await session.execute('sum(data)');
+
+      expect(result.value?.dartValue, 15);
+    });
+
+    test('schemas include registered functions', () {
+      session.register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'my_tool',
+            description: 'A custom tool',
+          ),
+          handler: (_) async => null,
+        ),
+      );
+
+      final names = session.schemas.map((s) => s.name).toList();
+
+      expect(names, contains('my_tool'));
+      expect(names, contains('__restore_state__'));
+      expect(names, contains('__persist_state__'));
+    });
+  });
+
+  group('AgentSession with filesystem', () {
+    late AgentSession session;
+
+    setUp(() {
+      // Use MemoryFsProvider for filesystem tests (not LocalFileSystem)
+      final time = TimeOsProvider();
+      session = AgentSession(
+        os: OsProvider.compose({
+          'Path.': MemoryFsProvider(),
+          'date.': time,
+          'datetime.': time,
+        }),
+      );
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('write and read file via pathlib', () async {
+      await session.execute(
+        'from pathlib import Path\n'
+        'Path("/data/test.txt").write_text("hello from agent")',
+      );
+      final result = await session.execute(
+        'from pathlib import Path\n'
+        'Path("/data/test.txt").read_text()',
+      );
+
+      expect(result.value?.dartValue, 'hello from agent');
+    });
+
+    test('filesystem state persists across calls', () async {
+      await session.execute(
+        'from pathlib import Path\n'
+        'Path("/data").mkdir(parents=True, exist_ok=True)\n'
+        'Path("/data/counter.txt").write_text("0")',
+      );
+
+      await session.execute(
+        'from pathlib import Path\n'
+        'n = int(Path("/data/counter.txt").read_text())\n'
+        'Path("/data/counter.txt").write_text(str(n + 1))',
+      );
+
+      final result = await session.execute(
+        'from pathlib import Path\n'
+        'int(Path("/data/counter.txt").read_text())',
+      );
+
+      expect(result.value?.dartValue, 1);
+    });
+
+    test('date.today() returns reasonable year', () async {
+      // Note: date objects stored in state are not JSON-serializable,
+      // so we extract the year immediately rather than persisting.
+      final result = await session.execute(
+        'from datetime import date\n'
+        'date.today().year >= 2024',
+      );
+
+      expect(result.value?.dartValue, true);
+    });
+  });
+
+  group('AgentSession error handling', () {
+    late AgentSession session;
+
+    setUp(() {
+      session = AgentSession();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('Python error returns error result', () async {
+      final result = await session.execute('1 / 0');
+
+      expect(result.error, isNotNull);
+    });
+
+    test('error does not break state', () async {
+      await session.execute('x = 42');
+      await session.execute('1 / 0'); // error, but x should survive
+      final result = await session.execute('x');
+
+      expect(result.value?.dartValue, 42);
+    });
+
+    test('execute after dispose throws', () async {
+      await session.dispose();
+
+      expect(
+        () => session.execute('1 + 1'),
+        throwsStateError,
+      );
+    });
+  });
+
+  group('AgentSession event streaming', () {
+    test('executeStream emits events', () async {
+      final session = AgentSession();
+
+      // First execute to ensure attached
+      await session.execute('pass');
+
+      final events = await session.executeStream('2 + 2').toList();
+
+      expect(events, isNotEmpty);
+      expect(events.whereType<BridgeRunFinished>(), hasLength(1));
+
+      await session.dispose();
+    });
+  });
+}


### PR DESCRIPTION
## Summary

`AgentSession` combines `MontyBridge`, `PluginRegistry`, `OsProvider`, and variable persistence into a single high-level API for LLM agent workloads.

```dart
final session = AgentSession(os: OsProvider());
await session.execute('x = 42');
final result = await session.execute('x + 1'); // 43
final tools = session.schemas; // feed to LLM
await session.dispose();
```

- Stateful: variables persist across `execute()` calls
- Full tool access: all registered plugins callable from Python
- LLM integration: `schemas` property returns tool definitions
- Event streaming: `executeStream()` for real-time bridge events

## Interactive demo

`example/web/web/agent.html` — four-panel layout with code editor, result+state, bridge events, and tool schemas. Examples: Stateful, Host Functions, KV Store, HTTP Fetch, Filesystem, Combined.

## Test plan

- [x] 17 AgentSession integration tests (state, tools, filesystem, errors, events)
- [x] 1367 unit tests pass
- [x] 209 FFI ladder pass
- [x] 8 FFI smoke pass
- [x] 187 WASM ladder pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)