### PR TITLE
fix: three correctness bugs — register-after-attach, dispose leaks, disposed-mid-spawn

### DIFF
--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -268,6 +268,7 @@ class AgentSession {
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    if (_sharedRegistry != null) await _sharedRegistry!.disposeAll();
     _sharedBridge?.dispose();
     _schemaBridge?.dispose();
     await _sharedMonty?.dispose();
@@ -305,8 +306,9 @@ class AgentSession {
     final monty = Monty(os: _os);
     final b = _buildBridge(platform: monty.platform);
 
+    PluginRegistry? registry;
     if (_plugins != null && _plugins.isNotEmpty) {
-      final registry = PluginRegistry();
+      registry = PluginRegistry();
       _plugins.forEach(registry.register);
       await registry.attachTo(b);
     }
@@ -318,6 +320,7 @@ class AgentSession {
 
       return _extractBridgeResult(events);
     } finally {
+      if (registry != null) await registry.disposeAll();
       b.dispose();
       await monty.dispose();
     }

--- a/lib/src/bridge/bridge/plugin_registry.dart
+++ b/lib/src/bridge/bridge/plugin_registry.dart
@@ -94,9 +94,16 @@ class PluginRegistry {
   ///
   /// Throws [ArgumentError] if the namespace is empty, malformed, or exceeds
   /// 32 characters.
-  /// Throws [StateError] if the namespace is reserved, already registered, or
-  /// any function name collides with a previously registered function.
+  /// Throws [StateError] if the namespace is reserved, already registered,
+  /// any function name collides with a previously registered function, or
+  /// [attachTo] has already been called.
   void register(MontyPlugin plugin) {
+    if (_attached) {
+      throw StateError(
+        'Cannot register plugin "${plugin.namespace}" after attachTo() '
+        'has been called. Create a new PluginRegistry.',
+      );
+    }
     _validateNamespace(plugin.namespace);
     _checkFunctionCollisions(plugin);
 

--- a/lib/src/bridge/plugins/sandbox_plugin.dart
+++ b/lib/src/bridge/plugins/sandbox_plugin.dart
@@ -500,6 +500,15 @@ class SandboxPlugin extends MontyPlugin {
       code.length,
     );
 
+    // Post-await disposed check — the plugin may have been disposed while
+    // _createChildPlatformAndBridge was in flight.
+    if (_disposed) {
+      bridge.dispose();
+      await platform.dispose();
+      if (childRegistry != null) await childRegistry.disposeAll();
+      throw StateError('SandboxPlugin was disposed during child spawn.');
+    }
+
     final completer = Completer<Object?>();
     completer.future.ignore();
     logger.info(

--- a/test/bridge/integration/agent_session_test.dart
+++ b/test/bridge/integration/agent_session_test.dart
@@ -355,6 +355,83 @@ result
     });
   });
 
+  group('AgentSession plugin lifecycle (#296)', () {
+    test('dispose() calls onDispose on shared-mode plugins', () async {
+      // Regression test for #296 — dispose() never called
+      // PluginRegistry.disposeAll().
+      //
+      // Without the fix, _onDisposeCalled stays false after dispose().
+      // With the fix, disposeAll() propagates to each plugin's onDispose().
+      final plugin = _TrackingPlugin();
+      final session = AgentSession(plugins: [plugin]);
+
+      await session.execute('pass'); // triggers attachTo
+      await session.dispose();
+
+      expect(
+        plugin.onDisposeCalled,
+        isTrue,
+        reason: 'plugin.onDispose must be called when session is disposed',
+      );
+    });
+
+    test('dispose() calls onDispose even without prior execute()', () async {
+      // Plugins registered but never attached (no execute() called) must
+      // still have onDispose called — disposeAll() iterates _plugins when
+      // _attachOrder is null, so this works once disposeAll() is invoked.
+      final plugin = _TrackingPlugin();
+      final session = AgentSession(plugins: [plugin]);
+
+      await session.dispose();
+
+      expect(
+        plugin.onDisposeCalled,
+        isTrue,
+        reason: 'onDispose must be called even without a prior execute()',
+      );
+    });
+
+    test(
+      'sandbox mode: plugin onDispose called after each execute()',
+      () async {
+        // In sandbox mode a fresh PluginRegistry is created per execute() and
+        // must be disposed in the finally block regardless of success or error.
+        final plugin = _TrackingPlugin();
+        final session = AgentSession(sandbox: true, plugins: [plugin]);
+        addTearDown(session.dispose);
+
+        await session.execute('pass');
+        expect(plugin.disposeCount, 1);
+
+        await session.execute('pass');
+        expect(
+          plugin.disposeCount,
+          2,
+          reason: 'each sandboxed execute() must dispose its per-call registry',
+        );
+      },
+    );
+
+    test(
+      'sandbox mode: plugin onDispose called even when execute() throws',
+      () async {
+        // The finally block must run even on error — verifies no leak when
+        // Python raises an exception.
+        final plugin = _TrackingPlugin();
+        final session = AgentSession(sandbox: true, plugins: [plugin]);
+        addTearDown(session.dispose);
+
+        await session.execute('raise ValueError("boom")');
+
+        expect(
+          plugin.disposeCount,
+          1,
+          reason: 'registry must be disposed even when Python raises',
+        );
+      },
+    );
+  });
+
   group('AgentSession event streaming', () {
     test('executeStream emits events', () async {
       final session = AgentSession();
@@ -390,4 +467,27 @@ result
       expect(finished.value, 'Hello test!');
     });
   });
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Plugin that records how many times [onDispose] was called.
+class _TrackingPlugin extends MontyPlugin {
+  bool onDisposeCalled = false;
+  int disposeCount = 0;
+
+  @override
+  String get namespace => 'track';
+
+  @override
+  List<HostFunction> get functions => [];
+
+  @override
+  Future<void> onDispose() async {
+    await super.onDispose();
+    onDisposeCalled = true;
+    disposeCount++;
+  }
 }

--- a/test/bridge/src/bridge/plugin_registry_test.dart
+++ b/test/bridge/src/bridge/plugin_registry_test.dart
@@ -284,6 +284,25 @@ void main() {
       });
     });
 
+    group('register after attachTo', () {
+      test('throws StateError', () async {
+        final bridge = _MockBridge();
+        registry.register(_TestPlugin(namespace: 'df'));
+        await registry.attachTo(bridge);
+
+        expect(
+          () => registry.register(_TestPlugin(namespace: 'chart')),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              allOf(contains('chart'), contains('attachTo')),
+            ),
+          ),
+        );
+      });
+    });
+
     group('attachTo', () {
       test(
         'registers all functions onto bridge and calls onRegister',

--- a/test/bridge/src/plugins/sandbox_plugin_test.dart
+++ b/test/bridge/src/plugins/sandbox_plugin_test.dart
@@ -873,6 +873,57 @@ void main() {
         await plugin.onDispose();
       });
 
+      test(
+        'dispose during child creation cleans up and spawn throws',
+        () async {
+          // Regression test for #264 — post-await _disposed check in
+          // _handleSpawn.
+          //
+          // Without the fix, the child platform would be created and added to
+          // _children after onDispose() returned, leaking it permanently.
+          // With the fix, the platform is disposed and spawn throws StateError.
+          final platformCompleter = Completer<MontyPlatform>();
+          late _SlowMockPlatform createdPlatform;
+
+          final plugin = SandboxPlugin(
+            platformFactory: () async {
+              createdPlatform = _SlowMockPlatform(
+                // Platform.start() never returns — child stays alive while we
+                // test the race.
+                Completer<MontyProgress>().future,
+              );
+              platformCompleter.complete(createdPlatform);
+
+              return createdPlatform;
+            },
+          );
+          final spawn = _findHandler(plugin, 'sandbox_spawn');
+
+          // Start spawn — hangs inside _createChildPlatformAndBridge at the
+          // await platformFactory() call.
+          final spawnFuture = spawn({'code': '1'});
+
+          // Wait until the factory has been entered (platform is now being
+          // created) then dispose the plugin while spawn is in flight.
+          await platformCompleter.future;
+          await plugin.onDispose();
+
+          // spawn should throw StateError and the created platform must be
+          // disposed by the post-await cleanup.
+          await expectLater(spawnFuture, throwsStateError);
+          expect(
+            createdPlatform.isDisposed,
+            isTrue,
+            reason: 'platform created during disposed spawn must be torn down',
+          );
+          expect(
+            plugin.childrenSignal.value,
+            isEmpty,
+            reason: 'disposed-mid-spawn child must not appear in children',
+          );
+        },
+      );
+
       test('completed children are not torn down again', () async {
         final mock = _completingMock();
         final plugin = SandboxPlugin(platformFactory: () async => mock);


### PR DESCRIPTION
## Summary

- **#238** — `PluginRegistry.register()` after `attachTo()` now throws `StateError` instead of silently registering a plugin that will never be wired to a bridge
- **#296** — `AgentSession.dispose()` now calls `_sharedRegistry.disposeAll()`; sandbox mode's `_executeSandboxed()` now calls `registry.disposeAll()` in `finally` so plugins are always torn down regardless of success or error
- **#264** — `SandboxPlugin._handleSpawn` now checks `_disposed` after the `await _createChildPlatformAndBridge(...)` returns; if the plugin was disposed during that async gap the freshly created child resources are cleaned up and `StateError` is thrown

## Test plan

- [x] New regression tests for each bug — each test would fail on `main` without the fix:
  - `plugin_registry_test.dart`: `register after attachTo throws StateError`
  - `agent_session_test.dart`: 4 new plugin lifecycle tests (shared dispose, pre-execute dispose, sandbox per-call dispose, sandbox error-path dispose)
  - `sandbox_plugin_test.dart`: `dispose during child creation cleans up and spawn throws`
- [x] `dart test test/bridge/src/bridge/plugin_registry_test.dart test/bridge/src/plugins/sandbox_plugin_test.dart` — 135 passed
- [x] `dart test --run-skipped --tags=integration test/bridge/integration/agent_session_test.dart` — 32 passed
- [x] `dcm analyze lib/` — no issues

Closes #238
Closes #296
Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)