### PR TITLE
docs: fix broken internal links and image paths after reorganization

### DIFF
--- a/docs/architecture/oscall-vfs.md
+++ b/docs/architecture/oscall-vfs.md
@@ -8,7 +8,7 @@
 > calls by name -- LLMs know about these and generate code against them.
 > Both are registered on `MontyBridge`: `registerOs()` for the OS side,
 > `register()` / `PluginRegistry` for the tool side.
-> See [architecture.md](architecture.md) for the full tool-calling flow.
+> See [overview.md](overview.md) for the full tool-calling flow.
 
 When Python code uses `pathlib`, `os`, or `datetime`, the Rust interpreter
 yields an `OsCall` progress event instead of performing the operation

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -135,8 +135,8 @@ not from a single JSON blob.
   call flow diagram, exception contract.
 - [Error Hierarchy](error-hierarchy.md) — Sealed types, type relationships,
   source-to-type mapping, propagation through boundaries.
-- [Native Crate Architecture](native-crate.md) — Handle lifecycle, FFI boundary,
+- [Native Crate Architecture](../internal/native-crate.md) — Handle lifecycle, FFI boundary,
   tracker abstraction, PrintWriter drain.
-- [Internals](internals.md) — BaseMontyPlatform/MontyCoreBindings, capability
+- [Internals](../internal/internals.md) — BaseMontyPlatform/MontyCoreBindings, capability
   interfaces, MontySession, state machine contract, cross-language memory
   contracts, execution paths, cross-backend parity, testing strategy.

--- a/docs/architecture/plugin-system.md
+++ b/docs/architecture/plugin-system.md
@@ -8,11 +8,11 @@ first principles through production patterns.
 
 | Level | Document | What you will learn |
 |-------|----------|---------------------|
-| Intro | [Host Functions Intro](guides/host-functions-intro.md) | What host functions are, why they exist, and a 3-line "hello world" |
-| Beginner | [Host Functions Beginner](guides/host-functions-beginner.md) | `HostFunctionSchema`, typed params, validation, error handling, `BridgeEvent` stream |
-| Intermediate | [Host Functions Intermediate](guides/host-functions-intermediate.md) | `MontyPlugin`, `PluginRegistry`, namespaces, lifecycle hooks, introspection, `EventLoopBridge` |
-| Advanced | [Host Functions Advanced](guides/host-functions-advanced.md) | `SandboxPlugin`, child spawning, depth/concurrency limits, production patterns |
-| Middleware | [Bridge Middleware](guides/bridge-middleware.md) | `BridgeMiddleware`, sealed `CallRole`, onion chain, grounding, rate limiting, why `CompositePlugin` was removed |
+| Intro | [Host Functions Intro](../user/host-functions-intro.md) | What host functions are, why they exist, and a 3-line "hello world" |
+| Beginner | [Host Functions Beginner](../user/host-functions-beginner.md) | `HostFunctionSchema`, typed params, validation, error handling, `BridgeEvent` stream |
+| Intermediate | [Host Functions Intermediate](../user/host-functions-intermediate.md) | `MontyPlugin`, `PluginRegistry`, namespaces, lifecycle hooks, introspection, `EventLoopBridge` |
+| Advanced | [Host Functions Advanced](../user/host-functions-advanced.md) | `SandboxPlugin`, child spawning, depth/concurrency limits, production patterns |
+| Middleware | [Bridge Middleware](../user/bridge-middleware.md) | `BridgeMiddleware`, sealed `CallRole`, onion chain, grounding, rate limiting, why `CompositePlugin` was removed |
 
 ## Architecture at a Glance
 

--- a/docs/architecture/sandbox-architecture.md
+++ b/docs/architecture/sandbox-architecture.md
@@ -250,8 +250,7 @@ etc.) are not supported on WASM. The WASM Worker architecture needs
 multi-session support (isolated Workers per child) to enable sandboxes.
 
 **Workaround:** Use the JS-level `DartMontyBridge.run()` for one-shot
-sandbox execution (no plugin inheritance or grandchildren). See
-`repl_demo.html` for this approach.
+sandbox execution (no plugin inheritance or grandchildren). See `../repl.html` for this approach.
 
 **Planned fix:** Refactor `MontyWasm` to use `createSession()` for
 each child, giving each sandbox its own Worker. The bridge JS already

--- a/docs/help.md
+++ b/docs/help.md
@@ -1,7 +1,7 @@
 # Overview
 
 <p align="center">
-  <img src="/assets/dart_monty.jpg" alt="dart_monty" width="280">
+  <img src="assets/dart_monty.jpg" alt="dart_monty" width="280">
 </p>
 
 [Live Demo](https://runyaga.github.io/dart_monty/) | [GitHub](https://github.com/runyaga/dart_monty) | [Monty](https://github.com/pydantic/monty)
@@ -45,10 +45,10 @@ print(r.value); // 'Hello World!'
 
 ## Documentation
 
-- [**Installation**](user/install.html) — Add to your project
-- [**Architecture**](architecture/overview.html) — Module structure and internals
-- [**REPL Guide**](user/repl.html) — Stateful interactive execution
-- [**Plugins**](user/plugins.html) — Template, MessageBus, Sandbox
-- [**Host Functions**](user/host-functions-intro.html) — Custom bridge functions
-- [**Testing**](contributor/testing.html) — Run tests and quality gates
-- [**Contributor Setup**](contributor/setup.html) — Build and test the library
+- [**Installation**](user/install.md) — Add to your project
+- [**Architecture**](architecture/overview.md) — Module structure and internals
+- [**REPL Guide**](user/repl.md) — Stateful interactive execution
+- [**Plugins**](user/plugins.md) — Template, MessageBus, Sandbox
+- [**Host Functions**](user/host-functions-intro.md) — Custom bridge functions
+- [**Testing**](contributor/testing.md) — Run tests and quality gates
+- [**Contributor Setup**](contributor/setup.md) — Build and test the library

--- a/docs/internal/api-coverage-plan.md
+++ b/docs/internal/api-coverage-plan.md
@@ -12,7 +12,7 @@
 > in sections 3-5 (kwargs, full tracebacks, exception types, call_id,
 > OS calls, async/futures) are now complete. The upstream API inventory
 > (section 1) and Rust type catalog remain useful references. Coverage
-> is now approximately 75% — see the table in README.md for current status.
+> is now approximately 75% — see the table in [README.md](../../README.md) for current status.
 
 ## 1. Upstream monty Surface Area
 

--- a/docs/user/plugins.md
+++ b/docs/user/plugins.md
@@ -144,7 +144,7 @@ gets its own `MontyPlatform` and `DefaultMontyBridge`. Children
 can inherit plugins from the parent and even spawn their own
 children (grandchildren).
 
-See [sandbox-architecture.md](sandbox-architecture.md) for the
+See [Sandbox Architecture](../architecture/sandbox-architecture.md) for the
 full deep dive.
 
 ### Sandbox Functions


### PR DESCRIPTION
Comprehensive audit and fix of all internal markdown links and image paths broken by the recent documentation reorganization.