### PR TITLE
refactor: MontyResult.value non-nullable (MontyValue? → MontyValue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,10 @@ typed sealed subclasses. `MontyValue.fromDart(value)` converts Dart values
 
 ```dart
 final result = await monty.run('import datetime; datetime.date(2024, 1, 15)');
-final date = result.value!.dartValue; // DateTime(2024, 1, 15)
+final date = result.value.dartValue; // DateTime(2024, 1, 15)
 
 final td = await monty.run('import datetime; datetime.timedelta(days=5)');
-final dur = td.value!.dartValue; // Duration(days: 5)
+final dur = td.value.dartValue; // Duration(days: 5)
 ```
 
 ### Resource Limits

--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -356,18 +356,15 @@ class AgentSession {
   MontyResult _extractResult(List<BridgeEvent> events) {
     for (final event in events.reversed) {
       if (event is BridgeRunFinished) {
-        final value = event.value != null
-            ? MontyValue.fromDart(event.value)
-            : null;
-
         return MontyResult(
-          value: value,
+          value: MontyValue.fromDart(event.value),
           usage: _zeroUsage,
           printOutput: event.printOutput,
         );
       }
       if (event is BridgeRunError) {
         return MontyResult(
+          value: const MontyNull(),
           error: event.exception ?? MontyException(message: event.message),
           usage: _zeroUsage,
           printOutput: event.printOutput,

--- a/lib/src/bridge/bridge/default_monty_bridge.dart
+++ b/lib/src/bridge/bridge/default_monty_bridge.dart
@@ -279,7 +279,7 @@ class DefaultMontyBridge implements MontyBridge {
             BridgeRunFinished(
               threadId: threadId,
               runId: runId,
-              value: result.value?.dartValue,
+              value: result.value.dartValue,
               printOutput: capturedOutput,
             ),
           );

--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -149,7 +149,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
 
         return MontyComplete(
           result: MontyResult(
-            value: p.value != null ? MontyValue.fromJson(p.value) : null,
+            value: MontyValue.fromJson(p.value),
             error: _buildError(p.error, p.excType, p.traceback),
             usage: p.usage ?? _zeroUsage,
             printOutput: p.printOutput,
@@ -213,7 +213,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   MontyResult _translateRunResult(CoreRunResult r) {
     if (r.ok) {
       return MontyResult(
-        value: r.value != null ? MontyValue.fromJson(r.value) : null,
+        value: MontyValue.fromJson(r.value),
         error: _buildError(r.error, r.excType, r.traceback),
         usage: r.usage ?? _zeroUsage,
         printOutput: r.printOutput,

--- a/lib/src/platform/monty_result.dart
+++ b/lib/src/platform/monty_result.dart
@@ -14,7 +14,7 @@ final class MontyResult {
   /// required [usage] statistics.
   const MontyResult({
     required this.usage,
-    this.value,
+    required this.value,
     this.error,
     this.printOutput,
   });
@@ -24,7 +24,7 @@ final class MontyResult {
   /// Expected keys: `value`, `error` (optional map), `usage` (required map).
   factory MontyResult.fromJson(Map<String, dynamic> json) {
     return MontyResult(
-      value: json['value'] != null ? MontyValue.fromJson(json['value']) : null,
+      value: MontyValue.fromJson(json['value']),
       error: json['error'] != null
           ? MontyException.fromJson(json['error'] as Map<String, dynamic>)
           : null,
@@ -33,18 +33,22 @@ final class MontyResult {
     );
   }
 
-  /// The return value from the Python execution, or `null` if an error
-  /// occurred or the code returned `None`.
+  /// The return value from the Python execution.
+  ///
+  /// Python always produces a value — when a script returns `None` this field
+  /// holds [MontyNull] rather than a Dart `null`. Use [MontyNull.dartValue]
+  /// (which returns `null`) if you need the raw Dart representation.
   ///
   /// Use pattern matching to access typed values:
   /// ```dart
   /// switch (result.value) {
+  ///   case MontyNull(): // Python returned None
   ///   case MontyInt(:final value): print(value);
   ///   case MontyString(:final value): print(value);
   ///   case MontyDate(:final year, :final month, :final day): ...
   /// }
   /// ```
-  final MontyValue? value;
+  final MontyValue value;
 
   /// The error from the Python execution, or `null` if execution succeeded.
   final MontyException? error;
@@ -62,7 +66,7 @@ final class MontyResult {
   /// Serializes this result to a JSON-compatible map.
   Map<String, dynamic> toJson() {
     return {
-      'value': value?.toJson(),
+      'value': value.toJson(),
       if (error case final e?) 'error': e.toJson(),
       'usage': usage.toJson(),
       'print_output': ?printOutput,

--- a/lib/src/platform/monty_session.dart
+++ b/lib/src/platform/monty_session.dart
@@ -333,11 +333,16 @@ class MontySession {
       );
     } on MontyScriptError catch (e) {
       return MontyComplete(
-        result: MontyResult(error: e.exception, usage: _zeroUsage),
+        result: MontyResult(
+          value: const MontyNull(),
+          error: e.exception,
+          usage: _zeroUsage,
+        ),
       );
     } on MontyError catch (e) {
       return MontyComplete(
         result: MontyResult(
+          value: const MontyNull(),
           error: MontyException(message: e.message),
           usage: _zeroUsage,
         ),
@@ -352,11 +357,16 @@ class MontySession {
       return await _platform.resume(returnValue);
     } on MontyScriptError catch (e) {
       return MontyComplete(
-        result: MontyResult(error: e.exception, usage: _zeroUsage),
+        result: MontyResult(
+          value: const MontyNull(),
+          error: e.exception,
+          usage: _zeroUsage,
+        ),
       );
     } on MontyError catch (e) {
       return MontyComplete(
         result: MontyResult(
+          value: const MontyNull(),
           error: MontyException(message: e.message),
           usage: _zeroUsage,
         ),
@@ -371,11 +381,16 @@ class MontySession {
       return await _platform.resumeWithError(errorMessage);
     } on MontyScriptError catch (e) {
       return MontyComplete(
-        result: MontyResult(error: e.exception, usage: _zeroUsage),
+        result: MontyResult(
+          value: const MontyNull(),
+          error: e.exception,
+          usage: _zeroUsage,
+        ),
       );
     } on MontyError catch (e) {
       return MontyComplete(
         result: MontyResult(
+          value: const MontyNull(),
           error: MontyException(message: e.message),
           usage: _zeroUsage,
         ),

--- a/lib/src/platform/testing/ladder_assertions.dart
+++ b/lib/src/platform/testing/ladder_assertions.dart
@@ -11,11 +11,11 @@ import 'package:test/test.dart';
 /// - `expectedContains` — asserts `actual.toString()` contains the string.
 /// - `expectedSorted` — sorts both sides before JSON comparison.
 /// - `expected` — exact JSON equality.
-void assertLadderResult(MontyValue? actual, Map<String, dynamic> fixture) {
+void assertLadderResult(MontyValue actual, Map<String, dynamic> fixture) {
   final expectedContains = fixture['expectedContains'] as String?;
   if (expectedContains != null) {
     expect(
-      actual?.toString(),
+      actual.toString(),
       contains(expectedContains),
       reason:
           'Fixture #${fixture['id']}: expected value to contain '
@@ -28,7 +28,7 @@ void assertLadderResult(MontyValue? actual, Map<String, dynamic> fixture) {
   var expected = fixture['expected'];
   final expectedSorted = fixture['expectedSorted'] as bool? ?? false;
 
-  var actualJson = actual?.toJson();
+  var actualJson = actual.toJson();
   if (expectedSorted) {
     actualJson = _sortValue(actualJson);
     expected = _sortValue(expected);

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -75,7 +75,7 @@ class MontyRepl {
 
     if (r.ok) {
       return MontyResult(
-        value: r.value != null ? MontyValue.fromJson(r.value) : null,
+        value: MontyValue.fromJson(r.value),
         error: _buildError(r.error, r.excType, r.traceback),
         usage: r.usage ?? _zeroUsage,
         printOutput: r.printOutput,
@@ -165,7 +165,7 @@ class MontyRepl {
       case 'complete':
         return MontyComplete(
           result: MontyResult(
-            value: p.value != null ? MontyValue.fromJson(p.value) : null,
+            value: MontyValue.fromJson(p.value),
             error: _buildError(p.error, p.excType, p.traceback),
             usage: p.usage ?? _zeroUsage,
             printOutput: p.printOutput,

--- a/lib/src/repl/repl_session.dart
+++ b/lib/src/repl/repl_session.dart
@@ -230,18 +230,15 @@ class ReplSession {
   MontyResult _extractResult(List<BridgeEvent> events) {
     for (final event in events.reversed) {
       if (event is BridgeRunFinished) {
-        final value = event.value != null
-            ? MontyValue.fromDart(event.value)
-            : null;
-
         return MontyResult(
-          value: value,
+          value: MontyValue.fromDart(event.value),
           usage: _zeroUsage,
           printOutput: event.printOutput,
         );
       }
       if (event is BridgeRunError) {
         return MontyResult(
+          value: const MontyNull(),
           error: event.exception ?? MontyException(message: event.message),
           usage: _zeroUsage,
           printOutput: event.printOutput,

--- a/lib/src/repl/testing/repl_ladder_runner.dart
+++ b/lib/src/repl/testing/repl_ladder_runner.dart
@@ -90,7 +90,7 @@ Future<void> _runFeedFixture(
 
       if (feed.containsKey('expected')) {
         final expected = feed['expected'];
-        final actual = result.value?.dartValue;
+        final actual = result.value.dartValue;
         expect(actual, equals(expected), reason: 'After feeding: $code');
       }
 

--- a/test/bridge/integration/agent_plugin_integration_test.dart
+++ b/test/bridge/integration/agent_plugin_integration_test.dart
@@ -33,7 +33,7 @@ void main() {
 tmpl_render(template='Hello {{ name }}!', context={'name': 'Alice'})
 ''');
 
-      expect(result.value?.dartValue, 'Hello Alice!');
+      expect(result.value.dartValue, 'Hello Alice!');
     });
 
     test('tmpl_render with loop', () async {
@@ -43,7 +43,7 @@ tmpl_render(
     context={'items': ['a', 'b', 'c']})
 ''');
 
-      expect(result.value?.dartValue, 'a b c ');
+      expect(result.value.dartValue, 'a b c ');
     });
 
     test('tmpl_render with conditional', () async {
@@ -53,7 +53,7 @@ tmpl_render(
     context={'n': 42})
 ''');
 
-      expect(result.value?.dartValue, 'big');
+      expect(result.value.dartValue, 'big');
     });
   });
 
@@ -81,13 +81,13 @@ msg_send(name='ch', message='second')
         "[msg_recv(name='ch'), msg_recv(name='ch')]",
       );
 
-      expect(result.value?.dartValue, ['first', 'second']);
+      expect(result.value.dartValue, ['first', 'second']);
     });
 
     test('peek returns None when empty', () async {
       final result = await session.execute("msg_peek(name='empty')");
 
-      expect(result.value?.dartValue, isNull);
+      expect(result.value.dartValue, isNull);
     });
 
     test('stats reports queue depth', () async {
@@ -96,7 +96,7 @@ msg_send(name='q', message=1)
 msg_send(name='q', message=2)
 ''');
       final result = await session.execute("msg_stats(name='q')");
-      final stats = result.value!.dartValue! as Map;
+      final stats = result.value.dartValue! as Map;
 
       expect(stats['send_count'], 2);
       expect(stats['queue_depth'], 2);
@@ -139,7 +139,7 @@ h = sandbox_spawn(code='2 + 3')
 sandbox_await(handle=h)
 ''');
 
-      expect(result.value?.dartValue, 5);
+      expect(result.value.dartValue, 5);
     });
 
     test('gather multiple children', () async {
@@ -150,7 +150,7 @@ h3 = sandbox_spawn(code='30')
 sandbox_await_all(handles=[h1, h2, h3])
 ''');
 
-      expect(result.value?.dartValue, [10, 20, 30]);
+      expect(result.value.dartValue, [10, 20, 30]);
     });
 
     test('child error propagates cleanly', () async {
@@ -162,7 +162,7 @@ except Exception as e:
     r = f'caught: {e}'
 r
 ''');
-      final val = result.value!.dartValue! as String;
+      final val = result.value.dartValue! as String;
 
       expect(val, contains('ZeroDivisionError'));
     });
@@ -174,7 +174,7 @@ sandbox_await(handle=h)
 sandbox_get_output(handle=h)
 ''');
 
-      expect(result.value?.dartValue, contains('hello'));
+      expect(result.value.dartValue, contains('hello'));
     });
 
     test('child lifecycle: spawn, alive, await, free', () async {
@@ -186,7 +186,7 @@ sandbox_free(handle=h)
 [r, alive]
 ''');
 
-      expect(result.value?.dartValue, [99, false]);
+      expect(result.value.dartValue, [99, false]);
     });
   });
 
@@ -226,7 +226,7 @@ h = sandbox_spawn(code='tmpl_render(template="Hi {{ who }}!", context={"who": "c
 sandbox_await(handle=h)
 ''');
 
-      expect(result.value?.dartValue, 'Hi child!');
+      expect(result.value.dartValue, 'Hi child!');
     });
 
     test('child sends message to parent via shared bus', () async {
@@ -238,7 +238,7 @@ parent_got = msg_recv(name='results')
 [child_got, parent_got]
 ''');
 
-      expect(result.value?.dartValue, ['do X', 'done: do X']);
+      expect(result.value.dartValue, ['do X', 'done: do X']);
     });
 
     test('producer/consumer pipeline between children', () async {
@@ -248,7 +248,7 @@ consumer = sandbox_spawn(code='items = []\nfor i in range(3):\n    items.append(
 sandbox_await(handle=producer)
 sandbox_await(handle=consumer)
 ''');
-      final items = result.value!.dartValue! as List;
+      final items = result.value.dartValue! as List;
 
       expect(items, ['item-0', 'item-1', 'item-2']);
     });
@@ -263,7 +263,7 @@ parent_file = Path('/parent.txt').read_text()
 [child_result, parent_file]
 ''');
 
-      expect(result.value?.dartValue, ['child data', 'parent data']);
+      expect(result.value.dartValue, ['child data', 'parent data']);
     });
   });
 }

--- a/test/bridge/integration/agent_session_test.dart
+++ b/test/bridge/integration/agent_session_test.dart
@@ -25,7 +25,7 @@ void main() {
     test('simple expression', () async {
       final result = await session.execute('2 + 2');
 
-      expect(result.value?.dartValue, 4);
+      expect(result.value.dartValue, 4);
     });
 
     test('variables persist across execute() calls', () async {
@@ -33,14 +33,14 @@ void main() {
       await session.execute('y = x * 2');
       final result = await session.execute('x + y');
 
-      expect(result.value?.dartValue, 126);
+      expect(result.value.dartValue, 126);
     });
 
     test('string variables persist', () async {
       await session.execute('name = "monty"');
       final result = await session.execute('name.upper()');
 
-      expect(result.value?.dartValue, 'MONTY');
+      expect(result.value.dartValue, 'MONTY');
     });
 
     test('list variables persist', () async {
@@ -48,14 +48,14 @@ void main() {
       await session.execute('data.append(4)');
       final result = await session.execute('sum(data)');
 
-      expect(result.value?.dartValue, 10);
+      expect(result.value.dartValue, 10);
     });
 
     test('dict variables persist', () async {
       await session.execute('config = {"debug": True, "level": 5}');
       final result = await session.execute('config["debug"]');
 
-      expect(result.value?.dartValue, true);
+      expect(result.value.dartValue, true);
     });
 
     test('clearState() resets all variables', () async {
@@ -70,7 +70,7 @@ void main() {
       await session.execute('a = 1; b = 2.5; c = "hello"; d = True');
       final result = await session.execute('[a, b, c, d]');
 
-      expect(result.value?.dartValue, [1, 2.5, 'hello', true]);
+      expect(result.value.dartValue, [1, 2.5, 'hello', true]);
     });
   });
 
@@ -99,7 +99,7 @@ void main() {
 
       final result = await session.execute('double_it(21)');
 
-      expect(result.value?.dartValue, 42);
+      expect(result.value.dartValue, 42);
     });
 
     test('host function result persists in state', () async {
@@ -116,7 +116,7 @@ void main() {
       await session.execute('data = get_data()');
       final result = await session.execute('sum(data)');
 
-      expect(result.value?.dartValue, 15);
+      expect(result.value.dartValue, 15);
     });
 
     test('schemas include registered functions', () {
@@ -167,7 +167,7 @@ void main() {
         'Path("/data/test.txt").read_text()',
       );
 
-      expect(result.value?.dartValue, 'hello from agent');
+      expect(result.value.dartValue, 'hello from agent');
     });
 
     test('filesystem state persists across calls', () async {
@@ -188,7 +188,7 @@ void main() {
         'int(Path("/data/counter.txt").read_text())',
       );
 
-      expect(result.value?.dartValue, 1);
+      expect(result.value.dartValue, 1);
     });
 
     test('date.today() returns reasonable year', () async {
@@ -199,7 +199,7 @@ void main() {
         'date.today().year >= 2024',
       );
 
-      expect(result.value?.dartValue, true);
+      expect(result.value.dartValue, true);
     });
   });
 
@@ -225,7 +225,7 @@ void main() {
       await session.execute('1 / 0'); // error, but x should survive
       final result = await session.execute('x');
 
-      expect(result.value?.dartValue, 42);
+      expect(result.value.dartValue, 42);
     });
 
     test('execute after dispose throws', () async {
@@ -252,7 +252,7 @@ void main() {
     test('simple expression', () async {
       final result = await session.execute('2 + 2');
 
-      expect(result.value?.dartValue, 4);
+      expect(result.value.dartValue, 4);
     });
 
     test('isSandboxMode is true', () {
@@ -263,7 +263,7 @@ void main() {
       await session.execute('x = 42');
       final result = await session.execute('x + 1');
 
-      expect(result.value?.dartValue, 43);
+      expect(result.value.dartValue, 43);
     });
 
     test('state persists across fresh interpreters', () async {
@@ -271,7 +271,7 @@ void main() {
       await session.execute('age = 30');
       final result = await session.execute('[name, age]');
 
-      expect(result.value?.dartValue, ['alice', 30]);
+      expect(result.value.dartValue, ['alice', 30]);
     });
 
     test('host function callable from sandbox', () async {
@@ -293,7 +293,7 @@ void main() {
 
       final result = await session.execute('double_it(21)');
 
-      expect(result.value?.dartValue, 42);
+      expect(result.value.dartValue, 42);
     });
 
     test('host function result persists in state', () async {
@@ -313,7 +313,7 @@ void main() {
       await session.execute('msg = greet("World")');
       final result = await session.execute('msg');
 
-      expect(result.value?.dartValue, 'Hello, World!');
+      expect(result.value.dartValue, 'Hello, World!');
     });
 
     test('clearState() resets all variables', () async {
@@ -327,7 +327,7 @@ except NameError:
 result
 ''');
 
-      expect(result.value?.dartValue, 'gone');
+      expect(result.value.dartValue, 'gone');
     });
 
     test('error does not break state', () async {
@@ -335,7 +335,7 @@ result
       await session.execute('1 / 0'); // error
       final result = await session.execute('x');
 
-      expect(result.value?.dartValue, 42);
+      expect(result.value.dartValue, 42);
     });
 
     test('executeStream throws in sandbox mode', () {
@@ -351,7 +351,7 @@ result
       }
       final result = await session.execute('x');
 
-      expect(result.value?.dartValue, 9);
+      expect(result.value.dartValue, 9);
     });
   });
 

--- a/test/bridge/integration/ffi_async_host_fn_test.dart
+++ b/test/bridge/integration/ffi_async_host_fn_test.dart
@@ -33,10 +33,10 @@ void main() {
       );
 
       final r1 = await session.execute('fast_fn()');
-      expect(r1.value?.dartValue, 'fast');
+      expect(r1.value.dartValue, 'fast');
 
       final r2 = await session.execute('fast_fn()');
-      expect(r2.value?.dartValue, 'fast');
+      expect(r2.value.dartValue, 'fast');
     });
 
     test('async host function with short delay — two calls', () async {
@@ -58,10 +58,10 @@ void main() {
       );
 
       final r1 = await session.execute('delay_100ms()');
-      expect(r1.value?.dartValue, 'done');
+      expect(r1.value.dartValue, 'done');
 
       final r2 = await session.execute('delay_100ms()');
-      expect(r2.value?.dartValue, 'done');
+      expect(r2.value.dartValue, 'done');
     });
 
     test('async host function with 1s delay — two calls', () async {
@@ -83,10 +83,10 @@ void main() {
       );
 
       final r1 = await session.execute('delay_1s()');
-      expect(r1.value?.dartValue, 'done');
+      expect(r1.value.dartValue, 'done');
 
       final r2 = await session.execute('delay_1s()');
-      expect(r2.value?.dartValue, 'done');
+      expect(r2.value.dartValue, 'done');
     });
 
     test(
@@ -127,14 +127,14 @@ void main() {
         final r1 = await session.execute(
           'http_get("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        expect(r1.value?.dartValue, isA<String>());
-        expect(r1.value?.dartValue, isNotEmpty);
+        expect(r1.value.dartValue, isA<String>());
+        expect(r1.value.dartValue, isNotEmpty);
 
         // This is the call that crashes on #271
         final r2 = await session.execute(
           'http_get("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        expect(r2.value?.dartValue, isA<String>());
+        expect(r2.value.dartValue, isA<String>());
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );
@@ -177,12 +177,12 @@ void main() {
         final r1 = await session.execute(
           'http_get("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        expect(r1.value?.dartValue, isA<String>());
+        expect(r1.value.dartValue, isA<String>());
 
         final r2 = await session.execute(
           'http_get("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        expect(r2.value?.dartValue, isA<String>());
+        expect(r2.value.dartValue, isA<String>());
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );
@@ -206,10 +206,10 @@ void main() {
       );
 
       final r1 = await session.execute('read_file()');
-      expect(r1.value?.dartValue, isA<String>());
+      expect(r1.value.dartValue, isA<String>());
 
       final r2 = await session.execute('read_file()');
-      expect(r2.value?.dartValue, isA<String>());
+      expect(r2.value.dartValue, isA<String>());
     });
 
     test('process I/O — two calls', () async {
@@ -231,10 +231,10 @@ void main() {
       );
 
       final r1 = await session.execute('run_cmd()');
-      expect(r1.value?.dartValue, 'hello');
+      expect(r1.value.dartValue, 'hello');
 
       final r2 = await session.execute('run_cmd()');
-      expect(r2.value?.dartValue, 'hello');
+      expect(r2.value.dartValue, 'hello');
     });
 
     test('socket listen — two calls', () async {
@@ -258,10 +258,10 @@ void main() {
       );
 
       final r1 = await session.execute('socket_test()');
-      expect(r1.value?.dartValue, startsWith('port:'));
+      expect(r1.value.dartValue, startsWith('port:'));
 
       final r2 = await session.execute('socket_test()');
-      expect(r2.value?.dartValue, startsWith('port:'));
+      expect(r2.value.dartValue, startsWith('port:'));
     });
 
     test(
@@ -299,12 +299,12 @@ void main() {
         final r1 = await session.execute(
           'http_tiny("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        expect(r1.value?.dartValue, 200);
+        expect(r1.value.dartValue, 200);
 
         final r2 = await session.execute(
           'http_tiny("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        expect(r2.value?.dartValue, 200);
+        expect(r2.value.dartValue, 200);
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );
@@ -345,13 +345,13 @@ void main() {
         final r1 = await session.execute(
           'http_large("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        final v1 = r1.value!.dartValue! as String;
+        final v1 = r1.value.dartValue! as String;
         expect(v1.length, greaterThan(10));
 
         final r2 = await session.execute(
           'http_large("https://demo.toughserv.com/api/v1/installation/versions")',
         );
-        expect(r2.value?.dartValue, isA<String>());
+        expect(r2.value.dartValue, isA<String>());
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );

--- a/test/bridge/integration/ffi_finalizer_race_test.dart
+++ b/test/bridge/integration/ffi_finalizer_race_test.dart
@@ -61,8 +61,8 @@ void main() {
         final s = AgentSession()..register(_httpFn());
         final r = await s.execute('http_fn()');
         await s.dispose();
-        print('  result: ${r.value?.dartValue}');
-        expect(r.value?.dartValue, isA<String>());
+        print('  result: ${r.value.dartValue}');
+        expect(r.value.dartValue, isA<String>());
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );
@@ -74,7 +74,7 @@ void main() {
           final s = AgentSession()..register(_httpFn());
           final r = await s.execute('http_fn()');
           await s.dispose();
-          expect(r.value?.dartValue, isA<String>());
+          expect(r.value.dartValue, isA<String>());
         }
         print('  10/10 sessions with HTTP passed');
       },
@@ -114,7 +114,7 @@ void main() {
         final r = await s.execute('http_fn()');
         await s.dispose();
         print('  survived 20 rapid dispose + 1 HTTP');
-        expect(r.value?.dartValue, isA<String>());
+        expect(r.value.dartValue, isA<String>());
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );
@@ -125,7 +125,7 @@ void main() {
         final s = AgentSession(sandbox: true)..register(_httpFn());
         for (var i = 0; i < 10; i++) {
           final r = await s.execute('http_fn()');
-          expect(r.value?.dartValue, isA<String>());
+          expect(r.value.dartValue, isA<String>());
         }
         await s.dispose();
         print('  10/10 sandbox HTTP calls passed');

--- a/test/bridge/integration/ffi_mixed_mode_test.dart
+++ b/test/bridge/integration/ffi_mixed_mode_test.dart
@@ -105,7 +105,7 @@ void main() {
       addTearDown(s.dispose);
       for (var i = 0; i < 20; i++) {
         final r = await s.execute('sync_fn()');
-        expect(r.value?.dartValue, 'sync_ok');
+        expect(r.value.dartValue, 'sync_ok');
       }
       print('  G1: 20/20 sync');
     });
@@ -117,7 +117,7 @@ void main() {
         addTearDown(s.dispose);
         for (var i = 0; i < 10; i++) {
           final r = await s.execute('delay_fn()');
-          expect(r.value?.dartValue, 'delay_ok');
+          expect(r.value.dartValue, 'delay_ok');
         }
         print('  G2: 10/10 delay');
       },
@@ -132,7 +132,7 @@ void main() {
         var passed = 0;
         for (var i = 0; i < 10; i++) {
           final r = await s.execute('http_fn()');
-          if (r.value?.dartValue != null) passed++;
+          if (r.value.dartValue != null) passed++;
         }
         print('  G3: $passed/10 http');
         expect(passed, 10);
@@ -145,7 +145,7 @@ void main() {
       addTearDown(s.dispose);
       for (var i = 1; i <= 5; i++) {
         final r = await s.execute('counter()');
-        expect(r.value?.dartValue, i);
+        expect(r.value.dartValue, i);
       }
       print('  G4: counter 1→5');
     });
@@ -156,8 +156,8 @@ void main() {
       await s.execute('accum("a")');
       await s.execute('accum("b")');
       final r = await s.execute('accum("c")');
-      print('  G5: accum count = ${r.value?.dartValue}');
-      expect(r.value?.dartValue, 3);
+      print('  G5: accum count = ${r.value.dartValue}');
+      expect(r.value.dartValue, 3);
     });
 
     test('G6. state accumulation: build list across 10 calls', () async {
@@ -168,8 +168,8 @@ void main() {
         await s.execute('items.append(sync_fn() + "_$i")');
       }
       final r = await s.execute('len(items)');
-      print('  G6: ${r.value?.dartValue} items');
-      expect(r.value?.dartValue, 10);
+      print('  G6: ${r.value.dartValue} items');
+      expect(r.value.dartValue, 10);
     });
 
     test('G7. error recovery: bad call then good call', () async {
@@ -178,8 +178,8 @@ void main() {
       await s.execute('x = 42');
       await s.execute('1/0'); // error
       final r = await s.execute('x');
-      print('  G7: x = ${r.value?.dartValue} (survived error)');
-      expect(r.value?.dartValue, 42);
+      print('  G7: x = ${r.value.dartValue} (survived error)');
+      expect(r.value.dartValue, 42);
     });
 
     test(
@@ -192,8 +192,8 @@ void main() {
         await s.execute('data = http_fn()');
         await s.execute('1/0'); // error
         final r = await s.execute('len(data)');
-        print('  G8: len(data) = ${r.value?.dartValue}');
-        expect(r.value?.dartValue as int, greaterThan(0));
+        print('  G8: len(data) = ${r.value.dartValue}');
+        expect(r.value.dartValue as int, greaterThan(0));
       },
       timeout: const Timeout(Duration(seconds: 15)),
     );
@@ -212,8 +212,8 @@ void main() {
       await s.execute('name = "Alice"');
       await s.execute('greeting2 = tmpl_render("Hi {{n}}", {"n": name})');
       final r = await s.execute('[greeting, greeting2]');
-      print('  H1: ${r.value?.dartValue}');
-      expect(r.value?.dartValue, ['Hi World', 'Hi Alice']);
+      print('  H1: ${r.value.dartValue}');
+      expect(r.value.dartValue, ['Hi World', 'Hi Alice']);
     });
 
     test('H2. MessageBus across execute calls', () async {
@@ -223,9 +223,9 @@ void main() {
       await s.execute('msg_send("q", "second")');
       final r1 = await s.execute('msg_recv("q")');
       final r2 = await s.execute('msg_recv("q")');
-      print('  H2: ${r1.value?.dartValue}, ${r2.value?.dartValue}');
-      expect(r1.value?.dartValue, 'first');
-      expect(r2.value?.dartValue, 'second');
+      print('  H2: ${r1.value.dartValue}, ${r2.value.dartValue}');
+      expect(r1.value.dartValue, 'first');
+      expect(r2.value.dartValue, 'second');
     });
 
     test('H3. FS + Template across calls', () async {
@@ -245,8 +245,8 @@ content = Path("/data.txt").read_text()
       final r = await s.execute(
         'tmpl_render("File has: {{c}}", {"c": content})',
       );
-      print('  H3: ${r.value?.dartValue}');
-      expect(r.value?.dartValue, 'File has: hello');
+      print('  H3: ${r.value.dartValue}');
+      expect(r.value.dartValue, 'File has: hello');
     });
 
     test(
@@ -262,8 +262,8 @@ content = Path("/data.txt").read_text()
         );
         await s.execute('msg_send("log", report)');
         final r = await s.execute('msg_recv("log")');
-        print('  H4: ${r.value?.dartValue}');
-        expect(r.value?.dartValue as String, startsWith('Got '));
+        print('  H4: ${r.value.dartValue}');
+        expect(r.value.dartValue as String, startsWith('Got '));
       },
       timeout: const Timeout(Duration(seconds: 15)),
     );
@@ -280,8 +280,8 @@ content = Path("/data.txt").read_text()
         await s.execute('http_fn()');
         await s.execute('c2 = counter()');
         final r = await s.execute('[c1, c2]');
-        print('  H5: ${r.value?.dartValue}');
-        expect(r.value?.dartValue, [1, 2]);
+        print('  H5: ${r.value.dartValue}');
+        expect(r.value.dartValue, [1, 2]);
       },
       timeout: const Timeout(Duration(seconds: 30)),
     );
@@ -337,8 +337,8 @@ from pathlib import Path
 cached = Path("/cache.txt").read_text()
 ''');
         final r = await s.execute('[kv_get("cached"), len(cached)]');
-        print('  H6: ${r.value?.dartValue}');
-        final list = r.value?.dartValue as List;
+        print('  H6: ${r.value.dartValue}');
+        final list = r.value.dartValue as List;
         expect(list[0], 'true');
         expect(list[1] as int, greaterThan(0));
       },
@@ -355,21 +355,21 @@ cached = Path("/cache.txt").read_text()
       final s = AgentSession();
       addTearDown(s.dispose);
       final r = await s.execute('pass');
-      print('  I1: ${r.value?.dartValue} (None)');
+      print('  I1: ${r.value.dartValue} (None)');
     });
 
     test('I2. execute with only comments', () async {
       final s = AgentSession();
       addTearDown(s.dispose);
       final r = await s.execute('# just a comment');
-      print('  I2: ${r.value?.dartValue}');
+      print('  I2: ${r.value.dartValue}');
     });
 
     test('I3. large string return', () async {
       final s = AgentSession();
       addTearDown(s.dispose);
       final r = await s.execute('"x" * 100000');
-      final v = r.value?.dartValue as String;
+      final v = r.value.dartValue as String;
       print('  I3: ${v.length} chars');
       expect(v.length, 100000);
     });
@@ -378,7 +378,7 @@ cached = Path("/cache.txt").read_text()
       final s = AgentSession();
       addTearDown(s.dispose);
       final r = await s.execute('list(range(1000))');
-      final v = r.value?.dartValue as List;
+      final v = r.value.dartValue as List;
       print('  I4: ${v.length} items');
       expect(v.length, 1000);
     });
@@ -387,7 +387,7 @@ cached = Path("/cache.txt").read_text()
       final s = AgentSession();
       addTearDown(s.dispose);
       final r = await s.execute('{"a": {"b": {"c": 42}}}');
-      final v = r.value?.dartValue as Map;
+      final v = r.value.dartValue as Map;
       print('  I5: $v');
       expect((v['a'] as Map)['b'], {'c': 42});
     });
@@ -408,8 +408,8 @@ cached = Path("/cache.txt").read_text()
 x = returns_none()
 x is None
 ''');
-      print('  I6: ${r.value?.dartValue}');
-      expect(r.value?.dartValue, true);
+      print('  I6: ${r.value.dartValue}');
+      expect(r.value.dartValue, true);
     });
 
     test('I7. host fn returning large string', () async {
@@ -425,8 +425,8 @@ x is None
         );
       addTearDown(s.dispose);
       final r = await s.execute('len(big_string())');
-      print('  I7: ${r.value?.dartValue}');
-      expect(r.value?.dartValue, 50000);
+      print('  I7: ${r.value.dartValue}');
+      expect(r.value.dartValue, 50000);
     });
 
     test('I8. host fn exception propagates to Python', () async {
@@ -449,8 +449,8 @@ except Exception as e:
     result = "caught"
 result
 ''');
-      print('  I8: ${r.value?.dartValue}');
-      expect(r.value?.dartValue, 'caught');
+      print('  I8: ${r.value.dartValue}');
+      expect(r.value.dartValue, 'caught');
     });
 
     test('I9. print output captured', () async {

--- a/test/bridge/integration/ffi_plugin_matrix_test.dart
+++ b/test/bridge/integration/ffi_plugin_matrix_test.dart
@@ -118,21 +118,21 @@ void main() {
 results = [sync_fn() for _ in range(10)]
 len(results)
 ''');
-        expect(r.value?.dartValue, 10);
+        expect(r.value.dartValue, 10);
         print('  A1. sync × 10: PASS');
 
         r = await session.execute('''
 results = [delay_fn() for _ in range(5)]
 len(results)
 ''');
-        expect(r.value?.dartValue, 5);
+        expect(r.value.dartValue, 5);
         print('  A2. delay × 5: PASS');
 
         r = await session.execute('''
 results = [http_fn() for _ in range(3)]
 len(results)
 ''');
-        expect(r.value?.dartValue, 3);
+        expect(r.value.dartValue, 3);
         print('  A3. http × 3: PASS');
 
         r = await session.execute('''
@@ -141,39 +141,39 @@ r2 = delay_fn()
 r3 = http_fn()
 [r1, r2, len(r3)]
 ''');
-        expect(r.value?.dartValue, isA<List<dynamic>>());
+        expect(r.value.dartValue, isA<List<dynamic>>());
         print('  A4. mixed sync+delay+http: PASS');
 
         r = await session.execute('''
 kv_set("name", "alice")
 kv_get("name")
 ''');
-        expect(r.value?.dartValue, 'alice');
+        expect(r.value.dartValue, 'alice');
         print('  A5. kv_set+kv_get: PASS');
 
         // ── B. State persistence ─────────────────────────────────────
 
         await session.execute('x = sync_fn()');
         r = await session.execute('x');
-        expect(r.value?.dartValue, 'sync_ok');
+        expect(r.value.dartValue, 'sync_ok');
         print('  B1. state persists (sync): PASS');
 
         await session.execute('hdata = http_fn()');
         r = await session.execute('len(hdata)');
-        expect(r.value?.dartValue as int, greaterThan(0));
+        expect(r.value.dartValue as int, greaterThan(0));
         print('  B2. state persists (http): PASS');
 
         await session.execute('items = []');
         await session.execute('items.append("a")');
         await session.execute('items.append("b")');
         r = await session.execute('len(items)');
-        expect(r.value?.dartValue, 2);
+        expect(r.value.dartValue, 2);
         print('  B3. list accumulation: PASS');
 
         await session.execute('safe_val = 42');
         await session.execute('1/0');
         r = await session.execute('safe_val');
-        expect(r.value?.dartValue, 42);
+        expect(r.value.dartValue, 42);
         print('  B4. error recovery: PASS');
 
         // ── C. Plugin combinations ───────────────────────────────────
@@ -185,7 +185,7 @@ b = kv_get("k1")
 c = delay_fn()
 [a, b, c]
 ''');
-        expect(r.value?.dartValue, ['sync_ok', 'v1', 'delay_ok']);
+        expect(r.value.dartValue, ['sync_ok', 'v1', 'delay_ok']);
         print('  C1. sync+kv+delay: PASS');
 
         r = await session.execute('''
@@ -194,7 +194,7 @@ kv_set("url_data", http_fn())
 b = kv_get("url_data")
 [a, len(b)]
 ''');
-        expect(r.value?.dartValue, isA<List<dynamic>>());
+        expect(r.value.dartValue, isA<List<dynamic>>());
         print('  C2. sync+kv+http: PASS');
 
         r = await session.execute('''
@@ -205,7 +205,7 @@ kv_set("all", r1 + "_" + r2)
 r4 = kv_get("all")
 [r1, r2, len(r3), r4]
 ''');
-        final c3 = r.value?.dartValue as List;
+        final c3 = r.value.dartValue as List;
         expect(c3[0], 'sync_ok');
         expect(c3[3], 'sync_ok_delay_ok');
         print('  C3. all 5 fns: PASS');
@@ -215,7 +215,7 @@ r4 = kv_get("all")
         r = await session.execute(
           'tmpl_render("Hello {{ n }}!", {"n": "World"})',
         );
-        expect(r.value?.dartValue, 'Hello World!');
+        expect(r.value.dartValue, 'Hello World!');
         print('  D1. template: PASS');
 
         r = await session.execute('''
@@ -225,7 +225,7 @@ r1 = msg_recv("ch1")
 r2 = msg_recv("ch1")
 [r1, r2]
 ''');
-        expect(r.value?.dartValue, ['hello', 'world']);
+        expect(r.value.dartValue, ['hello', 'world']);
         print('  D2. msgbus: PASS');
 
         r = await session.execute('''
@@ -234,7 +234,7 @@ b = tmpl_render("R: {{ v }}", {"v": a})
 msg_send("res", b)
 msg_recv("res")
 ''');
-        expect(r.value?.dartValue, 'R: sync_ok');
+        expect(r.value.dartValue, 'R: sync_ok');
         print('  D3. template+msgbus+sync: PASS');
 
         r = await session.execute('''
@@ -243,7 +243,7 @@ rendered = tmpl_render("Got {{ n }}", {"n": len(data)})
 msg_send("log", rendered)
 msg_recv("log")
 ''');
-        expect(r.value?.dartValue as String, startsWith('Got '));
+        expect(r.value.dartValue as String, startsWith('Got '));
         print('  D4. template+msgbus+http: PASS');
 
         r = await session.execute('''
@@ -257,7 +257,7 @@ msg_send("ch", e)
 f = msg_recv("ch")
 [a, b, len(c), d, e, f]
 ''');
-        final d5 = r.value?.dartValue as List;
+        final d5 = r.value.dartValue as List;
         expect(d5[0], 'sync_ok');
         expect(d5[4], 'sync_ok-delay_ok');
         print('  D5. ALL plugins+fns: PASS');
@@ -269,7 +269,7 @@ from pathlib import Path
 Path("/out.txt").write_text(sync_fn())
 Path("/out.txt").read_text()
 ''');
-        expect(r.value?.dartValue, 'sync_ok');
+        expect(r.value.dartValue, 'sync_ok');
         print('  E1. fs write+read: PASS');
 
         r = await session.execute('''
@@ -278,7 +278,7 @@ data = http_fn()
 Path("/data.json").write_text(data)
 len(Path("/data.json").read_text())
 ''');
-        expect(r.value?.dartValue as int, greaterThan(0));
+        expect(r.value.dartValue as int, greaterThan(0));
         print('  E2. http→fs: PASS');
 
         r = await session.execute('''
@@ -291,23 +291,23 @@ log = msg_recv("log2")
 saved = Path("/raw.txt").read_text()
 [log, len(saved)]
 ''');
-        final e3 = r.value?.dartValue as List;
+        final e3 = r.value.dartValue as List;
         expect(e3[0] as String, startsWith('Saved '));
         print('  E3. fs+template+msgbus+http: PASS');
 
         // ── F. Edge cases ────────────────────────────────────────────
 
         r = await session.execute('"x" * 100000');
-        expect((r.value?.dartValue as String).length, 100000);
+        expect((r.value.dartValue as String).length, 100000);
         print('  F1. large string (100K): PASS');
 
         r = await session.execute('list(range(1000))');
-        expect((r.value?.dartValue as List).length, 1000);
+        expect((r.value.dartValue as List).length, 1000);
         print('  F2. large list (1000): PASS');
 
         r = await session.execute('{"a": {"b": {"c": 42}}}');
         expect(
-          ((r.value?.dartValue as Map)['a'] as Map)['b'],
+          ((r.value.dartValue as Map)['a'] as Map)['b'],
           {'c': 42},
         );
         print('  F3. nested dict: PASS');
@@ -322,7 +322,7 @@ for i in range(5):
     results.append(len(http_fn()))
 results
 ''');
-        expect((r.value?.dartValue as List).length, 5);
+        expect((r.value.dartValue as List).length, 5);
         print('  F5. http × 5 loop: PASS');
 
         print('\n  ALL 25 EXPERIMENTS PASSED ✅');

--- a/test/bridge/integration/ffi_raw_bridge_http_test.dart
+++ b/test/bridge/integration/ffi_raw_bridge_http_test.dart
@@ -72,8 +72,8 @@ void main() {
 
       for (var i = 1; i <= 3; i++) {
         final result = await monty.run('http_get("$_url")');
-        print('  monty.run call $i: ${result.value?.dartValue}');
-        expect(result.value?.dartValue, isA<String>());
+        print('  monty.run call $i: ${result.value.dartValue}');
+        expect(result.value.dartValue, isA<String>());
       }
 
       bridge.dispose();
@@ -89,8 +89,8 @@ void main() {
 
       for (var i = 1; i <= 3; i++) {
         final result = await session.execute('http_get("$_url")');
-        print('  session.execute call $i: ${result.value?.dartValue}');
-        expect(result.value?.dartValue, isA<String>());
+        print('  session.execute call $i: ${result.value.dartValue}');
+        expect(result.value.dartValue, isA<String>());
       }
 
       await session.dispose();
@@ -105,8 +105,8 @@ void main() {
 
       for (var i = 1; i <= 3; i++) {
         final result = await session.execute('http_get("$_url")');
-        print('  sandbox.execute call $i: ${result.value?.dartValue}');
-        expect(result.value?.dartValue, isA<String>());
+        print('  sandbox.execute call $i: ${result.value.dartValue}');
+        expect(result.value.dartValue, isA<String>());
       }
 
       await session.dispose();

--- a/test/bridge/src/bridge/default_monty_bridge_test.dart
+++ b/test/bridge/src/bridge/default_monty_bridge_test.dart
@@ -33,6 +33,7 @@ void main() {
         mock.enqueueProgress(
           const MontyComplete(
             result: MontyResult(
+              value: MontyNull(),
               error: MontyException(
                 message: 'NameError: name "foo" is not defined',
                 lineNumber: 8,
@@ -93,6 +94,7 @@ void main() {
       mock.enqueueProgress(
         const MontyComplete(
           result: MontyResult(
+            value: MontyNull(),
             error: MontyException(
               message: 'error',
               traceback: [
@@ -147,7 +149,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await bridge.execute('slow_fail()').toList();
@@ -192,7 +196,9 @@ void main() {
           )
           // After the sync throw, bridge calls resumeWithError which yields:
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final events = await bridge.execute('explode()').toList();
@@ -225,7 +231,9 @@ void main() {
           const MontyPending(functionName: 'greet', arguments: []),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('greet()').toList();
@@ -251,7 +259,9 @@ void main() {
       mock
         ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn()').toList();
@@ -279,7 +289,9 @@ void main() {
       mock
         ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn()').toList();
@@ -307,7 +319,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn(__role__="infra")').toList();
@@ -337,7 +351,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn(__role__="infra")').toList();
@@ -361,7 +377,9 @@ void main() {
       mock
         ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn()').toList();
@@ -395,7 +413,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn(x=42, __role__="infra")').toList();
@@ -428,7 +448,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn(x=42, __role__="infra")').toList();
@@ -457,7 +479,9 @@ void main() {
       syncMock
         ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await syncBridge.execute('fn()').toList();
@@ -485,7 +509,9 @@ void main() {
       syncMock
         ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await syncBridge.execute('fn()').toList();
@@ -508,7 +534,9 @@ void main() {
       mock
         ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn()').toList();
@@ -543,7 +571,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('await async_fn()').toList();
@@ -571,7 +601,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('fn()').toList();
@@ -590,7 +622,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await bridge.execute('path.read_text()').toList();
@@ -631,7 +665,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await bridge.execute('os.getenv("APP_ENV")').toList();
@@ -667,7 +703,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await bridge.execute('path.write_text()').toList();
@@ -931,7 +969,9 @@ void main() {
     test('execute while already executing throws StateError', () async {
       // Start one execution.
       mock.enqueueProgress(
-        const MontyComplete(result: MontyResult(usage: _usage)),
+        const MontyComplete(
+          result: MontyResult(value: MontyNull(), usage: _usage),
+        ),
       );
       final stream = bridge.execute('1');
       // Try starting another before the first completes.
@@ -973,7 +1013,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final events = await bridge.execute('print()').toList();
@@ -996,7 +1038,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final events = await bridge
@@ -1025,6 +1069,7 @@ void main() {
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(
+              value: MontyNull(),
               error: MontyException(message: 'NameError'),
               usage: _usage,
             ),
@@ -1051,7 +1096,9 @@ void main() {
           const MontyPending(functionName: 'not_registered', arguments: []),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await bridge.execute('not_registered()').toList();
@@ -1091,7 +1138,9 @@ void main() {
           const MontyPending(functionName: 'need_param', arguments: []),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await syncBridge.execute('need_param()').toList();
@@ -1120,7 +1169,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await bridge.execute('need_param()').toList();
@@ -1144,7 +1195,9 @@ void main() {
       syncMock
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final events = await syncBridge.execute('code').toList();
@@ -1187,7 +1240,9 @@ void main() {
           )
           // Enqueued for resume but never consumed — throw happens first.
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final events = await failBridge.execute('greet()').toList();
@@ -1255,7 +1310,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final events = await failBridge.execute('code').toList();

--- a/test/bridge/src/bridge/event_loop_bridge_test.dart
+++ b/test/bridge/src/bridge/event_loop_bridge_test.dart
@@ -47,7 +47,9 @@ void main() {
           )
           ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final events = <BridgeEvent>[];
@@ -103,7 +105,9 @@ void main() {
           )
           ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [2]))
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         // Queue an event BEFORE execution starts.
@@ -151,7 +155,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [3]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       // Queue 3 events BEFORE execution starts.
@@ -191,7 +197,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [2]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final stream = bridge.execute('loop');
@@ -239,7 +247,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('render_ui(schema)').toList();
@@ -272,7 +282,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [2]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       await bridge.execute('code').toList();
@@ -301,6 +313,7 @@ void main() {
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(
+              value: MontyNull(),
               error: MontyException(message: 'kaboom'),
               usage: _usage,
             ),
@@ -343,6 +356,7 @@ void main() {
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(
+              value: MontyNull(),
               error: MontyException(
                 message: 'Bridge disposed while waiting for event',
               ),
@@ -374,7 +388,9 @@ void main() {
       expect(bridge.loopState, EventLoopState.idle);
 
       mock.enqueueProgress(
-        const MontyComplete(result: MontyResult(usage: _usage)),
+        const MontyComplete(
+          result: MontyResult(value: MontyNull(), usage: _usage),
+        ),
       );
 
       final stream = bridge.execute('42');
@@ -402,7 +418,9 @@ void main() {
           )
           ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final stream = bridge.execute('wait_for_event()');
@@ -439,7 +457,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final loopEvents = <BridgeEvent>[];
@@ -475,7 +495,9 @@ void main() {
         )
         ..enqueueProgress(const MontyResolveFutures(pendingCallIds: [1]))
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final loopEvents = <BridgeEvent>[];
@@ -564,6 +586,7 @@ void main() {
           ..enqueueProgress(
             const MontyComplete(
               result: MontyResult(
+                value: MontyNull(),
                 error: MontyException(message: 'script died unexpectedly'),
                 usage: _usage,
               ),
@@ -605,6 +628,7 @@ void main() {
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(
+              value: MontyNull(),
               error: MontyException(message: 'script crashed'),
               usage: _usage,
             ),
@@ -648,7 +672,9 @@ void main() {
           ),
         )
         ..enqueueProgress(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
 
       final stream = syncBridge.execute('wait_for_event()');

--- a/test/bridge/src/plugins/sandbox_plugin_test.dart
+++ b/test/bridge/src/plugins/sandbox_plugin_test.dart
@@ -15,8 +15,11 @@ const _usage = MontyResourceUsage(
 
 /// Creates a [MockMontyPlatform] that runs code to completion immediately.
 MockMontyPlatform _completingMock() {
-  return MockMontyPlatform()
-    ..enqueueProgress(const MontyComplete(result: MontyResult(usage: _usage)));
+  return MockMontyPlatform()..enqueueProgress(
+    const MontyComplete(
+      result: MontyResult(value: MontyNull(), usage: _usage),
+    ),
+  );
 }
 
 /// Creates a [MockMontyPlatform] that completes with [value] and [printOutput].
@@ -27,7 +30,7 @@ MockMontyPlatform _completingMockWithResult({
   return MockMontyPlatform()..enqueueProgress(
     MontyComplete(
       result: MontyResult(
-        value: value,
+        value: value ?? const MontyNull(),
         usage: _usage,
         printOutput: printOutput,
       ),
@@ -40,6 +43,7 @@ MockMontyPlatform _failingMock(String message) {
   return MockMontyPlatform()..enqueueProgress(
     MontyComplete(
       result: MontyResult(
+        value: const MontyNull(),
         error: MontyException(message: message),
         usage: _usage,
       ),
@@ -58,6 +62,7 @@ MockMontyPlatform _failingMockStructured({
   return MockMontyPlatform()..enqueueProgress(
     MontyComplete(
       result: MontyResult(
+        value: const MontyNull(),
         error: MontyException(
           message: message,
           filename: filename,
@@ -359,7 +364,9 @@ void main() {
 
         // Unblock and clean up.
         startCompleter.complete(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
         await plugin.onDispose();
       });
@@ -442,7 +449,9 @@ void main() {
 
         // Unblock and clean up.
         startCompleter.complete(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
         await plugin.onDispose();
       });
@@ -651,7 +660,9 @@ void main() {
         );
 
         startCompleter.complete(
-          const MontyComplete(result: MontyResult(usage: _usage)),
+          const MontyComplete(
+            result: MontyResult(value: MontyNull(), usage: _usage),
+          ),
         );
         await plugin.onDispose();
       });
@@ -689,6 +700,7 @@ void main() {
           ..enqueueProgress(
             const MontyComplete(
               result: MontyResult(
+                value: MontyNull(),
                 error: MontyException(message: 'NameError: x'),
                 usage: _usage,
                 printOutput: 'debug line\n',
@@ -774,7 +786,11 @@ void main() {
 
         // Unblock all children and dispose.
         for (final c in completers) {
-          c.complete(const MontyComplete(result: MontyResult(usage: _usage)));
+          c.complete(
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
+          );
         }
         await plugin.onDispose();
       });
@@ -839,7 +855,11 @@ void main() {
 
         // Unblock so _run() finishes.
         for (final c in completers) {
-          c.complete(const MontyComplete(result: MontyResult(usage: _usage)));
+          c.complete(
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
+          );
         }
       });
 
@@ -1485,7 +1505,11 @@ void main() {
         expect(warnRecord.attributes['maxChildren'], 1);
 
         for (final c in completers) {
-          c.complete(const MontyComplete(result: MontyResult(usage: _usage)));
+          c.complete(
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
+          );
         }
         await plugin.onDispose();
       });
@@ -1775,6 +1799,7 @@ class _DisposeBoomMock extends MontyPlatform {
     String? scriptName,
   }) async => const MontyComplete(
     result: MontyResult(
+      value: MontyNull(),
       usage: MontyResourceUsage(
         memoryBytesUsed: 1024,
         timeElapsedMs: 10,

--- a/test/ffi/ffi_core_bindings_finalizer_test.dart
+++ b/test/ffi/ffi_core_bindings_finalizer_test.dart
@@ -52,7 +52,7 @@ void main() {
       final r = await session.execute('test_fn()');
       await session.dispose();
 
-      expect(r.value?.dartValue, 'alive');
+      expect(r.value.dartValue, 'alive');
       print('  handle survived 20 prior disposals + GC pressure');
     });
 
@@ -76,7 +76,7 @@ void main() {
       final r = await s2.execute('y');
       await s2.dispose();
 
-      expect(r.value?.dartValue, 99);
+      expect(r.value.dartValue, 99);
       print('  s2 survived GC after s1 disposal');
     });
 
@@ -84,7 +84,7 @@ void main() {
       for (var i = 0; i < 100; i++) {
         final s = AgentSession();
         final r = await s.execute('$i * 2');
-        expect(r.value?.dartValue, i * 2);
+        expect(r.value.dartValue, i * 2);
         await s.dispose();
       }
       print('  100/100 rapid cycles passed');

--- a/test/ffi/integration/repl_smoke_test.dart
+++ b/test/ffi/integration/repl_smoke_test.dart
@@ -305,7 +305,7 @@ void main() {
     final value = (done as MontyComplete).result.value;
     expect(value, isA<MontyString>());
     expect(
-      (value! as MontyString).value,
+      (value as MontyString).value,
       contains('connection refused'),
     );
 

--- a/test/ffi/integration/smoke_test.dart
+++ b/test/ffi/integration/smoke_test.dart
@@ -69,7 +69,7 @@ void main() {
     final done = await monty.resumeWithError('network failure');
     expect(done, isA<MontyComplete>());
     final complete = done as MontyComplete;
-    expect(complete.result.value?.dartValue, contains('network failure'));
+    expect(complete.result.value.dartValue, contains('network failure'));
 
     await monty.dispose();
   });

--- a/test/ffi/mock_native_isolate_bindings.dart
+++ b/test/ffi/mock_native_isolate_bindings.dart
@@ -26,7 +26,7 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
 
   /// Result returned by [start].
   MontyProgress nextStartResult = const MontyComplete(
-    result: MontyResult(usage: _zeroUsage),
+    result: MontyResult(value: MontyNull(), usage: _zeroUsage),
   );
 
   /// Queue of results returned by [resume]. Dequeues on each call.
@@ -172,7 +172,9 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
     }
     if (resumeResults.isNotEmpty) return resumeResults.removeAt(0);
 
-    return const MontyComplete(result: MontyResult(usage: _zeroUsage));
+    return const MontyComplete(
+      result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+    );
   }
 
   @override
@@ -182,7 +184,9 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
       return resumeWithErrorResults.removeAt(0);
     }
 
-    return const MontyComplete(result: MontyResult(usage: _zeroUsage));
+    return const MontyComplete(
+      result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+    );
   }
 
   @override
@@ -206,7 +210,9 @@ class MockNativeIsolateBindings extends NativeIsolateBindings {
       return resolveFuturesResults.removeAt(0);
     }
 
-    return const MontyComplete(result: MontyResult(usage: _zeroUsage));
+    return const MontyComplete(
+      result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+    );
   }
 
   @override

--- a/test/ffi/monty_ffi_test.dart
+++ b/test/ffi/monty_ffi_test.dart
@@ -595,7 +595,7 @@ void main() {
       mock.nextRunResult = RunResult(tag: 0, resultJson: _okResultJson(null));
 
       final result = await monty.run('None');
-      expect(result.value, isNull);
+      expect(result.value, const MontyNull());
       expect(result.isError, isFalse);
     });
 

--- a/test/ffi/monty_native_test.dart
+++ b/test/ffi/monty_native_test.dart
@@ -108,10 +108,13 @@ void main() {
     });
 
     test('returns null value', () async {
-      mock.nextRunResult = const MontyResult(usage: _zeroUsage);
+      mock.nextRunResult = const MontyResult(
+        value: MontyNull(),
+        usage: _zeroUsage,
+      );
 
       final result = await monty.run('None');
-      expect(result.value, isNull);
+      expect(result.value, const MontyNull());
       expect(result.isError, isFalse);
     });
 
@@ -173,7 +176,7 @@ void main() {
 
     test('passes null externalFunctions when empty list', () async {
       mock.nextStartResult = const MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
+        result: MontyResult(value: MontyNull(), usage: _zeroUsage),
       );
 
       await monty.start('x', externalFunctions: []);
@@ -183,7 +186,7 @@ void main() {
 
     test('passes null externalFunctions when null', () async {
       mock.nextStartResult = const MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
+        result: MontyResult(value: MontyNull(), usage: _zeroUsage),
       );
 
       await monty.start('x');
@@ -208,7 +211,7 @@ void main() {
 
     test('applies limits', () async {
       mock.nextStartResult = const MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
+        result: MontyResult(value: MontyNull(), usage: _zeroUsage),
       );
       const limits = MontyLimits(memoryBytes: 512);
 
@@ -262,7 +265,9 @@ void main() {
 
     test('throws StateError when idle', () async {
       mock.resumeResults.add(
-        const MontyComplete(result: MontyResult(usage: _zeroUsage)),
+        const MontyComplete(
+          result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+        ),
       );
       await monty.resume(null);
 
@@ -276,7 +281,9 @@ void main() {
 
     test('passes complex return values', () async {
       mock.resumeResults.add(
-        const MontyComplete(result: MontyResult(usage: _zeroUsage)),
+        const MontyComplete(
+          result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+        ),
       );
 
       await monty.resume({
@@ -303,7 +310,9 @@ void main() {
 
     test('returns MontyComplete after error injection', () async {
       mock.resumeWithErrorResults.add(
-        const MontyComplete(result: MontyResult(usage: _zeroUsage)),
+        const MontyComplete(
+          result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+        ),
       );
 
       final progress = await monty.resumeWithError('network failure');
@@ -593,13 +602,13 @@ void main() {
 
     test('complete with null value', () async {
       mock.nextStartResult = const MontyComplete(
-        result: MontyResult(usage: _zeroUsage),
+        result: MontyResult(value: MontyNull(), usage: _zeroUsage),
       );
 
       final progress = await monty.start('None');
 
       final complete = progress as MontyComplete;
-      expect(complete.result.value, isNull);
+      expect(complete.result.value, const MontyNull());
     });
 
     test('resource usage is preserved from bindings', () async {
@@ -648,6 +657,7 @@ void main() {
 
     test('run() returns to idle after error', () async {
       mock.nextRunResult = const MontyResult(
+        value: MontyNull(),
         error: MontyException(message: 'boom'),
         usage: _zeroUsage,
       );

--- a/test/monty_test.dart
+++ b/test/monty_test.dart
@@ -33,7 +33,10 @@ void main() {
       )
       ..enqueueProgress(
         MontyComplete(
-          result: MontyResult(value: resultValue, usage: usage),
+          result: MontyResult(
+            value: resultValue ?? const MontyNull(),
+            usage: usage,
+          ),
         ),
       );
   }

--- a/test/platform/base_monty_platform_test.dart
+++ b/test/platform/base_monty_platform_test.dart
@@ -201,7 +201,7 @@ void main() {
       expect(result.isError, isTrue);
       expect(result.error?.message, 'NameError');
       expect(result.error?.excType, 'NameError');
-      expect(result.value, isNull);
+      expect(result.value, const MontyNull());
     });
   });
 
@@ -607,7 +607,7 @@ void main() {
       // Release the gate so the first run completes.
       gate.complete();
       final result = await first;
-      expect(result.value, isNull);
+      expect(result.value, const MontyNull());
       expect(platform.isIdle, isTrue);
     });
 

--- a/test/platform/mock_monty_platform_test.dart
+++ b/test/platform/mock_monty_platform_test.dart
@@ -116,7 +116,9 @@ void main() {
     });
 
     test('resume() dequeues progress and records return value', () async {
-      const complete = MontyComplete(result: MontyResult(usage: usage));
+      const complete = MontyComplete(
+        result: MontyResult(value: MontyNull(), usage: usage),
+      );
       // start() transitions idle→active; resume() requires active.
       mock
         ..enqueueProgress(
@@ -133,7 +135,9 @@ void main() {
     });
 
     test('resumeWithError() dequeues progress and records error', () async {
-      const complete = MontyComplete(result: MontyResult(usage: usage));
+      const complete = MontyComplete(
+        result: MontyResult(value: MontyNull(), usage: usage),
+      );
       mock
         ..enqueueProgress(
           const MontyPending(functionName: 'f', arguments: []),
@@ -193,7 +197,9 @@ void main() {
     // -----------------------------------------------------------------------
 
     test('resolveFutures() records results and errors, dequeues', () async {
-      const complete = MontyComplete(result: MontyResult(usage: usage));
+      const complete = MontyComplete(
+        result: MontyResult(value: MontyNull(), usage: usage),
+      );
       mock
         ..enqueueProgress(
           const MontyPending(functionName: 'f', arguments: []),
@@ -220,7 +226,9 @@ void main() {
     test('enqueueProgress dequeues in FIFO order', () async {
       const first = MontyPending(functionName: 'a', arguments: []);
       const second = MontyPending(functionName: 'b', arguments: []);
-      const third = MontyComplete(result: MontyResult(usage: usage));
+      const third = MontyComplete(
+        result: MontyResult(value: MontyNull(), usage: usage),
+      );
 
       mock
         ..enqueueProgress(first)

--- a/test/platform/monty_progress_test.dart
+++ b/test/platform/monty_progress_test.dart
@@ -707,7 +707,7 @@ void main() {
             },
           },
         });
-        expect(complete.result.value, isNull);
+        expect(complete.result.value, const MontyNull());
         expect(complete.result.error, isNotNull);
         expect(complete.result.error!.message, 'division by zero');
         expect(complete.result.isError, isTrue);

--- a/test/platform/monty_result_test.dart
+++ b/test/platform/monty_result_test.dart
@@ -34,7 +34,7 @@ void main() {
             'stack_depth_used': 3,
           },
         });
-        expect(result.value, isNull);
+        expect(result.value, const MontyNull());
         expect(result.error, const MontyException(message: 'fail'));
         expect(result.isError, isTrue);
       });
@@ -48,7 +48,7 @@ void main() {
             'stack_depth_used': 0,
           },
         });
-        expect(result.value, isNull);
+        expect(result.value, const MontyNull());
         expect(result.error, isNull);
         expect(result.printOutput, isNull);
       });
@@ -95,6 +95,7 @@ void main() {
 
       test('serializes error result', () {
         const result = MontyResult(
+          value: MontyNull(),
           error: MontyException(message: 'oops'),
           usage: usage,
         );
@@ -126,6 +127,7 @@ void main() {
 
     test('JSON round-trip for error result', () {
       const original = MontyResult(
+        value: MontyNull(),
         error: MontyException(
           message: 'SyntaxError',
           filename: 'test.py',
@@ -163,10 +165,12 @@ void main() {
 
       test('not equal when error differs', () {
         const a = MontyResult(
+          value: MontyNull(),
           error: MontyException(message: 'a'),
           usage: usage,
         );
         const b = MontyResult(
+          value: MontyNull(),
           error: MontyException(message: 'b'),
           usage: usage,
         );
@@ -227,6 +231,7 @@ void main() {
 
       test('error result', () {
         const result = MontyResult(
+          value: MontyNull(),
           error: MontyException(message: 'fail'),
           usage: usage,
         );
@@ -234,8 +239,8 @@ void main() {
       });
 
       test('null value result', () {
-        const result = MontyResult(usage: usage);
-        expect(result.toString(), 'MontyResult.value(null)');
+        const result = MontyResult(value: MontyNull(), usage: usage);
+        expect(result.toString(), 'MontyResult.value(MontyNull())');
       });
     });
 

--- a/test/platform/monty_session_test.dart
+++ b/test/platform/monty_session_test.dart
@@ -25,7 +25,7 @@ void main() {
         // First run: x = 42 — restore empty, persist {x: 42}
         _enqueueRunCycle(mock, stateToPersist: {'x': 42});
         final r1 = await session.run('x = 42');
-        expect(r1.value, isNull);
+        expect(r1.value, const MontyNull());
 
         // Verify restore got empty state on first call
         expect(mock.resumeReturnValues.first, isEmpty);
@@ -128,6 +128,7 @@ void main() {
           ..enqueueProgress(
             const MontyComplete(
               result: MontyResult(
+                value: MontyNull(),
                 usage: _usage,
                 error: MontyException(message: 'fetch not allowed'),
               ),
@@ -346,7 +347,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final p2 = await session.resumeWithError('network failure');
@@ -420,6 +423,7 @@ void main() {
           ..enqueueProgress(
             const MontyComplete(
               result: MontyResult(
+                value: MontyNull(),
                 usage: _usage,
                 error: MontyException(
                   message: 'ZeroDivisionError',
@@ -782,7 +786,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         final result = await session.run('import os');
@@ -957,7 +963,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         await session.run('pass');
@@ -1160,7 +1168,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         await s.run('open("/sandbox/test.txt")');
@@ -1199,7 +1209,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         await s.run('write("/sandbox/out.txt")');
@@ -1240,7 +1252,9 @@ void main() {
             ),
           )
           ..enqueueProgress(
-            const MontyComplete(result: MontyResult(usage: _usage)),
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _usage),
+            ),
           );
 
         await s.run('open("/sandbox/missing.txt")');
@@ -1331,7 +1345,10 @@ void _enqueueRunCycle(
     // 3. complete
     ..enqueueProgress(
       MontyComplete(
-        result: MontyResult(value: resultValue, usage: _usage),
+        result: MontyResult(
+          value: resultValue ?? const MontyNull(),
+          usage: _usage,
+        ),
       ),
     );
 }

--- a/test/platform/testing/ladder_assertions_test.dart
+++ b/test/platform/testing/ladder_assertions_test.dart
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('null value matches null expected', () {
-      assertLadderResult(null, {'id': 3, 'expected': null});
+      assertLadderResult(const MontyNull(), {'id': 3, 'expected': null});
     });
 
     test('expectedContains checks substring', () {

--- a/test/platform/testing/ladder_runner_test.dart
+++ b/test/platform/testing/ladder_runner_test.dart
@@ -88,6 +88,7 @@ void main() {
     test('fails when no exception thrown', () async {
       final mock = MockMontyPlatform()
         ..runResult = const MontyResult(
+          value: MontyNull(),
           usage: MontyResourceUsage(
             memoryBytesUsed: 0,
             timeElapsedMs: 0,

--- a/test/repl/repl_session_test.dart
+++ b/test/repl/repl_session_test.dart
@@ -48,7 +48,7 @@ void main() {
     );
 
     expect(r.value, isA<MontyString>());
-    expect((r.value! as MontyString).value, 'Hello World!');
+    expect((r.value as MontyString).value, 'Hello World!');
     await session.dispose();
   });
 
@@ -66,7 +66,7 @@ void main() {
     );
 
     expect(r.value, isA<MontyString>());
-    expect((r.value! as MontyString).value, 'avg=87.6, top=95');
+    expect((r.value as MontyString).value, 'avg=87.6, top=95');
     await session.dispose();
   });
 
@@ -84,7 +84,7 @@ void main() {
 
     expect(r.value, isA<MontyString>());
     expect(
-      (r.value! as MontyString).value,
+      (r.value as MontyString).value,
       contains('Alice'),
     );
     await session.dispose();

--- a/test/repl/repl_sse_test.dart
+++ b/test/repl/repl_sse_test.dart
@@ -58,7 +58,7 @@ void main() {
     final r3 = await session.run(
       "tmpl_render(template='Recovered {{ v }}', context={'v': 42})",
     );
-    expect((r3.value! as MontyString).value, 'Recovered 42');
+    expect((r3.value as MontyString).value, 'Recovered 42');
 
     await session.dispose();
   });
@@ -72,7 +72,7 @@ void main() {
       final r = await session.run(
         "tmpl_render(template='len={{ n }}', context={'n': len(data)})",
       );
-      expect((r.value! as MontyString).value, 'len=${i + 1}');
+      expect((r.value as MontyString).value, 'len=${i + 1}');
     }
 
     await session.dispose();

--- a/test/wasm/integration/repl_session_demo.dart
+++ b/test/wasm/integration/repl_session_demo.dart
@@ -138,7 +138,7 @@ Map<String, dynamic> _resultToJson(MontyResult result) {
   }
   return {
     'ok': true,
-    'value': result.value?.dartValue,
+    'value': result.value.dartValue,
     'print_output': result.printOutput,
   };
 }

--- a/test/wasm/monty_wasm_test.dart
+++ b/test/wasm/monty_wasm_test.dart
@@ -152,7 +152,7 @@ void main() {
       mock.nextRunResult = const WasmRunResult(ok: true);
 
       final result = await monty.run('None');
-      expect(result.value, isNull);
+      expect(result.value, const MontyNull());
       expect(result.isError, isFalse);
     });
 
@@ -649,7 +649,7 @@ void main() {
       final progress = await monty.start('None');
 
       final complete = progress as MontyComplete;
-      expect(complete.result.value, isNull);
+      expect(complete.result.value, const MontyNull());
     });
 
     test('resource usage has Dart-side wall-clock timing', () async {


### PR DESCRIPTION
## Summary

- `MontyResult.value` changes from `MontyValue?` to `MontyValue` (required, non-nullable)
- Python always returns a value — `None` is a value, not the absence of one
- `MontyNull` already existed in the sealed hierarchy; `MontyValue.fromJson(null)` and `MontyValue.fromDart(null)` both return `const MontyNull()` — no new types needed
- `MontyNull.dartValue` returns `null`, so downstream `if (x == null)` checks still work identically

## Changes

**Core type** (`lib/src/platform/monty_result.dart`):
- `final MontyValue? value` → `final MontyValue value` (required)
- `fromJson`: removes redundant `x != null ? MontyValue.fromJson(x) : null` guard
- `toJson`: `value?.toJson()` → `value.toJson()`

**Translation sites** (4 files):
- `base_monty_platform.dart`, `monty_repl.dart` — direct `MontyValue.fromJson(x)` at 4 sites
- `default_monty_bridge.dart` — `result.value?.dartValue` → `result.value.dartValue`
- `agent_session.dart`, `repl_session.dart`, `monty_session.dart` — error paths pass `value: const MontyNull()`

**Tests** (38 files, 1354 passing):
- `dart fix` removed 140 unnecessary `?.`/`!` operators on `result.value`
- `dart fix` removed 51 redundant `const` keywords
- `expect(result.value, isNull)` → `expect(result.value, const MontyNull())` (8 sites)
- `assertLadderResult` signature: `MontyValue?` → `MontyValue`

## Migration for consumers

```dart
// Before:
final x = result.value?.dartValue;
final v = result.value!.dartValue;

// After:
final x = result.value.dartValue;  // MontyNull.dartValue returns null
final v = result.value.dartValue;
```

## Test plan

- [x] `dart analyze --fatal-infos` — no issues
- [x] `dcm analyze lib/` — no issues
- [x] `dart test` — 1354 passed
- [ ] `dart test --run-skipped --tags=integration`
- [ ] `dart test --run-skipped --tags=ladder`

🤖 Generated with [Claude Code](https://claude.com/claude-code)