### PR TITLE
fix: separate handler errors from resume errors in bridge dispatch (#274)

### DIFF
--- a/lib/src/bridge/bridge/default_monty_bridge.dart
+++ b/lib/src/bridge/bridge/default_monty_bridge.dart
@@ -391,19 +391,12 @@ class DefaultMontyBridge implements MontyBridge {
       return _platform.resumeWithError(errorMsg);
     }
 
+    // Handler errors are safe to resumeWithError (platform still active).
+    // resume() errors must propagate — see _dispatchToolCall comment.
     final sw = Stopwatch()..start();
+    final Object? result;
     try {
-      final result = await handler.resolve(osCall);
-      sw.stop();
-      controller.add(
-        BridgeOsCallResult(
-          callId: callId,
-          result: result?.toString() ?? '',
-          durationMs: sw.elapsedMilliseconds,
-        ),
-      );
-
-      return await _platform.resume(result);
+      result = await handler.resolve(osCall);
     } on Object catch (e, st) {
       sw.stop();
       log.error(
@@ -422,6 +415,17 @@ class DefaultMontyBridge implements MontyBridge {
 
       return _platform.resumeWithError(e.toString());
     }
+
+    sw.stop();
+    controller.add(
+      BridgeOsCallResult(
+        callId: callId,
+        result: result?.toString() ?? '',
+        durationMs: sw.elapsedMilliseconds,
+      ),
+    );
+
+    return _platform.resume(result);
   }
 
   /// Resolves the [CallRole] for a tool call and strips the reserved
@@ -521,19 +525,14 @@ class DefaultMontyBridge implements MontyBridge {
       ..add(BridgeToolCallArgs(callId: callId, delta: jsonEncode(args)))
       ..add(BridgeToolCallEnd(callId: callId));
 
-    // Execute handler through middleware chain.
+    // Execute handler — errors here are safe to resumeWithError because
+    // the platform is still in active state (waiting for our response).
+    // resume() errors must NOT be caught here — if resume() fails it has
+    // already called markIdle(), so resumeWithError() would hit a
+    // StateError. Let resume() errors propagate to _run()'s outer catch.
+    final Object? result;
     try {
-      final result = await _invokeWithMiddleware(fn, stepName, args, role);
-      controller
-        ..add(
-          BridgeToolCallResult(
-            callId: callId,
-            result: result?.toString() ?? '',
-          ),
-        )
-        ..add(BridgeStepFinished(stepId: stepName));
-
-      return await _platform.resume(result);
+      result = await _invokeWithMiddleware(fn, stepName, args, role);
     } on Object catch (e, st) {
       log.error(
         'Host handler error',
@@ -547,6 +546,17 @@ class DefaultMontyBridge implements MontyBridge {
 
       return _platform.resumeWithError(e.toString());
     }
+
+    controller
+      ..add(
+        BridgeToolCallResult(
+          callId: callId,
+          result: result?.toString() ?? '',
+        ),
+      )
+      ..add(BridgeStepFinished(stepId: stepName));
+
+    return _platform.resume(result);
   }
 
   Future<MontyProgress> _dispatchToolCallAsFuture(

--- a/lib/src/ffi/monty_ffi.dart
+++ b/lib/src/ffi/monty_ffi.dart
@@ -58,9 +58,14 @@ class MontyFfi extends BaseMontyPlatform
   Future<MontyProgress> resumeAsFuture() async {
     assertNotDisposed('resumeAsFuture');
     assertActive('resumeAsFuture');
-    final progress = await coreBindings.resumeAsFuture();
+    try {
+      final progress = await coreBindings.resumeAsFuture();
 
-    return translateProgress(progress);
+      return translateProgress(progress);
+    } catch (e) {
+      markIdle();
+      rethrow;
+    }
   }
 
   @override
@@ -70,15 +75,23 @@ class MontyFfi extends BaseMontyPlatform
   }) async {
     assertNotDisposed('resolveFutures');
     assertActive('resolveFutures');
-    final resultsJson = json.encode(
-      results.map((k, v) => MapEntry(k.toString(), v)),
-    );
-    final errorsJson = errors != null
-        ? json.encode(errors.map((k, v) => MapEntry(k.toString(), v)))
-        : '{}';
-    final progress = await coreBindings.resolveFutures(resultsJson, errorsJson);
+    try {
+      final resultsJson = json.encode(
+        results.map((k, v) => MapEntry(k.toString(), v)),
+      );
+      final errorsJson = errors != null
+          ? json.encode(errors.map((k, v) => MapEntry(k.toString(), v)))
+          : '{}';
+      final progress = await coreBindings.resolveFutures(
+        resultsJson,
+        errorsJson,
+      );
 
-    return translateProgress(progress);
+      return translateProgress(progress);
+    } catch (e) {
+      markIdle();
+      rethrow;
+    }
   }
 
   @override

--- a/test/bridge/src/bridge/default_monty_bridge_test.dart
+++ b/test/bridge/src/bridge/default_monty_bridge_test.dart
@@ -1151,6 +1151,134 @@ void main() {
       expect(events.whereType<BridgeRunFinished>(), hasLength(1));
     });
   });
+
+  // Regression: resume() failure must not cause StateError (#274).
+  //
+  // Before the fix, _dispatchToolCall wrapped both the handler invocation
+  // AND platform.resume() in the same try/catch. If resume() threw
+  // (marking the platform idle), the catch called resumeWithError() on
+  // the idle platform → StateError.
+  group('resume() failure recovery (#274)', () {
+    test(
+      'handler succeeds but resume() throws — emits BridgeRunError',
+      () async {
+        // Platform throws when resume() is called with 'hello'.
+        final failMock = _ResumeFailsPlatform()..failOnValue = 'hello';
+        final failBridge = MontyBridge(platform: failMock, useFutures: false)
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'greet',
+                description: 'Returns hello',
+              ),
+              handler: (_) async => 'hello',
+            ),
+          );
+
+        // start → Pending(greet) → handler returns 'hello' →
+        // resume('hello') throws because failOnValue matches.
+        failMock
+          ..enqueueProgress(
+            const MontyPending(
+              functionName: 'greet',
+              arguments: [],
+              callId: 1,
+            ),
+          )
+          // Enqueued for resume but never consumed — throw happens first.
+          ..enqueueProgress(
+            const MontyComplete(result: MontyResult(usage: _usage)),
+          );
+
+        final events = await failBridge.execute('greet()').toList();
+
+        // Should get a BridgeRunError, NOT an uncaught StateError.
+        final errors = events.whereType<BridgeRunError>().toList();
+        expect(
+          errors,
+          hasLength(1),
+          reason:
+              'Expected BridgeRunError, got: '
+              '${events.map((e) => e.runtimeType).toList()}',
+        );
+        expect(errors.first.message, contains('resume failed'));
+
+        failBridge.dispose();
+      },
+    );
+
+    test(
+      'multiple tool calls — resume failure on 3rd does not StateError',
+      () async {
+        // Fail when resuming with value '3' (the 3rd call).
+        final failMock = _ResumeFailsPlatform()..failOnValue = '3';
+        final failBridge = MontyBridge(platform: failMock, useFutures: false)
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'count',
+                description: 'Returns incrementing number',
+                params: [
+                  HostParam(name: 'n', type: HostParamType.integer),
+                ],
+              ),
+              handler: (args) async => args['n'],
+            ),
+          );
+
+        // start → Pending(count,n=1) → resume(1) OK →
+        // Pending(count,n=2) → resume(2) OK →
+        // Pending(count,n=3) → resume(3) THROWS
+        failMock
+          ..enqueueProgress(
+            const MontyPending(
+              functionName: 'count',
+              arguments: [MontyInt(1)],
+              kwargs: {'n': MontyInt(1)},
+              callId: 1,
+            ),
+          )
+          ..enqueueProgress(
+            const MontyPending(
+              functionName: 'count',
+              arguments: [MontyInt(2)],
+              kwargs: {'n': MontyInt(2)},
+              callId: 2,
+            ),
+          )
+          ..enqueueProgress(
+            const MontyPending(
+              functionName: 'count',
+              arguments: [MontyInt(3)],
+              kwargs: {'n': MontyInt(3)},
+              callId: 3,
+            ),
+          )
+          ..enqueueProgress(
+            const MontyComplete(result: MontyResult(usage: _usage)),
+          );
+
+        final events = await failBridge.execute('code').toList();
+
+        // First two succeed, 3rd triggers error.
+        final errors = events.whereType<BridgeRunError>().toList();
+        expect(
+          errors,
+          hasLength(1),
+          reason:
+              'Expected BridgeRunError, got: '
+              '${events.map((e) => e.runtimeType).toList()}',
+        );
+        expect(errors.first.message, contains('resume failed'));
+
+        // First two tool calls should have result events.
+        final results = events.whereType<BridgeToolCallResult>().toList();
+        expect(results.length, greaterThanOrEqualTo(2));
+
+        failBridge.dispose();
+      },
+    );
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1320,6 +1448,21 @@ class _PrintThenThrowPlatform extends MockMontyPlatform {
     if (_resumeCount > throwAfterResumes) {
       throw const MontyPanicError('panic after print');
     }
+
+    return super.resume(returnValue);
+  }
+}
+
+/// A mock platform that throws on resume() when the return value matches.
+class _ResumeFailsPlatform extends MockMontyPlatform {
+  String? failOnValue;
+
+  @override
+  Future<MontyProgress> resume(Object? returnValue) async {
+    if (failOnValue != null && returnValue?.toString() == failOnValue) {
+      throw const MontyPanicError('resume failed on value');
+    }
+
     return super.resume(returnValue);
   }
 }


### PR DESCRIPTION
## Summary

`_dispatchToolCall` and `_handleOsCall` wrapped both the handler invocation AND `platform.resume()` in the same try/catch. If `resume()` threw (marking the platform idle via `markIdle()` + rethrow), the catch block called `resumeWithError()` on the idle platform → **StateError: "Cannot call resumeWithError() when not in active state"**.

## Fix

1. **Separate handler try/catch from resume()** — execute the handler in its own try/catch (errors here are safe to `resumeWithError` because the platform is still active). Call `resume()` OUTSIDE the catch — if it throws, the error propagates to `_run()`'s outer catch blocks which emit `BridgeRunError` gracefully.

2. **Add catch-and-markIdle to `MontyFfi.resumeAsFuture()` and `resolveFutures()`** — matches the pattern in `BaseMontyPlatform.resume()` / `resumeWithError()`.

```
_dispatchToolCall (before — broken):
  try {
    result = await handler(...)     ← handler error caught
    return platform.resume(result)  ← resume() error ALSO caught
  } catch (e) {
    return platform.resumeWithError(e)  ← StateError if resume() failed!
  }

_dispatchToolCall (after — fixed):
  try {
    result = await handler(...)     ← handler error: resumeWithError OK
  } catch (e) {
    return platform.resumeWithError(e)  ← safe: platform still active
  }
  return platform.resume(result)    ← errors propagate to _run() catch
```

## Files changed

- `lib/src/bridge/bridge/default_monty_bridge.dart` — `_dispatchToolCall` + `_handleOsCall`
- `lib/src/ffi/monty_ffi.dart` — `resumeAsFuture` + `resolveFutures` catch-and-markIdle
- `test/bridge/src/bridge/default_monty_bridge_test.dart` — 2 regression tests

## Test plan

- [x] "handler succeeds but resume() throws — emits BridgeRunError" (uses `_ResumeFailsPlatform` mock)
- [x] "multiple tool calls — resume failure on 3rd does not StateError" (2 succeed, 3rd fails gracefully)
- [x] All 49 bridge tests pass
- [x] `dart analyze --fatal-infos` clean
- [x] `dart format` clean

## Note

The futures path (`_dispatchToolCallAsFuture`) has a similar pattern but different mechanics (`resumeAsFuture()` instead of `resume(result)`). That will be addressed separately — tracked in investigation notes.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)