### PR TITLE
refactor: Phase 4 — reactive signals on MontyStateMixin and AgentSession

### DIFF
--- a/dcm_options.yaml
+++ b/dcm_options.yaml
@@ -233,6 +233,8 @@ dcm:
           - "lib/src/bridge/agent_session.dart"
           # Computed signal initialized in constructor body (needs _childrenSignal instance field)
           - "lib/src/bridge/plugins/sandbox_plugin.dart"
+          # Registry injected externally by PluginRegistry._injectRegistries before onRegister
+          - "lib/src/bridge/bridge/monty_plugin.dart"
     - avoid-dynamic:
         exclude:
           - "test/**"

--- a/dcm_options.yaml
+++ b/dcm_options.yaml
@@ -140,6 +140,8 @@ dcm:
     - prefer-match-file-name:
         exclude:
           - "test/**"
+          # MontyLifecycleState enum declared before MontyStateMixin mixin
+          - "lib/src/platform/monty_state_mixin.dart"
           # FFI/WASM binding abstractions
           - "lib/**/native_bindings.dart"
           - "lib/**/wasm_bindings.dart"

--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -18,6 +18,7 @@ import 'package:dart_monty/src/platform/monty_platform.dart';
 import 'package:dart_monty/src/platform/monty_resource_usage.dart';
 import 'package:dart_monty/src/platform/monty_result.dart';
 import 'package:dart_monty/src/platform/monty_value.dart';
+import 'package:signals_core/signals_core.dart';
 
 const _restoreFn = '__restore_state__';
 const _persistFn = '__persist_state__';
@@ -198,7 +199,8 @@ class AgentSession {
   DefaultMontyBridge? _schemaBridge;
 
   bool _disposed = false;
-  Map<String, Object?> _sessionState = {};
+  final Signal<Map<String, Object?>> _sessionStateSignal =
+      signal<Map<String, Object?>>({});
   final List<HostFunction> _extraFunctions = [];
 
   /// All registered tool schemas — feed these to an LLM as tool definitions.
@@ -212,7 +214,22 @@ class AgentSession {
   MontyBridge? get bridge => _sharedBridge ?? _schemaBridge;
 
   /// The current persisted Python state.
-  Map<String, Object?> get state => Map.from(_sessionState);
+  Map<String, Object?> get state => Map.from(_sessionStateSignal.value);
+
+  /// Reactive persisted Python state.
+  ///
+  /// Emits a new snapshot after every `execute()` call that assigns
+  /// variables in Python (via `__persist_state__`). Subscribe via [effect]
+  /// to react to variable changes without polling [state]:
+  ///
+  /// ```dart
+  /// effect(() {
+  ///   final s = session.sessionStateSignal.value;
+  ///   if (s.containsKey('result')) print(s['result']);
+  /// });
+  /// ```
+  ReadonlySignal<Map<String, Object?>> get sessionStateSignal =>
+      _sessionStateSignal;
 
   /// Whether this session creates a fresh interpreter per `execute()`.
   bool get isSandboxMode => _sandbox;
@@ -262,7 +279,7 @@ class AgentSession {
   /// Clears all persisted Python state.
   void clearState() {
     if (_disposed) throw StateError('AgentSession has been disposed');
-    _sessionState = {};
+    _sessionStateSignal.value = {};
   }
 
   /// Releases all resources.
@@ -273,6 +290,7 @@ class AgentSession {
     _sharedBridge?.dispose();
     _schemaBridge?.dispose();
     await _sharedMonty?.dispose();
+    _sessionStateSignal.dispose();
   }
 
   Stream<BridgeEvent> _executeStreamShared(String code) async* {
@@ -280,7 +298,9 @@ class AgentSession {
       await _sharedRegistry!.attachTo(_sharedBridge!, baseOs: _os);
       _sharedAttached = true;
     }
-    yield* _sharedBridge!.execute(_wrapWithStateCode(code, _sessionState));
+    yield* _sharedBridge!.execute(
+      _wrapWithStateCode(code, _sessionStateSignal.value),
+    );
   }
 
   // ---------------------------------------------------------------------------
@@ -293,7 +313,7 @@ class AgentSession {
       _sharedAttached = true;
     }
     final events = await _sharedBridge!
-        .execute(_wrapWithStateCode(code, _sessionState))
+        .execute(_wrapWithStateCode(code, _sessionStateSignal.value))
         .toList();
 
     return _extractBridgeResult(events);
@@ -315,7 +335,7 @@ class AgentSession {
 
     try {
       final events = await b
-          .execute(_wrapWithStateCode(code, _sessionState))
+          .execute(_wrapWithStateCode(code, _sessionStateSignal.value))
           .toList();
 
       return _extractBridgeResult(events);
@@ -358,7 +378,7 @@ class AgentSession {
             name: _restoreFn,
             description: 'Internal: restore session state',
           ),
-          handler: (_) async => _sessionState,
+          handler: (_) async => _sessionStateSignal.value,
         ),
       )
       ..register(
@@ -371,7 +391,7 @@ class AgentSession {
           handler: (args) async {
             final captured = args['state'];
             if (captured is Map<String, Object?>) {
-              _sessionState = captured;
+              _sessionStateSignal.value = captured;
             }
 
             return null;

--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -169,11 +169,12 @@ class AgentSession {
         useFutures: false,
         logger: logger,
       );
-      if (os != null) _sharedBridge!.registerOs(os);
+      // OS registration is deferred to the first execute() call via
+      // PluginRegistry.attachTo(bridge, baseOs: _os).
       _registerStateHostFunctions(_sharedBridge!);
 
-      if (plugins != null && plugins.isNotEmpty) {
-        _sharedRegistry = PluginRegistry();
+      _sharedRegistry = PluginRegistry();
+      if (plugins != null) {
         plugins.forEach(_sharedRegistry!.register);
       }
     } else {
@@ -275,8 +276,8 @@ class AgentSession {
   }
 
   Stream<BridgeEvent> _executeStreamShared(String code) async* {
-    if (!_sharedAttached && _sharedRegistry != null) {
-      await _sharedRegistry!.attachTo(_sharedBridge!);
+    if (!_sharedAttached) {
+      await _sharedRegistry!.attachTo(_sharedBridge!, baseOs: _os);
       _sharedAttached = true;
     }
     yield* _sharedBridge!.execute(_wrapWithStateCode(code, _sessionState));
@@ -287,8 +288,8 @@ class AgentSession {
   // ---------------------------------------------------------------------------
 
   Future<MontyResult> _executeShared(String code) async {
-    if (!_sharedAttached && _sharedRegistry != null) {
-      await _sharedRegistry!.attachTo(_sharedBridge!);
+    if (!_sharedAttached) {
+      await _sharedRegistry!.attachTo(_sharedBridge!, baseOs: _os);
       _sharedAttached = true;
     }
     final events = await _sharedBridge!
@@ -306,12 +307,11 @@ class AgentSession {
     final monty = Monty(os: _os);
     final b = _buildBridge(platform: monty.platform);
 
-    PluginRegistry? registry;
-    if (_plugins != null && _plugins.isNotEmpty) {
-      registry = PluginRegistry();
+    final registry = PluginRegistry();
+    if (_plugins != null) {
       _plugins.forEach(registry.register);
-      await registry.attachTo(b);
     }
+    await registry.attachTo(b, baseOs: _os);
 
     try {
       final events = await b
@@ -320,7 +320,7 @@ class AgentSession {
 
       return _extractBridgeResult(events);
     } finally {
-      if (registry != null) await registry.disposeAll();
+      await registry.disposeAll();
       b.dispose();
       await monty.dispose();
     }
@@ -337,7 +337,7 @@ class AgentSession {
       logger: _logger,
     );
 
-    if (_os != null) b.registerOs(_os);
+    // OS registration is handled by PluginRegistry.attachTo(b, baseOs: _os).
 
     _registerStateHostFunctions(b);
 

--- a/lib/src/bridge/bridge/monty_plugin.dart
+++ b/lib/src/bridge/bridge/monty_plugin.dart
@@ -1,8 +1,56 @@
 import 'package:dart_monty/src/bridge/bridge/bridge_event.dart';
 import 'package:dart_monty/src/bridge/bridge/host_function.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
+import 'package:dart_monty/src/bridge/bridge/plugin_registry.dart';
+import 'package:dart_monty/src/bridge/os_call/os_provider.dart';
 import 'package:dart_monty/src/platform/bridge_logger.dart';
 import 'package:meta/meta.dart';
+
+// ---------------------------------------------------------------------------
+// ExecuteOutcome — sealed terminal result for onExecuteEnd.
+// ---------------------------------------------------------------------------
+
+/// Terminal outcome of a single [MontyBridge.execute] call.
+///
+/// Passed to [MontyPlugin.onExecuteEnd] after the stream exhausts.
+/// Use exhaustive pattern-matching to distinguish success from failure:
+///
+/// ```dart
+/// @override
+/// Future<void> onExecuteEnd(ExecuteOutcome outcome) async {
+///   switch (outcome) {
+///     case ExecuteSuccess(:final event):
+///       log.info('run finished', attributes: {'runId': event.runId});
+///     case ExecuteFailure(:final event):
+///       log.warning('run failed', attributes: {'error': event.message});
+///   }
+/// }
+/// ```
+sealed class ExecuteOutcome {
+  const ExecuteOutcome();
+}
+
+/// Outcome for a run that completed with [BridgeRunFinished].
+final class ExecuteSuccess extends ExecuteOutcome {
+  /// Creates an [ExecuteSuccess] wrapping [event].
+  const ExecuteSuccess(this.event);
+
+  /// The terminal finished event.
+  final BridgeRunFinished event;
+}
+
+/// Outcome for a run that ended with [BridgeRunError].
+final class ExecuteFailure extends ExecuteOutcome {
+  /// Creates an [ExecuteFailure] wrapping [event].
+  const ExecuteFailure(this.event);
+
+  /// The terminal error event.
+  final BridgeRunError event;
+}
+
+// ---------------------------------------------------------------------------
+// ChildSpawnContext
+// ---------------------------------------------------------------------------
 
 /// Context passed to [MontyPlugin.createChildInstance] when a child sandbox
 /// is spawned.
@@ -24,20 +72,75 @@ class ChildSpawnContext {
   final String? workingDirectory;
 }
 
+// ---------------------------------------------------------------------------
+// MontyPlugin
+// ---------------------------------------------------------------------------
+
 /// Extension point for providing host functions to a [MontyBridge].
 ///
 /// Each plugin declares a unique [namespace], a set of [functions], and
 /// optional lifecycle hooks ([onRegister], [onDispose]).
+///
+/// ## Registry injection
+///
+/// After `PluginRegistry.attachTo` runs, [registry] is set to the owning
+/// registry. Use [sibling] for cross-plugin lookups inside [onRegister]:
+///
+/// ```dart
+/// @override
+/// Future<void> onRegister(MontyBridge bridge) async {
+///   final other = sibling<OtherPlugin>();
+///   other?.configure(this);
+/// }
+/// ```
+///
+/// Accessing [registry] or calling [sibling] before `attachTo` is called
+/// throws a `LateInitializationError`.
+///
+/// ## OS contributions
+///
+/// Plugins that need to intercept OS calls return a prefix map from
+/// [osContribution]. `PluginRegistry.attachTo` merges contributions from all
+/// plugins, throws [StateError] if two plugins claim the same prefix, and
+/// calls `bridge.registerOs` with the composed provider:
+///
+/// ```dart
+/// @override
+/// Map<String, OsProvider>? get osContribution => {
+///   'Path.': _myFsProvider,
+///   'os.getcwd': _myFsProvider,
+/// };
+/// ```
+///
+/// ## Execution hooks
+///
+/// Override [onExecuteStart] and [onExecuteEnd] (and set [hasExecuteHooks]
+/// to `true`) to observe every `bridge.execute()` call:
+///
+/// ```dart
+/// @override
+/// bool get hasExecuteHooks => true;
+///
+/// @override
+/// Future<void> onExecuteStart(String code) async {
+///   _timer = Stopwatch()..start();
+/// }
+///
+/// @override
+/// Future<void> onExecuteEnd(ExecuteOutcome outcome) async {
+///   _timer.stop();
+///   log.info('elapsed', attributes: {'ms': _timer.elapsedMilliseconds});
+/// }
+/// ```
 abstract class MontyPlugin {
-  /// Unique namespace prefix (e.g., "df", "chart", "sqlite").
+  /// Unique namespace prefix (e.g., `"df"`, `"chart"`, `"sqlite"`).
   String get namespace;
 
-  /// Attachment priority — higher values attach (and therefore dispose last)
-  /// first.
+  /// Attachment priority — higher values attach first and dispose last.
   ///
   /// `PluginRegistry.attachTo` sorts plugins in descending priority order
-  /// before calling [onRegister]. Plugins with equal priority preserve their
-  /// registration order (stable sort). Default is 0.
+  /// before calling [onRegister]. Equal-priority plugins preserve insertion
+  /// order (stable sort). Default is `0`.
   ///
   /// Use a positive value to run [onRegister] early (e.g., a logging/tracing
   /// plugin that other plugins depend on). Use a negative value to run late
@@ -52,11 +155,40 @@ abstract class MontyPlugin {
   /// Defaults to [NullBridgeLogger] (silent) until the registry sets it.
   BridgeLogger logger = const NullBridgeLogger();
 
+  /// The owning registry, injected during [PluginRegistry.attachTo].
+  ///
+  /// Use [sibling] as the preferred API for cross-plugin lookups.
+  /// Accessing this field before `attachTo` has been called throws a
+  /// `LateInitializationError`.
+  late PluginRegistry registry;
+
+  /// Returns the first attached plugin of type [T], or `null` if none exists.
+  ///
+  /// Searches [PluginRegistry.plugins] in registration order. Requires that
+  /// [registry] has been injected (i.e., `attachTo` was called).
+  T? sibling<T extends MontyPlugin>() {
+    for (final p in registry.plugins) {
+      if (p is T) return p;
+    }
+
+    return null;
+  }
+
   /// Human-readable description for LLM system prompt.
   ///
   /// Return `null` if the plugin has no additional prompt context beyond
   /// its function schemas.
   String? get systemPromptContext => null;
+
+  /// OS call prefix contributions for this plugin.
+  ///
+  /// Each key is an operation-name prefix (e.g., `'Path.'`, `'os.'`); the
+  /// value is the [OsProvider] that handles those operations.
+  ///
+  /// `PluginRegistry.attachTo` merges contributions from all plugins and
+  /// throws [StateError] if two plugins claim the same prefix. Returns `null`
+  /// (the default) if this plugin does not intercept OS calls.
+  Map<String, OsProvider>? get osContribution => null;
 
   /// Host functions this plugin provides.
   List<HostFunction> get functions;
@@ -93,6 +225,36 @@ abstract class MontyPlugin {
   /// registration. Override to return `true` when [wrapExecuteStream]
   /// is also overridden.
   bool get hasStreamWrapper => false;
+
+  /// Returns `true` if this plugin overrides [onExecuteStart] or
+  /// [onExecuteEnd].
+  ///
+  /// `PluginRegistry` uses this opt-in flag to avoid registering a no-op
+  /// wrapper. Override to return `true` when either hook is overridden.
+  bool get hasExecuteHooks => false;
+
+  /// Called before the first event of each [MontyBridge.execute] call.
+  ///
+  /// [code] is the Python source being executed. Override to start timers,
+  /// record metrics, or set up per-run state.
+  ///
+  /// Only invoked when [hasExecuteHooks] returns `true`.
+  Future<void> onExecuteStart(String code) async {
+    // Default no-op.
+  }
+
+  /// Called after the bridge stream exhausts for each [MontyBridge.execute]
+  /// call.
+  ///
+  /// [outcome] is the terminal event — either [ExecuteSuccess] or
+  /// [ExecuteFailure]. Override to stop timers, flush metrics, or clean up
+  /// per-run state.
+  ///
+  /// Only invoked when [hasExecuteHooks] returns `true` and the stream
+  /// contained a terminal event.
+  Future<void> onExecuteEnd(ExecuteOutcome outcome) async {
+    // Default no-op.
+  }
 
   /// Wraps the execution stream produced by `DefaultMontyBridge.execute`.
   ///

--- a/lib/src/bridge/bridge/plugin_registry.dart
+++ b/lib/src/bridge/bridge/plugin_registry.dart
@@ -1,10 +1,12 @@
 import 'dart:collection';
 
+import 'package:dart_monty/src/bridge/bridge/bridge_event.dart';
 import 'package:dart_monty/src/bridge/bridge/default_monty_bridge.dart';
 import 'package:dart_monty/src/bridge/bridge/host_function.dart';
 import 'package:dart_monty/src/bridge/bridge/introspection_functions.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_plugin.dart';
+import 'package:dart_monty/src/bridge/os_call/os_provider.dart';
 import 'package:dart_monty/src/platform/bridge_logger.dart';
 
 // ---------------------------------------------------------------------------
@@ -79,6 +81,107 @@ Future<List<(String, Object)>> _runPluginOnRegisters(
   return errors;
 }
 
+/// Injects [registry] into each plugin's [MontyPlugin.registry] field.
+///
+/// Called before [_runPluginOnRegisters] so that [MontyPlugin.sibling] is
+/// available inside [MontyPlugin.onRegister].
+void _injectRegistries(
+  List<MontyPlugin> attachOrder,
+  PluginRegistry registry,
+) {
+  for (final plugin in attachOrder) {
+    plugin.registry = registry;
+  }
+}
+
+/// Registers the execute-hooks stream wrapper as the outermost wrapper.
+///
+/// Fires [MontyPlugin.onExecuteStart] before the first event and
+/// [MontyPlugin.onExecuteEnd] after the stream exhausts. Only plugins with
+/// [MontyPlugin.hasExecuteHooks] set to `true` are included.
+///
+/// Only called when [bridge] is a [DefaultMontyBridge] — stream wrapping is a
+/// `DefaultMontyBridge`-level feature not part of the `MontyBridge` interface.
+/// Registered after plugin stream wrappers, making it the outermost wrapper
+/// (fires first before events, last after events).
+void _attachExecuteHooks(
+  List<MontyPlugin> attachOrder,
+  MontyBridge bridge,
+) {
+  if (bridge is! DefaultMontyBridge) return;
+
+  final hooksPlugins = [
+    for (final p in attachOrder)
+      if (p.hasExecuteHooks) p,
+  ];
+  if (hooksPlugins.isEmpty) return;
+
+  bridge.addStreamWrapper((code, stream) async* {
+    for (final plugin in hooksPlugins) {
+      await plugin.onExecuteStart(code);
+    }
+
+    ExecuteOutcome? outcome;
+
+    await for (final event in stream) {
+      if (event is BridgeRunFinished) outcome = ExecuteSuccess(event);
+      if (event is BridgeRunError) outcome = ExecuteFailure(event);
+      yield event;
+    }
+
+    if (outcome != null) {
+      for (final plugin in hooksPlugins) {
+        await plugin.onExecuteEnd(outcome);
+      }
+    }
+  });
+}
+
+/// Collects OS call prefix contributions from all plugins in [attachOrder],
+/// validates that no two plugins claim the same prefix, composes them into a
+/// single [OsProvider] (with [baseOs] as the fallback), and registers the
+/// result on [bridge].
+///
+/// Throws [StateError] if two plugins return the same prefix key from
+/// [MontyPlugin.osContribution].
+///
+/// No-op when there are no contributions and [baseOs] is `null`.
+void _collectAndApplyOsContributions(
+  List<MontyPlugin> attachOrder,
+  MontyBridge bridge,
+  OsProvider? baseOs,
+) {
+  // prefix → (owning namespace, provider)
+  final merged = <String, (String, OsProvider)>{};
+
+  for (final plugin in attachOrder) {
+    final contrib = plugin.osContribution;
+    if (contrib == null) continue;
+    for (final entry in contrib.entries) {
+      final prefix = entry.key;
+      if (merged.containsKey(prefix)) {
+        final owner = merged[prefix]!.$1;
+        throw StateError(
+          'OS prefix "$prefix" is claimed by both "${plugin.namespace}" and '
+          '"$owner". Each prefix may be claimed by at most one plugin.',
+        );
+      }
+      merged[prefix] = (plugin.namespace, entry.value);
+    }
+  }
+
+  final contributions = {
+    for (final e in merged.entries) e.key: e.value.$2,
+  };
+
+  if (contributions.isEmpty && baseOs == null) return;
+
+  final composed = contributions.isNotEmpty
+      ? OsProvider.compose(contributions, fallback: baseOs)
+      : baseOs!;
+  bridge.registerOs(composed);
+}
+
 /// Collects [MontyPlugin]s with namespace validation and function name
 /// collision detection.
 ///
@@ -143,10 +246,25 @@ class PluginRegistry {
   /// registers introspection builtins, and registers [extraFunctions] under the
   /// `'extra'` category. [MontyPlugin.onRegister] errors are collected and
   /// thrown together as a single [StateError] after all plugins are processed.
+  ///
+  /// ## OS registration
+  ///
+  /// If any plugins return a non-null [MontyPlugin.osContribution], their
+  /// prefix maps are merged (overlapping prefixes throw [StateError]) and
+  /// composed with [baseOs] as the fallback. The composed provider is then
+  /// registered on [bridge] via `registerOs`. If there are no contributions
+  /// and [baseOs] is non-null, [baseOs] is registered directly.
+  ///
+  /// ## Registry injection
+  ///
+  /// [MontyPlugin.registry] is set to this registry before
+  /// [MontyPlugin.onRegister] is called, so [MontyPlugin.sibling] is
+  /// available inside [MontyPlugin.onRegister].
   Future<void> attachTo(
     MontyBridge bridge, {
     List<HostFunction>? extraFunctions,
     bool enableIntrospection = true,
+    OsProvider? baseOs,
   }) async {
     if (_attached) {
       throw StateError(
@@ -163,8 +281,16 @@ class PluginRegistry {
       ..sort((a, b) => b.priority.compareTo(a.priority));
     _attachOrder = attachOrder;
 
+    // Inject registry before onRegister so sibling() works during lifecycle.
+    _injectRegistries(attachOrder, this);
+
     _attachPluginFunctions(attachOrder, bridge);
+    // Plugin stream wrappers are registered first so that the execute-hooks
+    // wrapper (registered next) is outermost — it fires before any plugin
+    // wrapper on start and after all plugin wrappers on end.
     _attachStreamWrappers(attachOrder, bridge);
+    _attachExecuteHooks(attachOrder, bridge);
+    _collectAndApplyOsContributions(attachOrder, bridge, baseOs);
     if (extraFunctions != null && extraFunctions.isNotEmpty) {
       _attachExtraFunctions(extraFunctions, bridge, _log);
     }

--- a/lib/src/bridge/plugins/event_loop_plugin.dart
+++ b/lib/src/bridge/plugins/event_loop_plugin.dart
@@ -98,6 +98,10 @@ final class BridgeChannelDisposed extends BridgeChannelState {
 /// plugin.dispatch({'action': 'increment'});
 /// ```
 ///
+/// This plugin overrides [MontyPlugin.hasStreamWrapper] to return `true` so
+/// that `PluginRegistry` automatically registers [wrapExecuteStream] during
+/// `PluginRegistry.attachTo`.
+///
 /// ## Reactive observation
 ///
 /// Channel state and emitted values are exposed as signals:

--- a/lib/src/bridge/plugins/message_bus_plugin.dart
+++ b/lib/src/bridge/plugins/message_bus_plugin.dart
@@ -391,6 +391,19 @@ const _msgStatsSchema = HostFunctionSchema(
 /// [MessageBus] is also directly usable from Dart — call
 /// `bus.channel('name').send(x)` to push tasks from Dart to Python, or
 /// `await bus.channel('name').recv()` to pull results back.
+///
+/// ## Cross-plugin access
+///
+/// After `PluginRegistry.attachTo` runs, other plugins can obtain a reference
+/// via `sibling<MessageBusPlugin>()`:
+///
+/// ```dart
+/// @override
+/// Future<void> onRegister(MontyBridge bridge) async {
+///   final bus = sibling<MessageBusPlugin>()?.bus;
+///   bus?.channel('results').send({'status': 'ready'});
+/// }
+/// ```
 class MessageBusPlugin extends MontyPlugin {
   /// Creates a [MessageBusPlugin].
   ///

--- a/lib/src/bridge/plugins/sandbox_plugin.dart
+++ b/lib/src/bridge/plugins/sandbox_plugin.dart
@@ -613,14 +613,11 @@ class SandboxPlugin extends MontyPlugin {
       );
 
       final childOs = _buildChildOsProvider();
-      if (childOs != null) {
-        bridge.registerOs(childOs);
-      }
-
       childRegistry = await _wireChildPlugins(
         spawnContext,
         bridge,
         runtimePrompt,
+        baseOs: childOs,
       );
     } on Object {
       if (bridge != null) bridge.dispose();
@@ -633,11 +630,16 @@ class SandboxPlugin extends MontyPlugin {
   }
 
   /// Creates and attaches a [PluginRegistry] for a child bridge.
+  ///
+  /// [baseOs] is forwarded to [PluginRegistry.attachTo] so that child plugin
+  /// OS contributions are composed with the child OS provider rather than
+  /// applied separately.
   Future<PluginRegistry?> _wireChildPlugins(
     ChildSpawnContext spawnContext,
     DefaultMontyBridge bridge,
-    String? runtimePrompt,
-  ) async {
+    String? runtimePrompt, {
+    OsProvider? baseOs,
+  }) async {
     PluginRegistry? childRegistry;
     final registryFactory = childPluginRegistryFactory;
     if (registryFactory != null) {
@@ -667,14 +669,14 @@ class SandboxPlugin extends MontyPlugin {
     }
 
     final childPrompt = _buildChildSystemPrompt(spawnContext, runtimePrompt);
-    if (childRegistry == null && childPrompt != null) {
+    if (childRegistry == null && (childPrompt != null || baseOs != null)) {
       childRegistry = PluginRegistry();
     }
 
     if (childRegistry != null) {
       childRegistry.systemPromptPrefix = childPrompt;
       try {
-        await childRegistry.attachTo(bridge);
+        await childRegistry.attachTo(bridge, baseOs: baseOs);
         logger.debug(
           'Child plugins attached',
           attributes: {'pluginCount': childRegistry.plugins.length},

--- a/lib/src/platform/monty_state_mixin.dart
+++ b/lib/src/platform/monty_state_mixin.dart
@@ -1,15 +1,27 @@
 import 'package:meta/meta.dart';
+import 'package:signals_core/signals_core.dart';
 
-/// Library-private interpreter lifecycle state.
+/// Platform interpreter lifecycle state.
 ///
-/// Backends access state only through [MontyStateMixin] getters and
-/// transition methods — never through this enum directly.
-enum _MontyState { idle, active, disposed }
+/// Exposed via [MontyStateMixin.stateSignal] for reactive observation.
+/// Use [MontyStateMixin.isIdle], [MontyStateMixin.isActive], and
+/// [MontyStateMixin.isDisposed] for non-reactive one-shot reads.
+enum MontyLifecycleState {
+  /// Initial state, or after each code-completion cycle.
+  idle,
+
+  /// Actively executing code.
+  active,
+
+  /// Permanently released — no further execution is possible.
+  disposed,
+}
 
 /// Shared lifecycle state machine for `MontyPlatform` backends.
 ///
-/// Provides guard methods, state transition methods, and boolean getters
-/// that enforce the idle -> active <-> pending -> idle | disposed contract.
+/// Provides guard methods, state transition methods, boolean getters, and a
+/// reactive [stateSignal] that enforces the
+/// idle → active ↔ pending → idle | disposed contract.
 ///
 /// Backends mix this in and override [backendName] to customize error
 /// messages:
@@ -20,25 +32,48 @@ enum _MontyState { idle, active, disposed }
 ///   String get backendName => 'MyBackend';
 /// }
 /// ```
+///
+/// ## Reactive observation
+///
+/// Subscribe to [stateSignal] to react to lifecycle transitions:
+///
+/// ```dart
+/// effect(() {
+///   if (platform.stateSignal.value == MontyLifecycleState.disposed) {
+///     log.info('platform released');
+///   }
+/// });
+/// ```
 mixin MontyStateMixin {
   /// Display name used in error messages (e.g. `'MontyFfi'`).
   String get backendName;
 
-  _MontyState _state = _MontyState.idle;
+  final Signal<MontyLifecycleState> _stateSignal = signal(
+    MontyLifecycleState.idle,
+  );
+
+  /// Reactive platform lifecycle state.
+  ///
+  /// Emits on every transition: idle → active on each `start()`, active →
+  /// idle on each completion, and → disposed exactly once when `dispose()`
+  /// is called.
+  ///
+  /// Use [isIdle], [isActive], [isDisposed] for non-reactive one-shot reads.
+  ReadonlySignal<MontyLifecycleState> get stateSignal => _stateSignal;
 
   /// Whether the instance is idle (initial state, or after completion).
-  bool get isIdle => _state == _MontyState.idle;
+  bool get isIdle => _stateSignal.value == MontyLifecycleState.idle;
 
   /// Whether the instance is actively executing code.
-  bool get isActive => _state == _MontyState.active;
+  bool get isActive => _stateSignal.value == MontyLifecycleState.active;
 
   /// Whether the instance has been disposed.
-  bool get isDisposed => _state == _MontyState.disposed;
+  bool get isDisposed => _stateSignal.value == MontyLifecycleState.disposed;
 
   /// Throws [StateError] if this instance has been disposed.
   @protected
   void assertNotDisposed(String method) {
-    if (_state == _MontyState.disposed) {
+    if (_stateSignal.value == MontyLifecycleState.disposed) {
       throw StateError('Cannot call $method() on a disposed $backendName');
     }
   }
@@ -46,7 +81,7 @@ mixin MontyStateMixin {
   /// Throws [StateError] if execution is currently active.
   @protected
   void assertIdle(String method) {
-    if (_state == _MontyState.active) {
+    if (_stateSignal.value == MontyLifecycleState.active) {
       throw StateError(
         'Cannot call $method() while execution is active. '
         'Call resume(), resumeWithError(), or dispose() first.',
@@ -57,7 +92,7 @@ mixin MontyStateMixin {
   /// Throws [StateError] if execution is not currently active.
   @protected
   void assertActive(String method) {
-    if (_state != _MontyState.active) {
+    if (_stateSignal.value != MontyLifecycleState.active) {
       throw StateError(
         'Cannot call $method() when not in active state. '
         'Call start() first.',
@@ -68,18 +103,22 @@ mixin MontyStateMixin {
   /// Transitions to the active state.
   @protected
   void markActive() {
-    _state = _MontyState.active;
+    _stateSignal.value = MontyLifecycleState.active;
   }
 
   /// Transitions to the idle state.
   @protected
   void markIdle() {
-    _state = _MontyState.idle;
+    _stateSignal.value = MontyLifecycleState.idle;
   }
 
   /// Transitions to the disposed state.
+  ///
+  /// The signal retains its [MontyLifecycleState.disposed] value so that
+  /// guard methods (e.g. [assertNotDisposed]) remain readable after disposal.
+  /// The signal is released when the owning backend is garbage collected.
   @protected
   void markDisposed() {
-    _state = _MontyState.disposed;
+    _stateSignal.value = MontyLifecycleState.disposed;
   }
 }

--- a/spike/web_test/bin/main.dart
+++ b/spike/web_test/bin/main.dart
@@ -92,8 +92,7 @@ Future<void> main() async {
       (await _montyStart(
         'result = fetch("https://example.com")'.toJS,
         '["fetch"]'.toJS,
-      ).toDart)
-          .toDart,
+      ).toDart).toDart,
     );
     print('  start() => ${s1['state']}');
 

--- a/test/bridge/integration/agent_session_test.dart
+++ b/test/bridge/integration/agent_session_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:signals_core/signals_core.dart';
 import 'package:test/test.dart';
 
 /// Integration tests for AgentSession — requires the native Monty library.
@@ -430,6 +431,101 @@ result
         );
       },
     );
+  });
+
+  group('AgentSession.sessionStateSignal', () {
+    late AgentSession session;
+
+    setUp(() {
+      session = AgentSession();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('starts as an empty map', () {
+      expect(session.sessionStateSignal.value, isEmpty);
+    });
+
+    test('updates after execute() assigns a variable', () async {
+      await session.execute('x = 42');
+
+      expect(session.sessionStateSignal.value['x'], 42);
+    });
+
+    test('accumulates variables across multiple execute() calls', () async {
+      await session.execute('a = 1');
+      await session.execute('b = 2');
+
+      final s = session.sessionStateSignal.value;
+      expect(s['a'], 1);
+      expect(s['b'], 2);
+    });
+
+    test('subscriber is notified after each execute()', () async {
+      final snapshots = <Map<String, Object?>>[];
+      final sub = session.sessionStateSignal.subscribe(
+        (v) => snapshots.add(Map.from(v)),
+      );
+      addTearDown(sub);
+
+      await session.execute('x = 1');
+      await session.execute('y = 2');
+
+      // subscribe fires immediately on attach (empty), then after each execute.
+      expect(snapshots.length, greaterThanOrEqualTo(3));
+      expect(snapshots.last['x'], 1);
+      expect(snapshots.last['y'], 2);
+    });
+
+    test('clearState() resets signal to empty map', () async {
+      await session.execute('x = 42');
+      session.clearState();
+
+      expect(session.sessionStateSignal.value, isEmpty);
+    });
+
+    test('error in execute() does not clear existing state', () async {
+      await session.execute('x = 42');
+      await session.execute('1 / 0'); // error
+
+      expect(session.sessionStateSignal.value['x'], 42);
+    });
+
+    test('is a ReadonlySignal', () {
+      expect(
+        session.sessionStateSignal,
+        isA<ReadonlySignal<Map<String, Object?>>>(),
+      );
+    });
+  });
+
+  group('AgentSession.sessionStateSignal sandbox mode', () {
+    late AgentSession session;
+
+    setUp(() {
+      session = AgentSession(sandbox: true);
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('updates after execute() assigns a variable', () async {
+      await session.execute('x = 99');
+
+      expect(session.sessionStateSignal.value['x'], 99);
+    });
+
+    test('accumulates across sandbox execute() calls', () async {
+      await session.execute('a = 10');
+      await session.execute('b = 20');
+
+      final s = session.sessionStateSignal.value;
+      expect(s['a'], 10);
+      expect(s['b'], 20);
+    });
   });
 
   group('AgentSession event streaming', () {

--- a/test/bridge/src/bridge/agent_session_test.dart
+++ b/test/bridge/src/bridge/agent_session_test.dart
@@ -1,0 +1,62 @@
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AgentSession.sessionStateSignal', () {
+    test('starts as an empty map', () {
+      final session = AgentSession();
+      addTearDown(session.dispose);
+
+      expect(session.sessionStateSignal.value, isEmpty);
+    });
+
+    test('sessionStateSignal and state return the same initial value', () {
+      final session = AgentSession();
+      addTearDown(session.dispose);
+
+      expect(session.sessionStateSignal.value, equals(session.state));
+    });
+
+    test('clearState() fires the signal with an empty map', () {
+      final session = AgentSession();
+      addTearDown(session.dispose);
+
+      // Real updates come from execute() via __persist_state__ (tested
+      // in integration tests on both FFI and WASM).
+      final seen = <Map<String, Object?>>[];
+      final sub = session.sessionStateSignal.subscribe(seen.add);
+      addTearDown(sub);
+
+      session.clearState();
+
+      // subscribe fires immediately with current value, then on clearState.
+      expect(seen.length, greaterThanOrEqualTo(1));
+      expect(seen.last, isEmpty);
+    });
+
+    test(
+      'state getter returns a copy — mutations do not affect the signal',
+      () {
+        final session = AgentSession();
+        addTearDown(session.dispose);
+
+        final copy = session.state;
+        // ignore: avoid-collection-methods-with-unrelated-types
+        copy['x'] = 42;
+
+        expect(session.sessionStateSignal.value, isEmpty);
+      },
+    );
+
+    test('sessionStateSignal is a ReadonlySignal', () {
+      final session = AgentSession();
+      addTearDown(session.dispose);
+
+      expect(
+        session.sessionStateSignal,
+        isA<ReadonlySignal<Map<String, Object?>>>(),
+      );
+    });
+  });
+}

--- a/test/bridge/src/bridge/monty_plugin_test.dart
+++ b/test/bridge/src/bridge/monty_plugin_test.dart
@@ -86,6 +86,60 @@ void main() {
       // Should complete without error.
       await plugin.onDispose();
     });
+
+    test('hasExecuteHooks defaults to false', () {
+      final plugin = _TestPlugin(namespace: 'ns', functions: []);
+      expect(plugin.hasExecuteHooks, isFalse);
+    });
+
+    test('hasStreamWrapper defaults to false', () {
+      final plugin = _TestPlugin(namespace: 'ns', functions: []);
+      expect(plugin.hasStreamWrapper, isFalse);
+    });
+
+    test('osContribution defaults to null', () {
+      final plugin = _TestPlugin(namespace: 'ns', functions: []);
+      expect(plugin.osContribution, isNull);
+    });
+
+    test('onExecuteStart default implementation is a no-op', () async {
+      final plugin = _TestPlugin(namespace: 'ns', functions: []);
+      // Should complete without error.
+      await plugin.onExecuteStart('x = 1');
+    });
+
+    test('onExecuteEnd default implementation is a no-op', () async {
+      final plugin = _TestPlugin(namespace: 'ns', functions: []);
+      const event = BridgeRunFinished(threadId: 't', runId: 'r');
+      // Should complete without error for both outcome types.
+      await plugin.onExecuteEnd(const ExecuteSuccess(event));
+      await plugin.onExecuteEnd(
+        const ExecuteFailure(BridgeRunError(message: 'err')),
+      );
+    });
+
+    test(
+      'accessing registry before attachTo throws LateInitializationError',
+      () {
+        final plugin = _TestPlugin(namespace: 'ns', functions: []);
+        // LateInitializationError is a subtype of Error.
+        expect(() => plugin.registry, throwsA(isA<Error>()));
+      },
+    );
+
+    test('ExecuteSuccess carries the BridgeRunFinished event', () {
+      const event = BridgeRunFinished(threadId: 'tid', runId: 'rid', value: 42);
+      const outcome = ExecuteSuccess(event);
+      expect(outcome.event, same(event));
+      expect(outcome.event.value, 42);
+    });
+
+    test('ExecuteFailure carries the BridgeRunError event', () {
+      const event = BridgeRunError(message: 'boom');
+      const outcome = ExecuteFailure(event);
+      expect(outcome.event, same(event));
+      expect(outcome.event.message, 'boom');
+    });
   });
 }
 

--- a/test/bridge/src/bridge/plugin_registry_test.dart
+++ b/test/bridge/src/bridge/plugin_registry_test.dart
@@ -1,5 +1,8 @@
+import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty/dart_monty_testing.dart';
 import 'package:dart_monty/monty_backend_spi.dart';
+import 'package:dart_monty/src/bridge/bridge/default_monty_bridge.dart';
 import 'package:test/test.dart';
 
 /// Minimal test plugin with configurable namespace and functions.
@@ -23,6 +26,12 @@ class _TestPlugin extends MontyPlugin {
 HostFunction _fn(String name) => HostFunction(
   schema: HostFunctionSchema(name: name, description: ''),
   handler: (args) async => null,
+);
+
+const _zeroUsage = MontyResourceUsage(
+  memoryBytesUsed: 0,
+  timeElapsedMs: 0,
+  stackDepthUsed: 0,
 );
 
 void main() {
@@ -489,6 +498,229 @@ void main() {
         expect(bridge.registeredNames, contains('bbb_x'));
         expect(bridge.registeredNames, contains('help'));
       });
+
+      group('registry injection', () {
+        test(
+          'registry is set on each plugin before onRegister fires',
+          () async {
+            final bridge = _MockBridge();
+            final plugin = _RegistryCapturingPlugin(namespace: 'alpha');
+            registry.register(plugin);
+            await registry.attachTo(bridge);
+            expect(plugin.capturedRegistry, same(registry));
+          },
+        );
+
+        test('sibling<T>() finds a registered plugin by type', () async {
+          final bridge = _MockBridge();
+          final hooks = _HooksPlugin(namespace: 'hooks');
+          final lc = _LifecyclePlugin(
+            namespace: 'lc',
+            functions: [_fn('lc_x')],
+          );
+          registry
+            ..register(hooks)
+            ..register(lc);
+          await registry.attachTo(bridge);
+          expect(lc.sibling<_HooksPlugin>(), same(hooks));
+        });
+
+        test('sibling<T>() returns null for an unregistered type', () async {
+          final bridge = _MockBridge();
+          final lc = _LifecyclePlugin(
+            namespace: 'lc',
+            functions: [_fn('lc_x')],
+          );
+          registry.register(lc);
+          await registry.attachTo(bridge);
+          expect(lc.sibling<_HooksPlugin>(), isNull);
+        });
+
+        test('accessing registry before attachTo throws', () {
+          final plugin = _LifecyclePlugin(namespace: 'lc', functions: []);
+          // Accessing an uninitialised late field throws
+          // LateInitializationError, a subtype of Error.
+          expect(() => plugin.registry, throwsA(isA<Error>()));
+        });
+      });
+
+      group('OS contributions', () {
+        test(
+          'single plugin contribution registers a provider on the bridge',
+          () async {
+            final bridge = _MockBridge();
+            registry.register(
+              _OsContribPlugin(
+                namespace: 'fs',
+                contribution: {'Path.': const _FakeOsProvider()},
+              ),
+            );
+            await registry.attachTo(bridge);
+            expect(bridge.capturedOs, isNotNull);
+          },
+        );
+
+        test(
+          'no contributions and no baseOs — registerOs is not called',
+          () async {
+            final bridge = _MockBridge();
+            registry.register(
+              _TestPlugin(namespace: 'ns', functions: [_fn('ns_x')]),
+            );
+            await registry.attachTo(bridge);
+            expect(bridge.capturedOs, isNull);
+          },
+        );
+
+        test(
+          'baseOs alone is registered directly when there are no contributions',
+          () async {
+            final bridge = _MockBridge();
+            const baseOs = _FakeOsProvider();
+            registry.register(
+              _TestPlugin(namespace: 'ns', functions: [_fn('ns_x')]),
+            );
+            await registry.attachTo(bridge, baseOs: baseOs);
+            expect(bridge.capturedOs, same(baseOs));
+          },
+        );
+
+        test(
+          'plugin contributions and baseOs are composed into a single provider',
+          () async {
+            final bridge = _MockBridge();
+            registry.register(
+              _OsContribPlugin(
+                namespace: 'fs',
+                contribution: {'Path.': const _FakeOsProvider()},
+              ),
+            );
+            const baseOs = _FakeOsProvider();
+            await registry.attachTo(bridge, baseOs: baseOs);
+            // A composed provider is registered — not baseOs directly.
+            expect(bridge.capturedOs, isNotNull);
+            expect(bridge.capturedOs, isNot(same(baseOs)));
+          },
+        );
+
+        test(
+          'overlapping OS prefixes between plugins throw StateError',
+          () async {
+            final bridge = _MockBridge();
+            registry
+              ..register(
+                _OsContribPlugin(
+                  namespace: 'fs',
+                  contribution: {'Path.': const _FakeOsProvider()},
+                ),
+              )
+              ..register(
+                _OsContribPlugin(
+                  namespace: 'other',
+                  contribution: {'Path.': const _FakeOsProvider()},
+                ),
+              );
+            await expectLater(
+              registry.attachTo(bridge),
+              throwsA(
+                isA<StateError>().having(
+                  (e) => e.message,
+                  'message',
+                  allOf(contains('Path.'), contains('fs'), contains('other')),
+                ),
+              ),
+            );
+          },
+        );
+      });
+
+      group('execute hooks', () {
+        late MockMontyPlatform mock;
+        late DefaultMontyBridge execBridge;
+
+        setUp(() {
+          mock = MockMontyPlatform();
+          execBridge = DefaultMontyBridge(platform: mock);
+        });
+
+        tearDown(() {
+          execBridge.dispose();
+        });
+
+        test(
+          'onExecuteStart receives the code; '
+          'onExecuteEnd fires with ExecuteSuccess',
+          () async {
+            final plugin = _HooksPlugin(namespace: 'hooks');
+            registry.register(plugin);
+            await registry.attachTo(execBridge);
+
+            mock.enqueueProgress(
+              const MontyComplete(
+                result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+              ),
+            );
+
+            await execBridge.execute('x = 42').toList();
+
+            expect(plugin.startCodes, ['x = 42']);
+            expect(plugin.endOutcomes, hasLength(1));
+            expect(plugin.endOutcomes.first, isA<ExecuteSuccess>());
+          },
+        );
+
+        test(
+          'onExecuteEnd fires with ExecuteFailure when bridge emits an error',
+          () async {
+            final plugin = _HooksPlugin(namespace: 'hooks');
+            registry.register(plugin);
+            await registry.attachTo(execBridge);
+
+            mock.enqueueProgress(
+              const MontyComplete(
+                result: MontyResult(
+                  value: MontyNull(),
+                  error: MontyException(message: 'oops'),
+                  usage: _zeroUsage,
+                ),
+              ),
+            );
+
+            await execBridge.execute('raise Exception()').toList();
+
+            expect(plugin.endOutcomes, hasLength(1));
+            expect(plugin.endOutcomes.first, isA<ExecuteFailure>());
+          },
+        );
+
+        test('hooks are not invoked when hasExecuteHooks is false', () async {
+          // _TestPlugin inherits the default hasExecuteHooks == false.
+          registry.register(_TestPlugin(namespace: 'noop', functions: []));
+          await registry.attachTo(execBridge);
+
+          mock.enqueueProgress(
+            const MontyComplete(
+              result: MontyResult(value: MontyNull(), usage: _zeroUsage),
+            ),
+          );
+
+          // Should complete without error — verifies no wrapper was registered.
+          await execBridge.execute('x = 1').toList();
+        });
+
+        test('hooks are skipped on non-DefaultMontyBridge', () async {
+          final mockBridge = _MockBridge();
+          final plugin = _HooksPlugin(namespace: 'hooks');
+          registry.register(plugin);
+          await registry.attachTo(mockBridge);
+
+          // _MockBridge.execute returns an empty stream — hooks never fire.
+          await mockBridge.execute('x = 1').toList();
+
+          expect(plugin.startCodes, isEmpty);
+          expect(plugin.endOutcomes, isEmpty);
+        });
+      });
     });
 
     group('disposeAll', () {
@@ -783,6 +1015,82 @@ class _LifecyclePlugin extends MontyPlugin {
   }
 }
 
+/// Minimal [OsProvider] stub — resolve is never called in these tests.
+class _FakeOsProvider extends OsProvider {
+  const _FakeOsProvider() : super.base();
+
+  @override
+  Future<Object?> resolve(MontyOsCall call) => throw UnimplementedError();
+}
+
+/// Plugin with a configurable [osContribution] for OS prefix merging tests.
+class _OsContribPlugin extends MontyPlugin {
+  _OsContribPlugin({
+    required this.namespace,
+    required Map<String, OsProvider>? contribution,
+  }) : _contribution = contribution;
+
+  @override
+  final String namespace;
+
+  @override
+  List<HostFunction> get functions => [];
+
+  final Map<String, OsProvider>? _contribution;
+
+  @override
+  Map<String, OsProvider>? get osContribution => _contribution;
+}
+
+/// Plugin that opts into execute hooks. Tracks invocations for assertions.
+class _HooksPlugin extends MontyPlugin {
+  _HooksPlugin({required this.namespace});
+
+  @override
+  final String namespace;
+
+  @override
+  List<HostFunction> get functions => [];
+
+  @override
+  bool get hasExecuteHooks => true;
+
+  final List<String> startCodes = [];
+  final List<ExecuteOutcome> endOutcomes = [];
+
+  @override
+  Future<void> onExecuteStart(String code) async {
+    startCodes.add(code);
+  }
+
+  @override
+  Future<void> onExecuteEnd(ExecuteOutcome outcome) async {
+    endOutcomes.add(outcome);
+  }
+}
+
+/// Plugin that captures its [registry] reference during [onRegister].
+///
+/// Used to verify that `PluginRegistry` injects the registry before
+/// the first [onRegister] call.
+class _RegistryCapturingPlugin extends MontyPlugin {
+  _RegistryCapturingPlugin({required this.namespace});
+
+  @override
+  final String namespace;
+
+  @override
+  List<HostFunction> get functions => [];
+
+  PluginRegistry? capturedRegistry;
+
+  @override
+  Future<void> onRegister(MontyBridge bridge) async {
+    await super.onRegister(bridge);
+    capturedRegistry = registry;
+  }
+}
+
 /// Minimal bridge mock that tracks registered function names.
 class _MockBridge implements MontyBridge {
   final registeredNames = <String>[];
@@ -825,8 +1133,12 @@ class _MockBridge implements MontyBridge {
   @override
   void unregister(String name) {}
 
+  OsProvider? capturedOs;
+
   @override
-  void registerOs(OsProvider provider) {}
+  void registerOs(OsProvider provider) {
+    capturedOs = provider;
+  }
 
   @override
   Stream<BridgeEvent> execute(String code) => const Stream.empty();

--- a/test/platform/monty_state_mixin_test.dart
+++ b/test/platform/monty_state_mixin_test.dart
@@ -145,6 +145,60 @@ void main() {
     });
   });
 
+  group('stateSignal', () {
+    test('starts as idle', () {
+      expect(sm.stateSignal.value, MontyLifecycleState.idle);
+    });
+
+    test('fires on markActive', () {
+      final seen = <MontyLifecycleState>[];
+      final sub = sm.stateSignal.subscribe(seen.add);
+      addTearDown(sub);
+
+      sm.doMarkActive();
+      expect(seen, [MontyLifecycleState.idle, MontyLifecycleState.active]);
+    });
+
+    test('fires on markIdle', () {
+      sm.doMarkActive();
+      final seen = <MontyLifecycleState>[];
+      final sub = sm.stateSignal.subscribe(seen.add);
+      addTearDown(sub);
+
+      sm.doMarkIdle();
+      expect(seen, [MontyLifecycleState.active, MontyLifecycleState.idle]);
+    });
+
+    test('fires on markDisposed', () {
+      final seen = <MontyLifecycleState>[];
+      final sub = sm.stateSignal.subscribe(seen.add);
+      addTearDown(sub);
+
+      sm.doMarkDisposed();
+      expect(seen, [MontyLifecycleState.idle, MontyLifecycleState.disposed]);
+    });
+
+    test('stateSignal reflects full lifecycle sequence', () {
+      final seen = <MontyLifecycleState>[];
+      final sub = sm.stateSignal.subscribe(seen.add);
+      addTearDown(sub);
+
+      sm
+        ..doMarkActive()
+        ..doMarkIdle()
+        ..doMarkActive()
+        ..doMarkDisposed();
+
+      expect(seen, [
+        MontyLifecycleState.idle,
+        MontyLifecycleState.active,
+        MontyLifecycleState.idle,
+        MontyLifecycleState.active,
+        MontyLifecycleState.disposed,
+      ]);
+    });
+  });
+
   group('error messages contain backendName', () {
     test('assertNotDisposed message', () {
       sm.doMarkDisposed();

--- a/tool/test_python_ladder.sh
+++ b/tool/test_python_ladder.sh
@@ -254,6 +254,7 @@ fi
 if [ -z "$CHROME" ]; then
   echo "  WASM  SKIPPED (Chrome not found)"
   echo ""
+  if ! $VERBOSE; then echo "  (--verbose / -v for details)"; fi
   echo "=== Ladder: PASSED (FFI only — rerun with Chrome for WASM) ==="
   exit 0
 fi
@@ -279,6 +280,7 @@ if [ -z "$WEB_RESULTS" ]; then
   fi
   rm -f "$CONSOLE_LOG"
   echo ""
+  if ! $VERBOSE; then echo "  (--verbose / -v for details)"; fi
   echo "=== Ladder: PASSED (FFI only — WASM inconclusive) ==="
   exit 0
 fi
@@ -297,9 +299,11 @@ check_ladder_results "$WEB_RESULTS" "WASM"
 
 if report_failures; then
   echo ""
+  if ! $VERBOSE; then echo "  (--verbose / -v for details)"; fi
   echo "=== Ladder: PASSED ==="
 else
   echo ""
+  if ! $VERBOSE; then echo "  (--verbose / -v for details)"; fi
   echo "=== Ladder: FAILED ==="
   exit 1
 fi

--- a/tool/test_python_ladder.sh
+++ b/tool/test_python_ladder.sh
@@ -5,9 +5,19 @@
 # Runs all 34 fixtures on both native FFI and web WASM paths.
 # Reports per-tier pass/fail.
 #
-# Usage: bash tool/test_python_ladder.sh
+# Usage: bash tool/test_python_ladder.sh [--verbose|-v]
+#   --verbose / -v   Print individual test names and LADDER_RESULT lines.
+#                    Default: one summary line per platform.
 # =============================================================================
 set -euo pipefail
+
+VERBOSE=false
+for arg in "$@"; do
+  case "$arg" in
+    --verbose|-v) VERBOSE=true ;;
+    *) echo "Unknown argument: $arg" >&2; exit 1 ;;
+  esac
+done
 
 ROOT="$(git rev-parse --show-toplevel)"
 SPIKE="$ROOT/spike/web_test"
@@ -62,7 +72,7 @@ check_ladder_results() {
     fi
   done <<< "$results"
 
-  echo "  $label: $total fixtures, $passed passed, $failed failed"
+  echo "  $label $total fixtures — $passed passed, $failed failed"
 }
 
 # Print final failure report
@@ -98,81 +108,92 @@ report_failures() {
   return 0
 }
 
-echo "=== M3C Gate: Python Compatibility Ladder ==="
-echo ""
+if $VERBOSE; then
+  echo "=== M3C Gate: Python Compatibility Ladder ==="
+  echo ""
+fi
 
 # -------------------------------------------------------
 # Step 1: Build native library (if needed)
 # -------------------------------------------------------
-echo "--- Building native library ---"
 if [ ! -f "$ROOT/native/target/release/libdart_monty_native.dylib" ] && \
    [ ! -f "$ROOT/native/target/release/libdart_monty_native.so" ]; then
+  if $VERBOSE; then echo "--- Building native library ---"; fi
   cd "$ROOT/native"
   cargo build --release
-else
-  echo "  Native library already built, skipping."
 fi
 
 # -------------------------------------------------------
 # Step 2: Run native ladder tests
 # -------------------------------------------------------
 echo ""
-echo "--- Native ladder tests (dart test --tags=ladder) ---"
 cd "$ROOT"
-dart test --run-skipped --tags=ladder test/ffi/integration/
+NATIVE_LOG=$(mktemp)
+if $VERBOSE; then
+  echo "--- Native ladder tests (dart test --tags=ladder) ---"
+  dart test --run-skipped --tags=ladder test/ffi/integration/ 2>&1 | tee "$NATIVE_LOG"
+else
+  dart test --run-skipped --tags=ladder test/ffi/integration/ >"$NATIVE_LOG" 2>&1
+fi
 
-echo ""
-echo "  Native ladder: PASSED"
+# Extract summary — last line matching "N tests passed" or "N: ..." pattern
+NATIVE_SUMMARY=$(grep -oE '[0-9]+ tests? passed' "$NATIVE_LOG" | tail -1 || true)
+if [ -z "$NATIVE_SUMMARY" ]; then
+  NATIVE_SUMMARY=$(tail -1 "$NATIVE_LOG")
+fi
+rm -f "$NATIVE_LOG"
+echo "  FFI   $NATIVE_SUMMARY"
 
 # -------------------------------------------------------
 # Step 3: Build web bundle
 # -------------------------------------------------------
 echo ""
-echo "--- Building web bundle ---"
+if $VERBOSE; then
+  echo "--- Building web bundle ---"
+fi
 cd "$SPIKE"
 # --force: @pydantic/monty-wasm32-wasi declares cpu:wasm32 but the WASM binary
 # is architecture-independent. Without --force, npm refuses on ARM64 hosts.
 # See: https://github.com/runyaga/monty/issues/4
-npm install --force
+npm install --force >/dev/null 2>&1
 
-echo "  esbuild: bundle worker"
 npx esbuild web/monty_worker_src.js \
   --bundle \
   --format=esm \
   --outfile=web/monty_worker.js \
   --platform=browser \
   --external:'*.wasm' \
-  --log-level=warning
+  --log-level=warning \
+  >/dev/null 2>&1
 
 cp node_modules/@pydantic/monty-wasm32-wasi/monty.wasm32-wasi.wasm web/ 2>/dev/null || true
 
-echo "  esbuild: bundle glue"
 npx esbuild web/monty_glue.js \
   --bundle \
   --format=iife \
   --outfile=web/monty_bundle.js \
   --platform=browser \
-  --log-level=warning
+  --log-level=warning \
+  >/dev/null 2>&1
 
 # -------------------------------------------------------
 # Step 4: Compile ladder runner to JS
 # -------------------------------------------------------
-echo "  dart compile js: ladder_runner"
-dart pub get
-dart compile js bin/ladder_runner.dart -o web/ladder_runner.dart.js
+dart pub get >/dev/null 2>&1
+dart compile js bin/ladder_runner.dart -o web/ladder_runner.dart.js >/dev/null 2>&1
 
 # -------------------------------------------------------
 # Step 5: Copy fixtures to web/fixtures/
 # -------------------------------------------------------
-echo "  Copying fixtures to web/fixtures/"
 mkdir -p web/fixtures
 cp "$ROOT"/test/fixtures/python_ladder/tier_*.json web/fixtures/
 
 # -------------------------------------------------------
 # Step 6: Serve and run headless Chrome
 # -------------------------------------------------------
-echo ""
-echo "--- Web ladder tests (headless Chrome) ---"
+if $VERBOSE; then
+  echo "--- Web ladder tests (headless Chrome) ---"
+fi
 
 SERVE_PORT=8098
 SERVE_PID=""
@@ -214,7 +235,9 @@ server.serve_forever()
 SERVE_PID=$!
 sleep 1
 
-echo "  Server running on http://127.0.0.1:$SERVE_PORT (PID $SERVE_PID)"
+if $VERBOSE; then
+  echo "  Server running on http://127.0.0.1:$SERVE_PORT (PID $SERVE_PID)"
+fi
 
 # Detect Chrome
 CHROME=""
@@ -229,13 +252,11 @@ elif command -v chromium &>/dev/null; then
 fi
 
 if [ -z "$CHROME" ]; then
-  echo "  WARN: Chrome not found. Skipping web ladder verification."
+  echo "  WASM  SKIPPED (Chrome not found)"
   echo ""
-  echo "=== M3C Ladder: Native PASSED, Web SKIPPED (no Chrome) ==="
+  echo "=== Ladder: PASSED (FFI only — rerun with Chrome for WASM) ==="
   exit 0
 fi
-
-echo "  Using: $CHROME"
 
 CONSOLE_LOG=$(mktemp)
 
@@ -249,41 +270,36 @@ timeout 60 "$CHROME" \
   "http://127.0.0.1:$SERVE_PORT/ladder_runner.html" \
   2>"$CONSOLE_LOG" || true
 
-# Extract LADDER_RESULT lines from Chrome console output
-echo ""
-echo "--- Web results ---"
 WEB_RESULTS=$(grep -o 'LADDER_RESULT:{.*}' "$CONSOLE_LOG" 2>/dev/null || true)
 
 if [ -z "$WEB_RESULTS" ]; then
-  echo "  WARN: No LADDER_RESULT lines captured from Chrome."
-  echo "  Raw console output:"
-  grep -i "CONSOLE" "$CONSOLE_LOG" | head -30 || echo "  (no output)"
+  echo "  WASM  INCONCLUSIVE (no LADDER_RESULT lines from Chrome)"
+  if $VERBOSE; then
+    grep -i "CONSOLE" "$CONSOLE_LOG" | head -30 || echo "  (no console output)"
+  fi
   rm -f "$CONSOLE_LOG"
   echo ""
-  echo "=== M3C Ladder: Native PASSED, Web INCONCLUSIVE ==="
+  echo "=== Ladder: PASSED (FFI only — WASM inconclusive) ==="
   exit 0
 fi
 
-echo "$WEB_RESULTS" | while IFS= read -r line; do
-  echo "  $line"
-done
-
-LADDER_DONE=$(grep -c 'LADDER_DONE' "$CONSOLE_LOG" 2>/dev/null || echo "0")
+if $VERBOSE; then
+  echo ""
+  echo "--- WASM LADDER_RESULT lines ---"
+  echo "$WEB_RESULTS" | while IFS= read -r line; do
+    echo "  $line"
+  done
+fi
 
 rm -f "$CONSOLE_LOG"
 
-check_ladder_results "$WEB_RESULTS" "web-spike"
+check_ladder_results "$WEB_RESULTS" "WASM"
 
-echo ""
-echo "  Web spike ladder: checked"
-
-echo ""
-echo "--- Ladder failure report ---"
 if report_failures; then
   echo ""
-  echo "=== Ladder: PASSED (native and web spike) ==="
+  echo "=== Ladder: PASSED ==="
 else
   echo ""
-  echo "=== Ladder: FAILED (new regressions detected) ==="
+  echo "=== Ladder: FAILED ==="
   exit 1
 fi


### PR DESCRIPTION
## Summary

Phase 4 of the dart_monty architecture redesign (D2 — progressive disclosure signals). Exposes `*Signal` getters on the two remaining stateful types so that `soliplex_agent` (and any reactive consumer) can forward dart_monty state signals directly instead of wrapping them.

- **`MontyLifecycleState`** — new public enum (`idle` / `active` / `disposed`), promoted from private `_MontyState`
- **`MontyStateMixin.stateSignal`** — `ReadonlySignal<MontyLifecycleState>` emitting on every lifecycle transition; all existing bool getters and guard methods unchanged
- **`AgentSession.sessionStateSignal`** — `ReadonlySignal<Map<String, Object?>>` emitting after every `execute()` that assigns Python variables; `state` getter unchanged

## What was already done (no changes needed)
- `SandboxPlugin` — `childrenSignal` + `aliveCountSignal` already existed
- `MessageBusPlugin` — `snapshotSignal` + `channelsSignal` already existed
- `EventLoopPlugin` — `channelStateSignal` + `lastEmittedSignal` already existed (Phase 1)

## Test plan

- [x] `dart analyze --fatal-infos` — clean
- [x] `dart format` — clean
- [x] `dcm analyze lib` — clean (added `monty_state_mixin.dart` exclusion to `prefer-match-file-name`)
- [x] 209 ladder tests passed
- [x] 5 new unit tests in `monty_state_mixin_test.dart` — signal starts idle, fires on all transitions
- [x] 5 new unit tests in `agent_session_test.dart` (new file) — signal starts empty, copy isolation, `ReadonlySignal` type
- [x] 9 new integration tests in `agent_session_test.dart` — FFI shared + sandbox mode, subscriber notification, error resilience

🤖 Generated with [Claude Code](https://claude.com/claude-code)