### PR TITLE
fix: two pre-existing integration test failures (HTTP routing + sandbox log level)

### DIFF
--- a/lib/src/bridge/plugins/sandbox_plugin.dart
+++ b/lib/src/bridge/plugins/sandbox_plugin.dart
@@ -632,7 +632,7 @@ class SandboxPlugin extends MontyPlugin {
               final truncated = errorMessage!.length > 200
                   ? '${errorMessage!.substring(0, 200)}\u2026'
                   : errorMessage!;
-              logger.warning(
+              logger.debug(
                 'Child failed',
                 attributes: {'childId': childId, 'error': truncated},
               );

--- a/test/bridge/integration/ffi_raw_bridge_http_test.dart
+++ b/test/bridge/integration/ffi_raw_bridge_http_test.dart
@@ -62,7 +62,11 @@ void main() {
   );
 
   test(
-    'Monty.run — 3 sequential HTTP calls',
+    // monty.run() is a direct platform call — it cannot dispatch bridge
+    // callbacks. External functions must be invoked via bridge.execute().
+    // This test verifies the bridge.execute() path works for 3 sequential
+    // calls (the bridge owns the callback loop; monty.run() does not).
+    'Monty.run — 3 sequential HTTP calls via bridge.execute()',
     () async {
       final monty = Monty();
       final bridge = DefaultMontyBridge(
@@ -71,9 +75,10 @@ void main() {
       )..register(_httpGetFn());
 
       for (var i = 1; i <= 3; i++) {
-        final result = await monty.run('http_get("$_url")');
-        print('  monty.run call $i: ${result.value?.dartValue}');
-        expect(result.value?.dartValue, isA<String>());
+        final events = await bridge.execute('http_get("$_url")').toList();
+        final finished = events.whereType<BridgeRunFinished>().first;
+        print('  monty.run call $i: ${finished.value}');
+        expect(finished.value, isA<String>());
       }
 
       bridge.dispose();

--- a/test/bridge/src/plugins/sandbox_plugin_test.dart
+++ b/test/bridge/src/plugins/sandbox_plugin_test.dart
@@ -1383,7 +1383,7 @@ void main() {
         expect(completedRecord.attributes['childId'], 0);
       });
 
-      test('failure logs warning with childId and error', () async {
+      test('failure logs debug with childId and error', () async {
         final plugin = SandboxPlugin(
           platformFactory: () async => _failingMock('NameError: x'),
         )..logger = StructLogBridgeLogger(logger, LogManager.instance);
@@ -1400,7 +1400,7 @@ void main() {
         final failRecord = sink.records.firstWhere(
           (r) => r.message == 'Child failed',
         );
-        expect(failRecord.level, LogLevel.warning);
+        expect(failRecord.level, LogLevel.debug);
         expect(failRecord.attributes['childId'], 0);
         expect(failRecord.attributes['error'], contains('NameError'));
       });


### PR DESCRIPTION
## Summary

Two integration tests were failing on `main` (pre-dating the non-nullable refactor):

### 1. `ffi_raw_bridge_http_test.dart: Monty.run — 3 sequential HTTP calls`

**Root cause**: `monty.run()` calls the platform directly — it never enters the bridge's callback loop. Host functions registered on a `DefaultMontyBridge` are never dispatched, so Python receives `None` instead of the HTTP response.

**Fix**: Replace `monty.run('http_get(...)')` with `bridge.execute('http_get(...)')` (which owns the callback loop) and update the test name/comment to document the architectural reason.

### 2. `sandbox_logging_test.dart: failed child logs error details`

**Root cause**: Test expected `LogLevel.debug` for the `'Child failed'` log record, but `SandboxPlugin` emitted `LogLevel.warning`. A Python exception in a child sandbox is an **expected outcome** (child code is allowed to raise errors; the parent handles them via `sandbox_await`). Logging at `warning` implies something unexpected.

**Fix**: Change `logger.warning('Child failed', ...)` → `logger.debug(...)` in `SandboxPlugin`, consistent with the other child lifecycle events (`Child bridge created`, `Child spawned`, `Child completed`, `Child freed`).

## Test plan

- [x] `test/bridge/integration/ffi_raw_bridge_http_test.dart` — all 4 tests pass
- [x] `test/bridge/integration/sandbox_logging_test.dart` — all 3 tests pass
- [x] `dart analyze --fatal-infos` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)