### PR TITLE
feat: add MontyStateMixin to MockMontyPlatform for state machine enforcement

### DIFF
--- a/lib/src/platform/mock_monty_platform.dart
+++ b/lib/src/platform/mock_monty_platform.dart
@@ -7,6 +7,7 @@ import 'package:dart_monty/src/platform/monty_platform.dart';
 import 'package:dart_monty/src/platform/monty_progress.dart';
 import 'package:dart_monty/src/platform/monty_result.dart';
 import 'package:dart_monty/src/platform/monty_snapshot_capable.dart';
+import 'package:dart_monty/src/platform/monty_state_mixin.dart';
 
 /// A mock implementation of [MontyPlatform] for testing.
 ///
@@ -25,9 +26,13 @@ import 'package:dart_monty/src/platform/monty_snapshot_capable.dart';
 /// mock.enqueueProgress(MontyComplete(result: result));
 /// ```
 class MockMontyPlatform extends MontyPlatform
+    with MontyStateMixin
     implements MontySnapshotCapable, MontyFutureCapable {
   /// Creates a [MockMontyPlatform].
   MockMontyPlatform();
+
+  @override
+  String get backendName => 'MockMontyPlatform';
 
   // ---------------------------------------------------------------------------
   // Config (what to return)
@@ -47,9 +52,6 @@ class MockMontyPlatform extends MontyPlatform
   ///
   /// Must be set before calling [restore] or a [StateError] is thrown.
   MontyPlatform? restoreResult;
-
-  /// Whether [dispose] has been called.
-  bool isDisposed = false;
 
   // ---------------------------------------------------------------------------
   // Invocation history (what was called)
@@ -181,33 +183,46 @@ class MockMontyPlatform extends MontyPlatform
     MontyLimits? limits,
     String? scriptName,
   }) async {
+    assertNotDisposed('start');
+    assertIdle('start');
+    markActive();
+
     startCodes.add(code);
     startExternalFunctionsList.add(externalFunctions);
     startLimitsList.add(limits);
     startScriptNamesList.add(scriptName);
 
-    return _dequeueProgress();
+    return _dequeueAndTransition();
   }
 
   @override
   Future<MontyProgress> resume(Object? returnValue) async {
+    assertNotDisposed('resume');
+    assertActive('resume');
+
     resumeReturnValues.add(returnValue);
 
-    return _dequeueProgress();
+    return _dequeueAndTransition();
   }
 
   @override
   Future<MontyProgress> resumeWithError(String errorMessage) async {
+    assertNotDisposed('resumeWithError');
+    assertActive('resumeWithError');
+
     resumeErrorMessages.add(errorMessage);
 
-    return _dequeueProgress();
+    return _dequeueAndTransition();
   }
 
   @override
   Future<MontyProgress> resumeAsFuture() async {
+    assertNotDisposed('resumeAsFuture');
+    assertActive('resumeAsFuture');
+
     resumeAsFutureCount++;
 
-    return _dequeueProgress();
+    return _dequeueAndTransition();
   }
 
   @override
@@ -215,10 +230,13 @@ class MockMontyPlatform extends MontyPlatform
     Map<int, Object?> results, {
     Map<int, String>? errors,
   }) async {
+    assertNotDisposed('resolveFutures');
+    assertActive('resolveFutures');
+
     resolveFuturesResultsList.add(results);
     resolveFuturesErrorsList.add(errors);
 
-    return _dequeueProgress();
+    return _dequeueAndTransition();
   }
 
   @override
@@ -250,7 +268,18 @@ class MockMontyPlatform extends MontyPlatform
   @override
   Future<void> dispose() async {
     await restoreResult?.dispose();
-    isDisposed = true;
+    markDisposed();
+  }
+
+  /// Dequeues progress and transitions state: `MontyComplete` → idle,
+  /// everything else stays active.
+  MontyProgress _dequeueAndTransition() {
+    final progress = _dequeueProgress();
+    if (progress is MontyComplete) {
+      markIdle();
+    }
+
+    return progress;
   }
 
   MontyProgress _dequeueProgress() {

--- a/test/platform/mock_monty_platform_test.dart
+++ b/test/platform/mock_monty_platform_test.dart
@@ -117,7 +117,13 @@ void main() {
 
     test('resume() dequeues progress and records return value', () async {
       const complete = MontyComplete(result: MontyResult(usage: usage));
-      mock.enqueueProgress(complete);
+      // start() transitions idle→active; resume() requires active.
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'f', arguments: []),
+        )
+        ..enqueueProgress(complete);
+      await mock.start('code');
 
       final progress = await mock.resume('hello');
 
@@ -128,7 +134,12 @@ void main() {
 
     test('resumeWithError() dequeues progress and records error', () async {
       const complete = MontyComplete(result: MontyResult(usage: usage));
-      mock.enqueueProgress(complete);
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'f', arguments: []),
+        )
+        ..enqueueProgress(complete);
+      await mock.start('code');
 
       final progress = await mock.resumeWithError('boom');
 
@@ -143,7 +154,12 @@ void main() {
 
     test('resumeAsFuture() increments count and dequeues', () async {
       const pending = MontyPending(functionName: 'slow_op', arguments: []);
-      mock.enqueueProgress(pending);
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'f', arguments: []),
+        )
+        ..enqueueProgress(pending);
+      await mock.start('code');
 
       expect(mock.resumeAsFutureCount, 0);
 
@@ -155,8 +171,16 @@ void main() {
 
     test('resumeAsFuture() increments on each call', () async {
       mock
-        ..enqueueProgress(const MontyPending(functionName: 'a', arguments: []))
-        ..enqueueProgress(const MontyPending(functionName: 'b', arguments: []));
+        ..enqueueProgress(
+          const MontyPending(functionName: 'f', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyPending(functionName: 'a', arguments: []),
+        )
+        ..enqueueProgress(
+          const MontyPending(functionName: 'b', arguments: []),
+        );
+      await mock.start('code');
 
       await mock.resumeAsFuture();
       await mock.resumeAsFuture();
@@ -170,7 +194,12 @@ void main() {
 
     test('resolveFutures() records results and errors, dequeues', () async {
       const complete = MontyComplete(result: MontyResult(usage: usage));
-      mock.enqueueProgress(complete);
+      mock
+        ..enqueueProgress(
+          const MontyPending(functionName: 'f', arguments: []),
+        )
+        ..enqueueProgress(complete);
+      await mock.start('code');
 
       final results = {1: 'value1' as Object?, 2: 42 as Object?};
       final errors = {3: 'timeout'};


### PR DESCRIPTION
## Summary

`MockMontyPlatform` had no state machine — tests could call `resume()` on a conceptually idle platform and it would succeed, masking bugs like #274 where the real platform's state machine was being violated.

## Changes

**`lib/src/platform/mock_monty_platform.dart`:**
- Mix in `MontyStateMixin` (same as `BaseMontyPlatform` uses)
- `start()` enforces `assertIdle()` → `markActive()`
- `resume`/`resumeWithError`/`resumeAsFuture`/`resolveFutures` enforce `assertActive()`
- `MontyComplete` transitions back to idle via `_dequeueAndTransition()`
- `dispose()` uses `markDisposed()` instead of manual `isDisposed = true`
- Removed manual `isDisposed` field (now from mixin)

**`test/platform/mock_monty_platform_test.dart`:**
- Updated 5 tests to call `start()` before resume operations (required by new state enforcement)

## Test plan

- [x] 1379 tests pass (0 failures)
- [x] `dart analyze --fatal-infos` clean
- [x] `dart format` clean

## Context

Identified during #274 investigation — see `~/dev/plans/futures-path-resume-footgun.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)