### PR TITLE
fix: capture multi-line expressions as last-expression return values

### DIFF
--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -12,32 +12,11 @@ import 'package:dart_monty/src/bridge/bridge/plugin_registry.dart';
 import 'package:dart_monty/src/bridge/os_call/os_provider.dart';
 import 'package:dart_monty/src/monty.dart';
 import 'package:dart_monty/src/platform/bridge_logger.dart';
+import 'package:dart_monty/src/platform/code_capture.dart' as code_capture;
 import 'package:dart_monty/src/platform/monty_exception.dart';
 import 'package:dart_monty/src/platform/monty_resource_usage.dart';
 import 'package:dart_monty/src/platform/monty_result.dart';
 import 'package:dart_monty/src/platform/monty_value.dart';
-
-/// Matches simple assignment targets: `identifier = ...`
-final _assignmentPattern = RegExp(r'^([a-zA-Z]\w*)\s*=[^=]', multiLine: true);
-
-/// Python keywords that start statements (not expressions).
-const _statementPrefixes = [
-  'if ',
-  'for ',
-  'while ',
-  'with ',
-  'try:',
-  'def ',
-  'class ',
-  'import ',
-  'from ',
-  'raise ',
-  'return ',
-  'pass',
-  'break',
-  'continue',
-  'assert ',
-];
 
 const _restoreFn = '__restore_state__';
 const _persistFn = '__persist_state__';
@@ -199,7 +178,8 @@ class AgentSession {
   String _wrapWithState(String userCode) {
     final restore = _generateRestore();
     final persist = _generatePersist(userCode);
-    final (processed, hasResult) = _captureLastExpression(userCode);
+    final (processed, hasResult) =
+        code_capture.captureLastExpression(userCode);
 
     final buf = StringBuffer(restore)
       ..write('\n')
@@ -226,7 +206,7 @@ class AgentSession {
   String _generatePersist(String userCode) {
     final names = <String>{
       ..._sessionState.keys,
-      ..._extractAssignmentTargets(userCode),
+      ...code_capture.extractAssignmentTargets(userCode),
     };
 
     if (names.isEmpty) {
@@ -244,54 +224,6 @@ class AgentSession {
     buf.write('\n$_persistFn(__d2)');
 
     return buf.toString();
-  }
-
-  static (String, bool) _captureLastExpression(String userCode) {
-    final lines = userCode.split('\n');
-    var lastIdx = -1;
-    for (var i = lines.length - 1; i >= 0; i--) {
-      final trimmed = lines[i].trim();
-      if (trimmed.isNotEmpty && !trimmed.startsWith('#')) {
-        lastIdx = i;
-        break;
-      }
-    }
-    if (lastIdx < 0) return (userCode, false);
-    if (!_isExpression(lines[lastIdx])) return (userCode, false);
-
-    lines[lastIdx] = '__r = (${lines[lastIdx]})';
-
-    return (lines.join('\n'), true);
-  }
-
-  static bool _isExpression(String line) {
-    final trimmed = line.trim();
-    if (trimmed.isEmpty || trimmed.startsWith('#')) return false;
-    for (final prefix in _statementPrefixes) {
-      if (trimmed.startsWith(prefix) || trimmed == prefix.trim()) return false;
-    }
-    if (_assignmentPattern.hasMatch(trimmed)) return false;
-
-    return true;
-  }
-
-  static Set<String> _extractAssignmentTargets(String code) {
-    final names = <String>{};
-    for (final line in code.split('\n')) {
-      if (line.isNotEmpty && line[0] != ' ' && line[0] != '\t') {
-        for (final segment in line.split(';')) {
-          final match = _assignmentPattern.firstMatch(segment.trimLeft());
-          if (match != null) {
-            final name = match.group(1)!;
-            if (!name.startsWith('_')) {
-              names.add(name);
-            }
-          }
-        }
-      }
-    }
-
-    return names;
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/src/platform/code_capture.dart
+++ b/lib/src/platform/code_capture.dart
@@ -1,0 +1,171 @@
+/// Shared utilities for capturing the last expression in user code.
+///
+/// Used by both [MontySession] and [AgentSession] to wrap the trailing
+/// expression as `__r = (expr)` so it becomes the execution's return value.
+library;
+
+/// Matches simple assignment targets: `identifier = ...`
+///
+/// Only captures a single identifier before `=`.
+/// Excludes `==` (comparison) and augmented assignments (`+=`, etc.).
+final assignmentPattern = RegExp(r'^([a-zA-Z]\w*)\s*=[^=]', multiLine: true);
+
+/// Python keyword prefixes that indicate a line is a statement (not an
+/// expression). Used to detect the user code's last expression so it can
+/// be captured before the persist postamble runs.
+const statementPrefixes = [
+  'if ',
+  'for ',
+  'while ',
+  'with ',
+  'try:',
+  'def ',
+  'class ',
+  'import ',
+  'from ',
+  'raise ',
+  'return ',
+  'pass',
+  'break',
+  'continue',
+  'assert ',
+];
+
+/// Checks whether [line] looks like a Python expression (not a statement).
+///
+/// Returns `false` for lines starting with known statement keywords,
+/// assignments (`name = ...`), or empty/comment lines.
+bool isExpression(String line) {
+  final trimmed = line.trim();
+  if (trimmed.isEmpty || trimmed.startsWith('#')) return false;
+
+  for (final prefix in statementPrefixes) {
+    if (trimmed.startsWith(prefix) || trimmed == prefix.trim()) return false;
+  }
+
+  if (assignmentPattern.hasMatch(trimmed)) return false;
+
+  return true;
+}
+
+/// Processes [userCode] to capture the last expression's value.
+///
+/// If the trailing non-empty lines form an expression (single-line or
+/// multi-line via brackets), replaces the expression with
+/// `__r = (expression)` and returns `(modifiedCode, true)`.
+///
+/// Multi-line expressions are detected by scanning backwards from the
+/// last non-empty line, tracking `()`, `[]`, and `{}` depth. A dict
+/// literal, list literal, or function call spanning multiple lines is
+/// captured as a single expression.
+///
+/// If the last line is a statement (or there is no code), returns
+/// `(userCode, false)`.
+(String, bool) captureLastExpression(String userCode) {
+  final lines = userCode.split('\n');
+
+  // Find last non-empty, non-comment line index.
+  var lastIdx = -1;
+  for (var i = lines.length - 1; i >= 0; i--) {
+    final trimmed = lines[i].trim();
+    if (trimmed.isNotEmpty && !trimmed.startsWith('#')) {
+      lastIdx = i;
+      break;
+    }
+  }
+
+  if (lastIdx < 0) return (userCode, false);
+
+  // Find where the expression actually starts. For multi-line
+  // expressions (dict/list/tuple literals, multi-line calls), scan
+  // backwards tracking bracket depth to find the opening line.
+  final startIdx = _findExpressionStart(lines, lastIdx);
+
+  // Check whether the first line of the expression is a statement.
+  if (!isExpression(lines[startIdx])) return (userCode, false);
+
+  // Join the (possibly multi-line) expression and wrap it.
+  final exprLines = lines.sublist(startIdx, lastIdx + 1);
+  final expr = exprLines.join('\n');
+
+  final result = <String>[
+    ...lines.sublist(0, startIdx),
+    '__r = ($expr)',
+    ...lines.sublist(lastIdx + 1),
+  ];
+
+  return (result.join('\n'), true);
+}
+
+/// Extracts top-level assignment target names from [code].
+///
+/// Only considers lines with no leading whitespace (top-level).
+/// Handles semicolons for multi-statement lines.
+/// Excludes names starting with `_` (internal/dunder).
+Set<String> extractAssignmentTargets(String code) {
+  final names = <String>{};
+  for (final line in code.split('\n')) {
+    if (line.isNotEmpty && line[0] != ' ' && line[0] != '\t') {
+      for (final segment in line.split(';')) {
+        final match = assignmentPattern.firstMatch(segment.trimLeft());
+        if (match != null) {
+          final name = match.group(1)!;
+          if (!name.startsWith('_')) {
+            names.add(name);
+          }
+        }
+      }
+    }
+  }
+  return names;
+}
+
+/// Scans backwards from [lastIdx] tracking bracket depth to find where
+/// a multi-line expression begins (e.g. `{\n  "a": 1,\n}`).
+///
+/// Returns [lastIdx] when the last line is a complete single-line
+/// expression. Returns an earlier index when unclosed brackets indicate
+/// the expression spans multiple lines.
+int _findExpressionStart(List<String> lines, int lastIdx) {
+  var depth = 0;
+
+  for (var i = lastIdx; i >= 0; i--) {
+    final line = lines[i];
+
+    // Scan characters, skipping content inside string literals.
+    var inSingle = false;
+    var inDouble = false;
+    var escaped = false;
+
+    for (var c = 0; c < line.length; c++) {
+      final ch = line[c];
+
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch == r'\') {
+        escaped = true;
+        continue;
+      }
+
+      if (!inDouble && ch == "'") {
+        inSingle = !inSingle;
+      } else if (!inSingle && ch == '"') {
+        inDouble = !inDouble;
+      } else if (!inSingle && !inDouble) {
+        if (ch == ')' || ch == ']' || ch == '}') {
+          depth++;
+        } else if (ch == '(' || ch == '[' || ch == '{') {
+          depth--;
+        }
+      }
+    }
+
+    // depth <= 0 means this line has at least as many openers as closers
+    // seen so far — the expression starts here.
+    if (depth <= 0) return i;
+  }
+
+  return 0;
+}

--- a/lib/src/platform/monty_session.dart
+++ b/lib/src/platform/monty_session.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:dart_monty/src/bridge/os_call/os_provider.dart';
+import 'package:dart_monty/src/platform/code_capture.dart' as code_capture;
 import 'package:dart_monty/src/platform/monty_error.dart';
 import 'package:dart_monty/src/platform/monty_exception.dart';
 import 'package:dart_monty/src/platform/monty_limits.dart';
@@ -17,11 +18,6 @@ const _restoreStateFn = '__restore_state__';
 /// The internal function name used to persist state from Python globals.
 const _persistStateFn = '__persist_state__';
 
-/// Matches simple assignment targets: `identifier = ...`
-///
-/// Only captures a single identifier before `=`.
-/// Excludes `==` (comparison) and augmented assignments (`+=`, etc.).
-final _assignmentPattern = RegExp(r'^([a-zA-Z]\w*)\s*=[^=]', multiLine: true);
 
 /// Zero-cost usage for error results synthesized from caught exceptions.
 const _zeroUsage = MontyResourceUsage(
@@ -30,26 +26,6 @@ const _zeroUsage = MontyResourceUsage(
   stackDepthUsed: 0,
 );
 
-/// Python keyword prefixes that indicate a line is a statement (not an
-/// expression). Used to detect the user code's last expression so it can
-/// be captured before the persist postamble runs.
-const _statementPrefixes = [
-  'if ',
-  'for ',
-  'while ',
-  'with ',
-  'try:',
-  'def ',
-  'class ',
-  'import ',
-  'from ',
-  'raise ',
-  'return ',
-  'pass',
-  'break',
-  'continue',
-  'assert ',
-];
 
 /// A stateful execution session that persists variables across calls.
 ///
@@ -229,7 +205,7 @@ class MontySession {
   /// patterns. Excludes names starting with `_` (dunder/private).
   @visibleForTesting
   static Set<String> extractAssignmentTargets(String code) =>
-      _extractAssignmentTargets(code);
+      code_capture.extractAssignmentTargets(code);
 
   // ---------------------------------------------------------------------------
   // Code generation
@@ -244,7 +220,8 @@ class MontySession {
   String _wrapCode(String userCode) {
     final restore = _generateRestore();
     final persist = _generatePersist(userCode);
-    final (processedCode, hasResult) = _captureLastExpression(userCode);
+    final (processedCode, hasResult) =
+        code_capture.captureLastExpression(userCode);
 
     final buf = StringBuffer(restore)
       ..write('\n')
@@ -281,7 +258,7 @@ class MontySession {
   String _generatePersist(String userCode) {
     final names = <String>{
       ..._state.keys,
-      ..._extractAssignmentTargets(userCode),
+      ...code_capture.extractAssignmentTargets(userCode),
     };
 
     if (names.isEmpty) {
@@ -299,80 +276,6 @@ class MontySession {
     buf.write('\n__persist_state__(__d2)');
 
     return buf.toString();
-  }
-
-  /// Checks whether [line] looks like a Python expression (not a statement).
-  ///
-  /// Returns `false` for lines starting with known statement keywords,
-  /// assignments (`name = ...`), or empty/comment lines.
-  static bool _isExpression(String line) {
-    final trimmed = line.trim();
-    if (trimmed.isEmpty || trimmed.startsWith('#')) return false;
-
-    for (final prefix in _statementPrefixes) {
-      if (trimmed.startsWith(prefix) || trimmed == prefix.trim()) return false;
-    }
-
-    // Simple assignment: `identifier = ...` (not `==`)
-    if (_assignmentPattern.hasMatch(trimmed)) return false;
-
-    return true;
-  }
-
-  /// Processes [userCode] to capture the last expression's value.
-  ///
-  /// If the last non-empty line is an expression, replaces it with
-  /// `__r = (expression)` and returns `(modifiedCode, true)`.
-  /// After the persist postamble, `__r` is re-emitted so
-  /// `MontyResult.value` reflects the user's expression.
-  ///
-  /// If the last line is a statement (or there is no code), returns
-  /// `(userCode, false)`.
-  static (String, bool) _captureLastExpression(String userCode) {
-    final lines = userCode.split('\n');
-
-    // Find last non-empty, non-comment line index.
-    var lastIdx = -1;
-    for (var i = lines.length - 1; i >= 0; i--) {
-      final trimmed = lines[i].trim();
-      if (trimmed.isNotEmpty && !trimmed.startsWith('#')) {
-        lastIdx = i;
-        break;
-      }
-    }
-
-    if (lastIdx < 0) return (userCode, false);
-
-    if (!_isExpression(lines[lastIdx])) return (userCode, false);
-
-    // Replace last expression with `__r = (expression)`
-    final expr = lines[lastIdx];
-    lines[lastIdx] = '__r = ($expr)';
-
-    return (lines.join('\n'), true);
-  }
-
-  static Set<String> _extractAssignmentTargets(String code) {
-    final names = <String>{};
-    for (final line in code.split('\n')) {
-      // Only process top-level lines (no leading whitespace).
-      if (line.isNotEmpty && line[0] != ' ' && line[0] != '\t') {
-        // Split by semicolons to handle multi-statement lines
-        // like `x = 1; y = 2; z = 3`.
-        for (final segment in line.split(';')) {
-          final trimmed = segment.trimLeft();
-          final match = _assignmentPattern.firstMatch(trimmed);
-          if (match != null) {
-            final name = match.group(1)!;
-            if (!name.startsWith('_')) {
-              names.add(name);
-            }
-          }
-        }
-      }
-    }
-
-    return names;
   }
 
   // ---------------------------------------------------------------------------

--- a/test/platform/monty_session_test.dart
+++ b/test/platform/monty_session_test.dart
@@ -654,6 +654,70 @@ void main() {
         final code = mock.lastStartCode!;
         expect(code, contains('__r = (42)'));
       });
+
+      test('captures multi-line dict literal as expression', () async {
+        _enqueueRunCycle(
+          mock,
+          stateToPersist: {'x': 1},
+          resultValue: const MontyDict({'a': MontyInt(1)}),
+        );
+        await session.run('x = 1\n{\n    "a": x,\n}');
+
+        final code = mock.lastStartCode!;
+        // The entire dict should be captured, not just the closing `}`.
+        expect(code, contains('__r = ({\n    "a": x,\n})'));
+        expect(code.trimRight().endsWith('__r'), isTrue);
+      });
+
+      test('captures multi-line list literal as expression', () async {
+        _enqueueRunCycle(
+          mock,
+          stateToPersist: {},
+          resultValue: const MontyList([MontyInt(1), MontyInt(2)]),
+        );
+        await session.run('[\n    1,\n    2,\n]');
+
+        final code = mock.lastStartCode!;
+        expect(code, contains('__r = ([\n    1,\n    2,\n])'));
+      });
+
+      test('captures multi-line function call as expression', () async {
+        _enqueueRunCycle(
+          mock,
+          stateToPersist: {},
+          resultValue: const MontyString('result'),
+        );
+        await session.run('foo(\n    1,\n    2,\n)');
+
+        final code = mock.lastStartCode!;
+        expect(code, contains('__r = (foo(\n    1,\n    2,\n))'));
+      });
+
+      test('multi-line dict assigned to var is not double-captured',
+          () async {
+        _enqueueRunCycle(
+          mock,
+          stateToPersist: {'result': <String, Object>{'a': 1}},
+          resultValue: const MontyDict({'a': MontyInt(1)}),
+        );
+        await session.run('result = {\n    "a": 1,\n}\nresult');
+
+        final code = mock.lastStartCode!;
+        // `result` on the last line should be captured, not the dict.
+        expect(code, contains('__r = (result)'));
+      });
+
+      test('multi-line dict with complex values is captured', () async {
+        _enqueueRunCycle(
+          mock,
+          stateToPersist: {'x': 1},
+          resultValue: const MontyDict({'ok': MontyBool(true)}),
+        );
+        await session.run('x = 1\n{\n    "ok": x == 1,\n}');
+
+        final code = mock.lastStartCode!;
+        expect(code, contains('__r = ({\n    "ok": x == 1,\n})'));
+      });
     });
 
     group('C-1: catches MontyError (panic/disposed)', () {


### PR DESCRIPTION
## Summary

- `_captureLastExpression` only wrapped the **last line** as the return value. For multi-line dict/list/tuple literals, it captured just `}` → `__r = (})`, leaving `{` orphaned. Ruff rejected the broken code with `"Expected ':', found '='"`.
- Added `_findExpressionStart` in shared `code_capture.dart` that scans backwards tracking bracket depth to find where multi-line expressions begin.
- Both `MontySession` and `AgentSession` now delegate to `code_capture.dart` — no duplicate code.

## Test plan

- [x] 5 new unit tests in `monty_session_test.dart` (multi-line dict, list, function call, assigned-to-var, complex values)
- [x] 68/68 `monty_session_test.dart` pass
- [x] 439 bridge tests pass
- [x] 26/26 end-to-end multi-line dict parsing tests pass in fe_plugin_soliplex integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)