### PR TITLE
chore(native): upgrade monty to 0.0.12

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,75 @@ Instructions for AI coding agents working on this repository.
 dart pub get                              # Install dependencies
 dart format .                             # Format all Dart files
 dart analyze --fatal-infos                # Analyze (zero issues required)
+dcm analyze .                             # DCM lint (zero issues required)
 dart test                                 # Run unit tests
 bash tool/gate.sh                         # Run ALL quality checks
 ```
 
 See [Testing Guide](docs/contributor/testing.md) for more commands.
+
+## Test Commands
+
+### Dart unit tests
+```bash
+dart test                                 # All unit tests (VM)
+dart test --tags=ffi                      # FFI unit tests only
+```
+
+### FFI integration tests (requires built native library)
+```bash
+# Build native dylib first:
+cd native && cargo build --release
+cp target/release/libdart_monty.dylib ../assets/
+
+# Run against oracle (requires cargo build --bin oracle):
+dart test test/integration/oracle_ffi_test.dart -p vm --run-skipped
+```
+
+### WASM fixture tests (requires Chrome + built WASM/JS)
+```bash
+# Full build + test (npm, cargo wasm32-wasip1, dart compile js):
+bash tool/test_wasm.sh
+
+# Skip rebuild when assets are already current:
+bash tool/test_wasm.sh --skip-build
+
+# Run the dart2js fixture test directly (after building):
+dart test -p chrome --run-skipped --tags=wasm
+
+# Run the standalone wasm_runner.dart (headless Chrome, no dart test):
+# This uses a custom runner that prints FIXTURE_RESULT/FIXTURE_DONE lines.
+# See tool/test_wasm.sh for the full pipeline — it compiles wasm_runner.dart
+# to JS, serves it, and parses the output from Chrome.
+```
+
+### WASM oracle test (compares dart2js output vs directive expectations)
+```bash
+# wasm_fixture_test.dart — driven by # Return= / # Raise= directives
+# (unlike oracle_ffi_test which compares against a Rust oracle binary):
+dart test test/integration/wasm_fixture_test.dart -p chrome --run-skipped --tags=wasm
+```
+
+### Rust tests and linting
+```bash
+cd native
+
+# Unit + integration tests:
+cargo test
+
+# Clippy linter (zero warnings required):
+cargo clippy -- -D warnings
+
+# Format check:
+cargo fmt --check
+```
+
+### Dart linting
+```bash
+dart analyze --fatal-infos                # Zero issues required
+dcm analyze .                             # DCM rules (zero issues required)
+dart format --set-exit-if-changed .       # Format check
+```
 
 ## Architecture
 

--- a/lib/dart_monty_bridge.dart
+++ b/lib/dart_monty_bridge.dart
@@ -11,6 +11,7 @@ export 'src/bridge/bridge/host_function.dart';
 export 'src/bridge/bridge/host_function_schema.dart';
 export 'src/bridge/bridge/host_param.dart';
 export 'src/bridge/bridge/host_param_type.dart';
+export 'src/bridge/bridge/introspection_functions.dart';
 export 'src/bridge/bridge/monty_bridge.dart';
 export 'src/bridge/bridge/monty_plugin.dart';
 export 'src/bridge/bridge/plugin_registry.dart';

--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -6,6 +6,7 @@ import 'package:dart_monty/src/bridge/bridge/host_function.dart';
 import 'package:dart_monty/src/bridge/bridge/host_function_schema.dart';
 import 'package:dart_monty/src/bridge/bridge/host_param.dart';
 import 'package:dart_monty/src/bridge/bridge/host_param_type.dart';
+import 'package:dart_monty/src/bridge/bridge/introspection_functions.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_plugin.dart';
 import 'package:dart_monty/src/bridge/bridge/plugin_registry.dart';
@@ -398,5 +399,15 @@ class AgentSession {
           },
         ),
       );
+
+    // Register introspection builtins (e.g. help()) so they are available
+    // even when no PluginRegistry is attached — e.g. when functions are
+    // registered directly via AgentSession.register() without going through
+    // PluginRegistry.attachTo(). When a PluginRegistry IS later attached,
+    // re-registration is a safe no-op (bridge.register() overwrites by name,
+    // _categoryIndex is a Set so the duplicate category entry is ignored).
+    for (final fn in buildIntrospectionFunctions(target)) {
+      target.register(fn, category: introspectionCategory);
+    }
   }
 }

--- a/lib/src/bridge/plugins/storage_plugin.dart
+++ b/lib/src/bridge/plugins/storage_plugin.dart
@@ -92,14 +92,14 @@ class StoragePlugin extends MontyPlugin {
       );
     }
     await _backend.set(args['key']! as String, value);
-    unawaited(_updateSignal());
+    await _updateSignal();
 
     return null;
   }
 
   Future<Object?> _handleDelete(Map<String, Object?> args) async {
     await _backend.delete(args['key']! as String);
-    unawaited(_updateSignal());
+    await _updateSignal();
 
     return null;
   }

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -588,8 +588,8 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "monty"
-version = "0.0.10"
-source = "git+https://github.com/runyaga/monty.git?branch=runyaga%2F0.0.10#0bec01436bdede88b01dd6c5b7a77e361d040719"
+version = "0.0.12"
+source = "git+https://github.com/runyaga/monty.git?branch=runyaga%2F0.0.12#9473d87807f17eb93d0b635c7e0e64d04a79ef6e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -604,7 +604,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "postcard",
- "pyo3-build-config",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_text_size",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -10,7 +10,7 @@ name = "dart_monty_native"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-monty = { git = "https://github.com/runyaga/monty.git", branch = "runyaga/0.0.10" }
+monty = { git = "https://github.com/runyaga/monty.git", branch = "runyaga/0.0.12" }
 num-bigint = "0.4"
 num-traits = "0.2"
 serde_json = "1"

--- a/native/src/handle.rs
+++ b/native/src/handle.rs
@@ -144,7 +144,7 @@ impl MontyHandle {
         let mut buf = String::new();
         let limits = self.limits.clone().unwrap_or_else(default_limits);
         let tracker = Tracker::new(limits);
-        let result = compiled.run(vec![], tracker, PrintWriter::Collect(&mut buf));
+        let result = compiled.run(vec![], tracker, PrintWriter::CollectString(&mut buf));
 
         self.print_output.push_str(&buf);
 
@@ -466,7 +466,7 @@ impl MontyHandle {
         f: impl FnOnce(PrintWriter) -> Result<RunProgress<Tracker>, MontyException>,
     ) -> (MontyProgressTag, Option<String>) {
         let mut buf = String::new();
-        let result = f(PrintWriter::Collect(&mut buf));
+        let result = f(PrintWriter::CollectString(&mut buf));
         self.print_output.push_str(&buf);
         match result {
             Ok(progress) => self.process_progress(progress),
@@ -542,10 +542,13 @@ impl MontyHandle {
                                 name,
                                 docstring: None,
                             }),
-                            PrintWriter::Collect(&mut buf),
+                            PrintWriter::CollectString(&mut buf),
                         )
                     } else {
-                        lookup.resume(NameLookupResult::Undefined, PrintWriter::Collect(&mut buf))
+                        lookup.resume(
+                            NameLookupResult::Undefined,
+                            PrintWriter::CollectString(&mut buf),
+                        )
                     };
                     self.print_output.push_str(&buf);
                     match result {

--- a/native/src/repl_handle.rs
+++ b/native/src/repl_handle.rs
@@ -131,7 +131,7 @@ impl MontyReplHandle {
         };
 
         let mut buf = String::new();
-        let result = repl.feed_run(code, vec![], PrintWriter::Collect(&mut buf));
+        let result = repl.feed_run(code, vec![], PrintWriter::CollectString(&mut buf));
 
         self.print_output.push_str(&buf);
 
@@ -171,7 +171,7 @@ impl MontyReplHandle {
         };
 
         let mut buf = String::new();
-        let result = repl.feed_start(code, vec![], PrintWriter::Collect(&mut buf));
+        let result = repl.feed_start(code, vec![], PrintWriter::CollectString(&mut buf));
         self.print_output.push_str(&buf);
 
         match result {
@@ -194,7 +194,7 @@ impl MontyReplHandle {
                 let mut buf = String::new();
                 let result = call.resume(
                     ExtFunctionResult::Return(obj),
-                    PrintWriter::Collect(&mut buf),
+                    PrintWriter::CollectString(&mut buf),
                 );
                 self.print_output.push_str(&buf);
                 match result {
@@ -206,7 +206,7 @@ impl MontyReplHandle {
                 let mut buf = String::new();
                 let result = call.resume(
                     ExtFunctionResult::Return(obj),
-                    PrintWriter::Collect(&mut buf),
+                    PrintWriter::CollectString(&mut buf),
                 );
                 self.print_output.push_str(&buf);
                 match result {
@@ -235,7 +235,7 @@ impl MontyReplHandle {
                         monty::ExcType::RuntimeError,
                         Some(error_message.to_string()),
                     )),
-                    PrintWriter::Collect(&mut buf),
+                    PrintWriter::CollectString(&mut buf),
                 );
                 self.print_output.push_str(&buf);
                 match result {
@@ -250,7 +250,7 @@ impl MontyReplHandle {
                         monty::ExcType::RuntimeError,
                         Some(error_message.to_string()),
                     )),
-                    PrintWriter::Collect(&mut buf),
+                    PrintWriter::CollectString(&mut buf),
                 );
                 self.print_output.push_str(&buf);
                 match result {
@@ -274,7 +274,7 @@ impl MontyReplHandle {
         match state {
             ReplHandleState::Paused { call, .. } => {
                 let mut buf = String::new();
-                let result = call.resume_pending(PrintWriter::Collect(&mut buf));
+                let result = call.resume_pending(PrintWriter::CollectString(&mut buf));
                 self.print_output.push_str(&buf);
                 match result {
                     Ok(progress) => self.process_repl_progress(progress),
@@ -327,7 +327,7 @@ impl MontyReplHandle {
         }
 
         let mut buf = String::new();
-        let result = futures.resume(resolved, PrintWriter::Collect(&mut buf));
+        let result = futures.resume(resolved, PrintWriter::CollectString(&mut buf));
         self.print_output.push_str(&buf);
 
         match result {
@@ -553,10 +553,13 @@ impl MontyReplHandle {
                                 name,
                                 docstring: None,
                             }),
-                            PrintWriter::Collect(&mut buf),
+                            PrintWriter::CollectString(&mut buf),
                         )
                     } else {
-                        lookup.resume(NameLookupResult::Undefined, PrintWriter::Collect(&mut buf))
+                        lookup.resume(
+                            NameLookupResult::Undefined,
+                            PrintWriter::CollectString(&mut buf),
+                        )
                     };
                     self.print_output.push_str(&buf);
                     match result {


### PR DESCRIPTION
## Summary

- Points `native/Cargo.toml` at `runyaga/0.0.12` (= upstream `v0.0.12` tag + parse.rs debug-leak fix)
- Renames `PrintWriter::Collect` → `PrintWriter::CollectString` in `handle.rs` and `repl_handle.rs` to match the renamed variant in the 0.0.12 API
- Drops `pyo3-build-config` from `Cargo.lock` (removed upstream in 0.0.12)
- `CancellableTracker` is not present in `v0.0.12` upstream — no removal needed

## What's in `runyaga/0.0.12`

Branches from the upstream `v0.0.12` tag with one patch commit:

- **parse.rs debug-leak fix** — replaces `{other:?}` Rust debug format in `parse_unpack_target_impl` with a human-readable `ast_expr_type_name()` helper, so `arr[i], arr[j] = arr[j], arr[i]` produces `SyntaxError: invalid unpacking target: subscript (e.g. arr[i])` instead of leaking internal AST node structs into user-visible error messages.

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy` passes
- [ ] `cargo test` (151 unit tests) passes
- [ ] Rust gate (`bash tool/test_rust.sh`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)