### PR TITLE
refactor: live introspection via category-tracked bridge registration

### DIFF
--- a/lib/src/bridge/bridge/default_monty_bridge.dart
+++ b/lib/src/bridge/bridge/default_monty_bridge.dart
@@ -86,6 +86,7 @@ class DefaultMontyBridge implements MontyBridge {
   final MontyLimits? _limits;
   final bool _useFutures;
   final Map<String, HostFunction> _functions = {};
+  final Map<String, Set<String>> _categoryIndex = {};
   final List<BridgeMiddleware> _middleware = [];
   final Map<int, _PendingFuture> _pendingFutures = {};
   int _idCounter = 0;
@@ -103,15 +104,32 @@ class DefaultMontyBridge implements MontyBridge {
       _functions.values.map((f) => f.schema).toList(growable: false);
 
   @override
+  Map<String, List<HostFunctionSchema>> get schemasByCategory {
+    final result = <String, List<HostFunctionSchema>>{};
+    for (final entry in _categoryIndex.entries) {
+      final schemas = <HostFunctionSchema>[];
+      for (final name in entry.value) {
+        final fn = _functions[name];
+        if (fn != null) schemas.add(fn.schema);
+      }
+      if (schemas.isNotEmpty) result[entry.key] = schemas;
+    }
+    return result;
+  }
+
+  @override
   void use(BridgeMiddleware middleware) {
     if (_isDisposed) throw StateError('Bridge has been disposed');
     _middleware.add(middleware);
   }
 
   @override
-  void register(HostFunction function) {
+  void register(HostFunction function, {String? category}) {
     if (_isDisposed) throw StateError('Bridge has been disposed');
-    _functions[function.schema.name] = function;
+    final name = function.schema.name;
+    _functions[name] = function;
+    final cat = category ?? 'uncategorized';
+    (_categoryIndex[cat] ??= {}).add(name);
   }
 
   @override
@@ -549,10 +567,7 @@ class DefaultMontyBridge implements MontyBridge {
 
     controller
       ..add(
-        BridgeToolCallResult(
-          callId: callId,
-          result: result?.toString() ?? '',
-        ),
+        BridgeToolCallResult(callId: callId, result: result?.toString() ?? ''),
       )
       ..add(BridgeStepFinished(stepId: stepName));
 

--- a/lib/src/bridge/bridge/event_loop_bridge.dart
+++ b/lib/src/bridge/bridge/event_loop_bridge.dart
@@ -159,6 +159,7 @@ class EventLoopBridge extends DefaultMontyBridge {
         ),
         handler: _handleWaitForEvent,
       ),
+      category: 'event_loop',
     );
 
     register(
@@ -176,6 +177,7 @@ class EventLoopBridge extends DefaultMontyBridge {
         ),
         handler: _handleRenderUi,
       ),
+      category: 'event_loop',
     );
   }
 

--- a/lib/src/bridge/bridge/introspection_functions.dart
+++ b/lib/src/bridge/bridge/introspection_functions.dart
@@ -5,6 +5,7 @@ import 'package:dart_monty/src/bridge/bridge/host_function.dart';
 import 'package:dart_monty/src/bridge/bridge/host_function_schema.dart';
 import 'package:dart_monty/src/bridge/bridge/host_param.dart';
 import 'package:dart_monty/src/bridge/bridge/host_param_type.dart';
+import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
 
 /// Category name for introspection builtins.
 const introspectionCategory = 'introspection';
@@ -42,19 +43,18 @@ const helpSchema = HostFunctionSchema(
 
 /// Builds the introspection host function (`help`).
 ///
-/// Takes [schemasByCategory] from the registry so introspection can enumerate
-/// all registered functions without a circular dependency on the registry.
-List<HostFunction> buildIntrospectionFunctions(
-  Map<String, List<HostFunctionSchema>> schemasByCategory,
-) {
+/// Takes the [bridge] so introspection queries live state rather than a
+/// point-in-time snapshot. Functions registered after `attachTo` are visible.
+List<HostFunction> buildIntrospectionFunctions(MontyBridge bridge) {
   return [
     HostFunction(
       schema: helpSchema,
       handler: (args) async {
         final name = args['name'] as String?;
-        if (name == null) return _handleListAll(schemasByCategory);
+        final schemas = bridge.schemasByCategory;
+        if (name == null) return _handleListAll(schemas);
 
-        return _handleHelp(schemasByCategory, name);
+        return _handleHelp(schemas, name);
       },
       role: const InfraCall(),
     ),
@@ -82,25 +82,22 @@ Map<String, Object?> _serializeSchema(HostFunctionSchema schema) {
 
 /// Handler for `help()` with no arguments.
 ///
-/// Returns JSON with all categories including introspection's own entry.
-String _handleListAll(
-  Map<String, List<HostFunctionSchema>> schemasByCategory,
-) {
+/// Returns JSON with all categories. The introspection category is already
+/// present in [schemasByCategory] because `help` is registered with that
+/// category on the bridge.
+String _handleListAll(Map<String, List<HostFunctionSchema>> schemasByCategory) {
   final tools = <String, Object?>{};
 
   for (final entry in schemasByCategory.entries) {
     tools[entry.key] = [for (final s in entry.value) _serializeSchema(s)];
   }
 
-  // Include introspection's own schema.
-  tools[introspectionCategory] = [_serializeSchema(helpSchema)];
-
   return jsonEncode({'tools': tools});
 }
 
 /// Handler for `help(name)`.
 ///
-/// Looks up [name] across all categories and the introspection schema.
+/// Looks up [name] across all categories.
 /// Supports both fully-qualified names (`storage_get`) and bare names (`get`).
 /// When a bare name matches exactly one function, returns its detail.
 /// When multiple functions share the same bare name, returns a disambiguation
@@ -109,16 +106,13 @@ String _handleHelp(
   Map<String, List<HostFunctionSchema>> schemasByCategory,
   String name,
 ) {
-  // 1. Exact match on fully-qualified name (backwards compatible).
+  // 1. Exact match on fully-qualified name.
   for (final schemas in schemasByCategory.values) {
     for (final schema in schemas) {
       if (schema.name == name) {
         return jsonEncode(_serializeSchema(schema));
       }
     }
-  }
-  if (helpSchema.name == name) {
-    return jsonEncode(_serializeSchema(helpSchema));
   }
 
   // 2. Bare-name fuzzy match: strip namespace prefix and compare suffix.

--- a/lib/src/bridge/bridge/monty_bridge.dart
+++ b/lib/src/bridge/bridge/monty_bridge.dart
@@ -37,8 +37,14 @@ abstract class MontyBridge {
   /// All registered function schemas.
   List<HostFunctionSchema> get schemas;
 
+  /// All registered function schemas, grouped by category.
+  Map<String, List<HostFunctionSchema>> get schemasByCategory;
+
   /// Registers a host function.
-  void register(HostFunction function);
+  ///
+  /// When [category] is provided, the function is indexed under that category
+  /// for introspection. Functions with no category go into `'uncategorized'`.
+  void register(HostFunction function, {String? category});
 
   /// Unregisters a host function by name.
   void unregister(String name);

--- a/lib/src/bridge/bridge/plugin_registry.dart
+++ b/lib/src/bridge/bridge/plugin_registry.dart
@@ -1,7 +1,6 @@
 import 'dart:collection';
 
 import 'package:dart_monty/src/bridge/bridge/host_function.dart';
-import 'package:dart_monty/src/bridge/bridge/host_function_schema.dart';
 import 'package:dart_monty/src/bridge/bridge/introspection_functions.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_plugin.dart';
@@ -84,7 +83,6 @@ class PluginRegistry {
     // Get registry's own logger from the bridge.
     _log = bridge.logger.child('registry');
 
-    final schemasByCategory = <String, List<HostFunctionSchema>>{};
     final errors = <(String, Object)>[];
 
     for (final plugin in _plugins) {
@@ -92,22 +90,16 @@ class PluginRegistry {
       // during onRegister().
       plugin.logger = bridge.logger.child(plugin.namespace);
 
-      final schemas = <HostFunctionSchema>[];
       for (final fn in plugin.functions) {
-        bridge.register(fn);
-        schemas.add(fn.schema);
+        bridge.register(fn, category: plugin.namespace);
       }
-      schemasByCategory[plugin.namespace] = schemas;
     }
 
     // Register standalone functions under the 'extra' category.
     if (extraFunctions != null && extraFunctions.isNotEmpty) {
-      final extraSchemas = <HostFunctionSchema>[];
       for (final fn in extraFunctions) {
-        bridge.register(fn);
-        extraSchemas.add(fn.schema);
+        bridge.register(fn, category: 'extra');
       }
-      schemasByCategory['extra'] = extraSchemas;
       _log.debug(
         'Registered extra functions',
         attributes: {'count': extraFunctions.length},
@@ -130,7 +122,9 @@ class PluginRegistry {
     }
 
     if (enableIntrospection) {
-      buildIntrospectionFunctions(schemasByCategory).forEach(bridge.register);
+      for (final fn in buildIntrospectionFunctions(bridge)) {
+        bridge.register(fn, category: introspectionCategory);
+      }
     }
 
     if (errors.isNotEmpty) {

--- a/test/bridge/src/bridge/introspection_functions_test.dart
+++ b/test/bridge/src/bridge/introspection_functions_test.dart
@@ -1,50 +1,79 @@
 import 'dart:convert';
 
+import 'package:dart_monty/src/bridge/bridge/bridge_event.dart';
+import 'package:dart_monty/src/bridge/bridge/bridge_middleware.dart';
+import 'package:dart_monty/src/bridge/bridge/host_function.dart';
 import 'package:dart_monty/src/bridge/bridge/host_function_schema.dart';
 import 'package:dart_monty/src/bridge/bridge/host_param.dart';
 import 'package:dart_monty/src/bridge/bridge/host_param_type.dart';
 import 'package:dart_monty/src/bridge/bridge/introspection_functions.dart';
+import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
+import 'package:dart_monty/src/bridge/os_call/os_provider.dart';
+import 'package:dart_monty/src/platform/bridge_logger.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('buildIntrospectionFunctions', () {
     group('help', () {
-      late Map<String, List<HostFunctionSchema>> schemas;
+      late _FakeBridge bridge;
 
       setUp(() {
-        schemas = {
-          'storage': [
-            const HostFunctionSchema(
-              name: 'storage_get',
-              description: 'Get a value from storage.',
-              params: [
-                HostParam(
-                  name: 'key',
-                  type: HostParamType.string,
-                  description: 'The key.',
-                ),
-              ],
+        bridge = _FakeBridge()
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'storage_get',
+                description: 'Get a value from storage.',
+                params: [
+                  HostParam(
+                    name: 'key',
+                    type: HostParamType.string,
+                    description: 'The key.',
+                  ),
+                ],
+              ),
+              handler: (_) async => null,
             ),
-            const HostFunctionSchema(
-              name: 'storage_set',
-              description: 'Set a value in storage.',
+            category: 'storage',
+          )
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'storage_set',
+                description: 'Set a value in storage.',
+              ),
+              handler: (_) async => null,
             ),
-          ],
-          'cache': [
-            const HostFunctionSchema(
-              name: 'cache_get',
-              description: 'Get a value from cache.',
+            category: 'storage',
+          )
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'cache_get',
+                description: 'Get a value from cache.',
+              ),
+              handler: (_) async => null,
             ),
-            const HostFunctionSchema(
-              name: 'cache_clear',
-              description: 'Clear the cache.',
+            category: 'cache',
+          )
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'cache_clear',
+                description: 'Clear the cache.',
+              ),
+              handler: (_) async => null,
             ),
-          ],
-        };
+            category: 'cache',
+          );
+        // Register introspection builtins so help can find itself.
+        for (final fn in buildIntrospectionFunctions(bridge)) {
+          bridge.register(fn, category: 'introspection');
+        }
       });
 
       Future<String> callHelp([String? name]) async {
-        final fns = buildIntrospectionFunctions(schemas);
+        final fns = buildIntrospectionFunctions(bridge);
         final helpFn = fns.firstWhere((f) => f.schema.name == 'help');
         final result = await helpFn.handler({'name': name});
         return result! as String;
@@ -158,15 +187,18 @@ void main() {
       });
 
       test('bare name resolves with underscore namespace', () async {
-        final underscoreSchemas = {
-          'db_utils': [
-            const HostFunctionSchema(
-              name: 'db_utils_query',
-              description: 'Run a DB query.',
+        final b = _FakeBridge()
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'db_utils_query',
+                description: 'Run a DB query.',
+              ),
+              handler: (_) async => null,
             ),
-          ],
-        };
-        final fns = buildIntrospectionFunctions(underscoreSchemas);
+            category: 'db_utils',
+          );
+        final fns = buildIntrospectionFunctions(b);
         final helpFn = fns.firstWhere((f) => f.schema.name == 'help');
         final result = await helpFn.handler({'name': 'query'});
         final decoded = jsonDecode(result! as String) as Map<String, Object?>;
@@ -175,11 +207,124 @@ void main() {
       });
 
       test('only one function is registered (no list_functions)', () {
-        final fns = buildIntrospectionFunctions(schemas);
+        final fns = buildIntrospectionFunctions(bridge);
 
         expect(fns, hasLength(1));
         expect(fns.first.schema.name, 'help');
       });
     });
+
+    group('live introspection', () {
+      test(
+        'function registered after buildIntrospectionFunctions is visible',
+        () async {
+          final bridge = _FakeBridge();
+          // Build introspection FIRST.
+          final fns = buildIntrospectionFunctions(bridge);
+          final helpFn = fns.firstWhere((f) => f.schema.name == 'help');
+
+          // Register a function AFTER.
+          bridge.register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'late_fn',
+                description: 'Registered late.',
+              ),
+              handler: (_) async => null,
+            ),
+            category: 'late',
+          );
+
+          final result = await helpFn.handler({'name': 'late_fn'});
+          final decoded = jsonDecode(result! as String) as Map<String, Object?>;
+
+          expect(decoded['name'], 'late_fn');
+          expect(decoded['description'], 'Registered late.');
+        },
+      );
+
+      test('late-registered function appears in no-arg listing', () async {
+        final bridge = _FakeBridge();
+        final fns = buildIntrospectionFunctions(bridge);
+        final helpFn = fns.firstWhere((f) => f.schema.name == 'help');
+
+        // Register after.
+        bridge.register(
+          HostFunction(
+            schema: const HostFunctionSchema(
+              name: 'late_fn',
+              description: 'Registered late.',
+            ),
+            handler: (_) async => null,
+          ),
+          category: 'late',
+        );
+
+        final result = await helpFn.handler({});
+        final decoded = jsonDecode(result! as String) as Map<String, Object?>;
+        final tools = decoded['tools']! as Map<String, Object?>;
+
+        expect(tools, contains('late'));
+      });
+    });
   });
+}
+
+/// Minimal fake bridge that tracks registered functions and categories.
+class _FakeBridge implements MontyBridge {
+  final Map<String, HostFunction> _functions = {};
+  final Map<String, Set<String>> _categoryIndex = {};
+
+  @override
+  BridgeLogger get logger => const NullBridgeLogger();
+
+  @override
+  List<HostFunctionSchema> get schemas =>
+      _functions.values.map((f) => f.schema).toList(growable: false);
+
+  @override
+  Map<String, List<HostFunctionSchema>> get schemasByCategory {
+    final result = <String, List<HostFunctionSchema>>{};
+    for (final entry in _categoryIndex.entries) {
+      final schemas = <HostFunctionSchema>[];
+      for (final name in entry.value) {
+        final fn = _functions[name];
+        if (fn != null) schemas.add(fn.schema);
+      }
+      if (schemas.isNotEmpty) result[entry.key] = schemas;
+    }
+    return result;
+  }
+
+  @override
+  void register(HostFunction function, {String? category}) {
+    final name = function.schema.name;
+    _functions[name] = function;
+    final cat = category ?? 'uncategorized';
+    (_categoryIndex[cat] ??= {}).add(name);
+  }
+
+  @override
+  void unregister(String name) {
+    _functions.remove(name);
+  }
+
+  @override
+  void use(BridgeMiddleware middleware) {}
+
+  @override
+  void registerOs(OsProvider provider) {}
+
+  @override
+  Stream<BridgeEvent> execute(String code) => const Stream.empty();
+
+  @override
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    CallRole role = const ToolCall(),
+  }) => throw UnimplementedError();
+
+  @override
+  void dispose() {}
 }

--- a/test/bridge/src/bridge/monty_plugin_test.dart
+++ b/test/bridge/src/bridge/monty_plugin_test.dart
@@ -98,10 +98,13 @@ class _NoOpBridge implements MontyBridge {
   List<HostFunctionSchema> get schemas => [];
 
   @override
+  Map<String, List<HostFunctionSchema>> get schemasByCategory => {};
+
+  @override
   void use(BridgeMiddleware middleware) {}
 
   @override
-  void register(HostFunction function) {}
+  void register(HostFunction function, {String? category}) {}
 
   @override
   void unregister(String name) {}

--- a/test/bridge/src/bridge/plugin_registry_test.dart
+++ b/test/bridge/src/bridge/plugin_registry_test.dart
@@ -679,19 +679,40 @@ class _LifecyclePlugin extends MontyPlugin {
 /// Minimal bridge mock that tracks registered function names.
 class _MockBridge implements MontyBridge {
   final registeredNames = <String>[];
+  final _functions = <String, HostFunction>{};
+  final _categoryIndex = <String, Set<String>>{};
 
   @override
   BridgeLogger get logger => const NullBridgeLogger();
 
   @override
-  List<HostFunctionSchema> get schemas => [];
+  List<HostFunctionSchema> get schemas =>
+      _functions.values.map((f) => f.schema).toList(growable: false);
+
+  @override
+  Map<String, List<HostFunctionSchema>> get schemasByCategory {
+    final result = <String, List<HostFunctionSchema>>{};
+    for (final entry in _categoryIndex.entries) {
+      final schemas = <HostFunctionSchema>[];
+      for (final name in entry.value) {
+        final fn = _functions[name];
+        if (fn != null) schemas.add(fn.schema);
+      }
+      if (schemas.isNotEmpty) result[entry.key] = schemas;
+    }
+    return result;
+  }
 
   @override
   void use(BridgeMiddleware middleware) {}
 
   @override
-  void register(HostFunction function) {
-    registeredNames.add(function.schema.name);
+  void register(HostFunction function, {String? category}) {
+    final name = function.schema.name;
+    registeredNames.add(name);
+    _functions[name] = function;
+    final cat = category ?? 'uncategorized';
+    (_categoryIndex[cat] ??= {}).add(name);
   }
 
   @override


### PR DESCRIPTION
## Summary
- `MontyBridge.register()` now accepts an optional `category` parameter; `DefaultMontyBridge` maintains a live `_categoryIndex` so `schemasByCategory` reflects current state
- `buildIntrospectionFunctions` takes `MontyBridge` instead of a frozen map — `help()` queries live bridge state, making late-registered functions (e.g. EventLoopBridge's `wait_for_event`) visible
- `PluginRegistry.attachTo` passes categories when registering plugin, extra, and introspection functions; `EventLoopBridge` registers with `category: 'event_loop'`

## Test plan
- [x] All 1381 existing tests pass
- [x] `dart analyze` reports zero issues
- [x] New live introspection tests: function registered after `buildIntrospectionFunctions` is visible in both `help("name")` and `help()` no-arg listing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)