### PR TITLE
test(native): add unit tests to reach 80%+ Rust coverage

### DIFF
--- a/native/src/convert.rs
+++ b/native/src/convert.rs
@@ -1424,4 +1424,76 @@ mod tests {
             "plain dict should not gain extra __type wrapper"
         );
     }
+
+    // --- number_to_monty_object: u64-overflow branch ---
+    // A JSON number that doesn't fit i64 but is a valid u64 (e.g. u64::MAX)
+    // falls through as_i64() and as_f64() (f64 loses precision) into the
+    // BigInt branch.  We test via a raw serde_json::Number.
+    #[test]
+    fn test_number_to_monty_u64_large() {
+        // serde_json represents u64::MAX correctly as a Number.
+        // u64::MAX doesn't fit in i64 — monty's json_to_monty_object will
+        // try as_i64() (fails), then as_f64() (lossy), so it may return Float.
+        // The important thing is it doesn't panic and returns a numeric MontyObject.
+        let val = serde_json::Value::Number(serde_json::Number::from(u64::MAX));
+        let obj = json_to_monty_object(&val);
+        match obj {
+            MontyObject::Int(_) | MontyObject::BigInt(_) | MontyObject::Float(_) => {}
+            other => panic!("expected a numeric MontyObject for u64::MAX, got {other:?}"),
+        }
+    }
+
+    // --- json_to_monty_object with unknown __type falls through to dict ---
+    #[test]
+    fn test_json_to_monty_unknown_type_becomes_dict() {
+        // An object with an unrecognised __type must produce a Dict,
+        // not panic or discard data.
+        let val = json!({"__type": "xyzzy", "data": 42});
+        let obj = json_to_monty_object(&val);
+        match obj {
+            MontyObject::Dict(pairs) => {
+                let items: Vec<_> = pairs.into_iter().collect();
+                assert!(
+                    !items.is_empty(),
+                    "unknown __type should produce a non-empty dict"
+                );
+            }
+            other => panic!("expected Dict for unknown __type, got {other:?}"),
+        }
+    }
+
+    // --- MontyObject::Cycle serializes as a plain string ---
+    // NOTE: Cycle(HeapId, String) cannot be constructed from outside the monty crate because
+    // HeapId is not pub-exported. Instead we verify Cycle output by running Python code that
+    // produces a self-referential structure, which the monty VM wraps in Cycle.
+    #[test]
+    fn test_cycle_to_json_via_execution() {
+        // Verify that dict-to-JSON handles self-referential structures without panic.
+        // The Cycle branch is exercised when monty's VM detects a reference loop.
+        use monty::{MontyRun, NoLimitTracker, PrintWriter};
+        // A self-referential list: x = []; x.append(x) → Cycle
+        let code = "x = []\nx.append(x)\nx";
+        let compiled = MontyRun::new(code.into(), "<test>", vec![]).unwrap();
+        let result = compiled.run(vec![], NoLimitTracker, PrintWriter::Disabled);
+        if let Ok(obj) = result {
+            let val = monty_object_to_json(&obj);
+            // The value is either an array (if cycle detection wraps each elem)
+            // or a string sentinel — just confirm it doesn't panic and is JSON-serializable.
+            let _ = serde_json::to_string(&val).unwrap();
+        }
+    }
+
+    // --- empty dict serializes as an empty JSON object ---
+    #[test]
+    fn test_dict_to_json_empty() {
+        let obj = MontyObject::dict(vec![]);
+        let val = monty_object_to_json(&obj);
+        // An empty dict has all-string-keys vacuously, so it becomes Value::Object({})
+        assert!(val.is_object(), "empty dict should be JSON object");
+        assert_eq!(
+            val.as_object().unwrap().len(),
+            0,
+            "empty dict should have 0 keys"
+        );
+    }
 }

--- a/native/src/error.rs
+++ b/native/src/error.rs
@@ -259,4 +259,69 @@ mod tests {
         // SAFETY: err was allocated by CString::into_raw inside to_c_string, reclaiming ownership
         unsafe { drop(CString::from_raw(err)) };
     }
+
+    #[test]
+    fn test_parse_c_str_null_ptr_null_out_error() {
+        // null ptr + null out_error: must return Err without crashing (no write attempted)
+        // SAFETY: both pointers are null; parse_c_str must guard the out_error write
+        let result = unsafe { parse_c_str(ptr::null(), "myarg", ptr::null_mut()) };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_c_str_invalid_utf8() {
+        // Build a raw C string with invalid UTF-8 bytes (0xFF is never valid in UTF-8)
+        let invalid: &[u8] = &[0xFF, 0xFE, 0x00]; // NUL-terminated but not valid UTF-8
+        let ptr = invalid.as_ptr().cast::<c_char>();
+        let mut err: *mut c_char = ptr::null_mut();
+        // SAFETY: ptr points to a NUL-terminated byte slice; to_str() will fail on 0xFF
+        let result = unsafe { parse_c_str(ptr, "myarg", &mut err) };
+        assert!(result.is_err());
+        assert!(!err.is_null());
+        // SAFETY: err was set by parse_c_str to a valid NUL-terminated C string
+        let msg = unsafe { CStr::from_ptr(err) }.to_str().unwrap();
+        assert!(
+            msg.contains("not valid UTF-8"),
+            "expected UTF-8 error, got: {msg}"
+        );
+        // SAFETY: err was allocated by CString::into_raw inside to_c_string
+        unsafe { drop(CString::from_raw(err)) };
+    }
+
+    #[test]
+    fn test_parse_c_str_invalid_utf8_null_out_error() {
+        // Invalid UTF-8 + null out_error: must return Err without crashing
+        let invalid: &[u8] = &[0xFF, 0x00];
+        let ptr = invalid.as_ptr().cast::<c_char>();
+        // SAFETY: ptr is a NUL-terminated byte sequence; out_error is null (skip write)
+        let result = unsafe { parse_c_str(ptr, "myarg", ptr::null_mut()) };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_monty_exception_to_json_no_traceback() {
+        // A freshly constructed exception has no traceback — the traceback
+        // block should be omitted entirely (no "filename", "line_number",
+        // "traceback" keys in the JSON).
+        let exc = MontyException::new(ExcType::ValueError, Some("no frames".into()));
+        let json = monty_exception_to_json(&exc);
+        let obj = json.as_object().unwrap();
+
+        assert!(obj["message"].as_str().unwrap().contains("no frames"));
+        assert_eq!(obj["exc_type"].as_str().unwrap(), "ValueError");
+
+        // No traceback frames → legacy single-frame keys must be absent
+        assert!(
+            obj.get("filename").is_none(),
+            "expected no filename key when traceback is empty"
+        );
+        assert!(
+            obj.get("line_number").is_none(),
+            "expected no line_number key when traceback is empty"
+        );
+        assert!(
+            obj.get("traceback").is_none(),
+            "expected no traceback key when traceback is empty"
+        );
+    }
 }

--- a/native/src/handle.rs
+++ b/native/src/handle.rs
@@ -1409,4 +1409,222 @@ outer()
         let result: Value = serde_json::from_str(handle.complete_result_json().unwrap()).unwrap();
         assert_eq!(result["value"], "limited_response");
     }
+
+    // --- OsCall state tests ---
+
+    fn os_call_code() -> &'static str {
+        "from pathlib import Path\np = Path('test.txt')\np.read_text()"
+    }
+
+    #[test]
+    fn test_os_call_pauses_handle() {
+        let mut handle = MontyHandle::new(os_call_code().into(), vec![], None).unwrap();
+        let (tag, err) = handle.start();
+        assert_eq!(tag, MontyProgressTag::OsCall);
+        assert!(err.is_none());
+    }
+
+    #[test]
+    fn test_os_call_fn_name() {
+        let mut handle = MontyHandle::new(os_call_code().into(), vec![], None).unwrap();
+        handle.start();
+        let name = handle.os_call_fn_name();
+        assert!(name.is_some(), "expected os_call_fn_name to be Some");
+        assert!(
+            name.unwrap().contains("read_text") || name.unwrap().contains("Path"),
+            "expected a Path-related OsCall, got: {:?}",
+            name
+        );
+    }
+
+    #[test]
+    fn test_os_call_args_json() {
+        let mut handle = MontyHandle::new(os_call_code().into(), vec![], None).unwrap();
+        handle.start();
+        let args = handle.os_call_args_json();
+        assert!(args.is_some());
+        // args should be a valid JSON array
+        let _: Value = serde_json::from_str(args.unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_os_call_kwargs_json() {
+        let mut handle = MontyHandle::new(os_call_code().into(), vec![], None).unwrap();
+        handle.start();
+        let kwargs = handle.os_call_kwargs_json();
+        assert!(kwargs.is_some());
+        let _: Value = serde_json::from_str(kwargs.unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_os_call_id() {
+        let mut handle = MontyHandle::new(os_call_code().into(), vec![], None).unwrap();
+        handle.start();
+        let id = handle.os_call_id();
+        assert!(id.is_some());
+    }
+
+    #[test]
+    fn test_os_call_accessors_wrong_state() {
+        let handle = MontyHandle::new("2 + 2".into(), vec![], None).unwrap();
+        assert!(handle.os_call_fn_name().is_none());
+        assert!(handle.os_call_args_json().is_none());
+        assert!(handle.os_call_kwargs_json().is_none());
+        assert!(handle.os_call_id().is_none());
+    }
+
+    #[test]
+    fn test_resume_from_os_call_with_value() {
+        let code = r#"
+from pathlib import Path
+p = Path('test.txt')
+result = p.read_text()
+result
+"#;
+        let mut handle = MontyHandle::new(code.into(), vec![], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::OsCall);
+
+        // Resume with a fake file content
+        let (tag, _) = handle.resume("\"file contents here\"");
+        assert_eq!(tag, MontyProgressTag::Complete);
+        let result: Value = serde_json::from_str(handle.complete_result_json().unwrap()).unwrap();
+        assert_eq!(result["value"], "file contents here");
+    }
+
+    #[test]
+    fn test_resume_from_os_call_with_error() {
+        let code = r#"
+from pathlib import Path
+p = Path('missing.txt')
+try:
+    result = p.read_text()
+except Exception as e:
+    result = str(e)
+result
+"#;
+        let mut handle = MontyHandle::new(code.into(), vec![], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::OsCall);
+
+        let (tag, _) = handle.resume_with_error("file not found");
+        assert_eq!(tag, MontyProgressTag::Complete);
+        let result: Value = serde_json::from_str(handle.complete_result_json().unwrap()).unwrap();
+        assert!(result["value"].as_str().unwrap().contains("file not found"));
+    }
+
+    #[test]
+    fn test_resume_with_error_not_paused_or_oscall() {
+        let mut handle = MontyHandle::new("2 + 2".into(), vec![], None).unwrap();
+        // handle is in Ready state — not Paused or OsCall
+        let (tag, err) = handle.resume_with_error("boom");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("not in Paused or OsCall state"));
+    }
+
+    // --- Resume futures with invalid errors JSON ---
+
+    #[test]
+    fn test_resume_futures_invalid_errors_json() {
+        let mut handle =
+            MontyHandle::new(async_code_single().into(), vec!["fetch".into()], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::Pending);
+        let (tag, _) = handle.resume_as_future();
+        assert_eq!(tag, MontyProgressTag::ResolveFutures);
+
+        let (tag, err) = handle.resume_futures("{}", "not-valid-json{{{");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("invalid errors JSON"));
+    }
+
+    #[test]
+    fn test_resume_futures_invalid_call_id_in_results() {
+        let mut handle =
+            MontyHandle::new(async_code_single().into(), vec!["fetch".into()], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::Pending);
+        let (tag, _) = handle.resume_as_future();
+        assert_eq!(tag, MontyProgressTag::ResolveFutures);
+
+        // Non-numeric call_id in results
+        let (tag, err) = handle.resume_futures("{\"not-a-number\":42}", "{}");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("invalid call_id"));
+    }
+
+    #[test]
+    fn test_resume_futures_invalid_call_id_in_errors() {
+        let mut handle =
+            MontyHandle::new(async_code_single().into(), vec!["fetch".into()], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::Pending);
+        let (tag, _) = handle.resume_as_future();
+        assert_eq!(tag, MontyProgressTag::ResolveFutures);
+
+        // Non-numeric call_id in errors
+        let (tag, err) = handle.resume_futures("{}", "{\"not-a-number\":\"err\"}");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("invalid call_id"));
+    }
+
+    // --- Kwargs passthrough ---
+
+    #[test]
+    fn test_pending_kwargs_with_values() {
+        // Python: ext_fn(x=1, y=2) — kwargs should appear in kwargs_json
+        let code = "result = ext_fn(x=10, y=20)\nresult";
+        let mut handle = MontyHandle::new(code.into(), vec!["ext_fn".into()], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let kwargs_str = handle.pending_fn_kwargs_json().unwrap();
+        let kwargs: Value = serde_json::from_str(kwargs_str).unwrap();
+        // kwargs should be an object with x and y
+        assert!(kwargs.is_object(), "kwargs should be JSON object");
+        assert_eq!(kwargs["x"], json!(10));
+        assert_eq!(kwargs["y"], json!(20));
+    }
+
+    // --- NameLookup with known ext_fn ---
+
+    #[test]
+    fn test_name_lookup_known_ext_fn() {
+        // When ext_fn is registered, NameLookup resolves to a Function variant.
+        // This exercises the `ext_fn_names.contains(&name)` branch.
+        let code = "result = ext_fn(99)\nresult";
+        let mut handle = MontyHandle::new(code.into(), vec!["ext_fn".into()], None).unwrap();
+        let (tag, err) = handle.start();
+        // Should pause at the function call — NameLookup was auto-resolved
+        assert_eq!(tag, MontyProgressTag::Pending);
+        assert!(err.is_none());
+        assert_eq!(handle.pending_fn_name(), Some("ext_fn"));
+
+        let (tag, _) = handle.resume("99");
+        assert_eq!(tag, MontyProgressTag::Complete);
+        let result: Value = serde_json::from_str(handle.complete_result_json().unwrap()).unwrap();
+        assert_eq!(result["value"], json!(99));
+    }
+
+    // --- Debug impl ---
+
+    #[test]
+    fn test_debug_impl() {
+        let handle = MontyHandle::new("2 + 2".into(), vec![], None).unwrap();
+        let debug_str = format!("{handle:?}");
+        assert!(debug_str.contains("MontyHandle"));
+    }
+
+    // --- build_result_json invalid usage_json fallback ---
+
+    #[test]
+    fn test_build_result_json_invalid_usage_json_fallback() {
+        // When usage_json is invalid, falls back to zeros object
+        let result = build_result_json(&json!(42), None, "not-valid-json", "");
+        let parsed: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["value"], 42);
+        assert!(parsed["usage"].is_object());
+        // Should have fallen back to defaults
+        assert_eq!(parsed["usage"]["memory_bytes_used"], 0);
+    }
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1221,3 +1221,1232 @@ pub unsafe extern "C" fn monty_dealloc(ptr: *mut u8, size: usize) {
     // SAFETY: ptr was allocated by monty_alloc with the same layout (size, align=1)
     unsafe { std::alloc::dealloc(ptr, layout) };
 }
+
+// ---------------------------------------------------------------------------
+// FFI unit tests
+//
+// These tests call the `#[no_mangle]` entry points directly using raw
+// pointers, mirroring what a Dart/C caller does. Each test frees every
+// heap allocation it receives so that address-sanitiser or Miri runs stay
+// clean. String inputs are created with `CString::new(...).unwrap().into_raw()`
+// and reclaimed after the FFI call; string outputs are freed with
+// `monty_string_free`; byte buffers with `monty_bytes_free`.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod ffi_tests {
+    use super::*;
+    use std::ffi::{CStr, CString};
+    use std::ptr;
+
+    // --- Helpers -----------------------------------------------------------
+
+    fn c(s: &str) -> *mut std::ffi::c_char {
+        CString::new(s).unwrap().into_raw()
+    }
+
+    unsafe fn free_c(p: *mut std::ffi::c_char) {
+        if !p.is_null() {
+            // SAFETY: p was produced by CString::into_raw
+            drop(unsafe { CString::from_raw(p) });
+        }
+    }
+
+    unsafe fn c_str(p: *const std::ffi::c_char) -> &'static str {
+        // SAFETY: p is a valid NUL-terminated C string from our FFI
+        unsafe { CStr::from_ptr(p) }.to_str().unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_create
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_create_null_code() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: passing null code — must return NULL and set error message
+        let h = unsafe { monty_create(ptr::null(), ptr::null(), ptr::null(), &mut err) };
+        assert!(h.is_null());
+        assert!(!err.is_null());
+        // SAFETY: err is a valid NUL-terminated C string set by monty_create
+        let msg = unsafe { c_str(err) };
+        assert!(
+            msg.contains("NULL"),
+            "error should mention NULL, got: {msg}"
+        );
+        // SAFETY: monty_string_free reclaims the C string allocated by to_c_string
+        unsafe { monty_string_free(err) };
+    }
+
+    #[test]
+    fn ffi_create_null_code_null_out_error() {
+        // null code + null out_error: must return NULL without crashing
+        // SAFETY: both pointers are null; monty_create must guard both writes
+        let h = unsafe { monty_create(ptr::null(), ptr::null(), ptr::null(), ptr::null_mut()) };
+        assert!(h.is_null());
+    }
+
+    #[test]
+    fn ffi_create_syntax_error() {
+        let code = c("def");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is a valid NUL-terminated C string
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(h.is_null());
+        assert!(!err.is_null());
+        // SAFETY: monty_string_free reclaims the allocation
+        unsafe {
+            monty_string_free(err);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_create_simple() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is a valid NUL-terminated C string
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+        assert!(err.is_null());
+        // SAFETY: h was created by monty_create; monty_free reclaims it
+        unsafe {
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_create_with_ext_fns() {
+        let code = c("result = my_fn(1)\nresult");
+        let ext = c("my_fn");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: both C strings are valid
+        let h = unsafe { monty_create(code, ext, ptr::null(), &mut err) };
+        assert!(!h.is_null());
+        // SAFETY: h was created by monty_create
+        unsafe {
+            monty_free(h);
+            free_c(code);
+            free_c(ext);
+        }
+    }
+
+    #[test]
+    fn ffi_create_with_empty_ext_fns() {
+        let code = c("2 + 2");
+        let ext = c("");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: both C strings are valid
+        let h = unsafe { monty_create(code, ext, ptr::null(), &mut err) };
+        assert!(!h.is_null());
+        // SAFETY: h was created by monty_create
+        unsafe {
+            monty_free(h);
+            free_c(code);
+            free_c(ext);
+        }
+    }
+
+    #[test]
+    fn ffi_create_with_script_name() {
+        let code = c("1/0");
+        let name = c("test_script.py");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: both C strings are valid
+        let h = unsafe { monty_create(code, ptr::null(), name, &mut err) };
+        assert!(!h.is_null());
+        // SAFETY: h was created by monty_create
+        unsafe {
+            monty_free(h);
+            free_c(code);
+            free_c(name);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_free
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_free_null() {
+        // SAFETY: passing null to monty_free must be a no-op
+        unsafe { monty_free(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn ffi_free_double_free() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is a valid C string
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+        // SAFETY: first free is legitimate
+        unsafe { monty_free(h) };
+        // SAFETY: second free must be a safe no-op (pointer no longer in LIVE_HANDLES)
+        unsafe { monty_free(h) };
+        unsafe { free_c(code) };
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_run
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_run_null_handle() {
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle — must return Error and set error message
+        let tag = unsafe { monty_run(ptr::null_mut(), &mut result, &mut err) };
+        assert_eq!(tag, MontyResultTag::Error);
+        assert!(!err.is_null());
+        // SAFETY: err was allocated by to_c_string
+        unsafe { monty_string_free(err) };
+    }
+
+    #[test]
+    fn ffi_run_null_handle_null_out_error() {
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle + null error_msg — must return Error without crashing
+        let tag = unsafe { monty_run(ptr::null_mut(), &mut result, ptr::null_mut()) };
+        assert_eq!(tag, MontyResultTag::Error);
+    }
+
+    #[test]
+    fn ffi_run_success() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut run_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is a valid live handle
+        let tag = unsafe { monty_run(h, &mut result, &mut run_err) };
+        assert_eq!(tag, MontyResultTag::Ok);
+        assert!(!result.is_null());
+        assert!(run_err.is_null());
+
+        // SAFETY: result is a valid JSON C string from monty_run
+        let json_str = unsafe { c_str(result) };
+        let parsed: serde_json::Value = serde_json::from_str(json_str).unwrap();
+        assert_eq!(parsed["value"], serde_json::json!(4));
+
+        // SAFETY: free allocations
+        unsafe {
+            monty_string_free(result);
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_run_null_out_params() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        // SAFETY: both out-params are null — should not crash
+        let tag = unsafe { monty_run(h, ptr::null_mut(), ptr::null_mut()) };
+        assert_eq!(tag, MontyResultTag::Ok);
+
+        // SAFETY: free
+        unsafe {
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_run_error() {
+        let code = c("1/0");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut run_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is valid
+        let tag = unsafe { monty_run(h, &mut result, &mut run_err) };
+        assert_eq!(tag, MontyResultTag::Error);
+        assert!(!run_err.is_null());
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(result);
+            monty_string_free(run_err);
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_start / monty_resume / monty_resume_with_error
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_start_null_handle() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_start(ptr::null_mut(), &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(!err.is_null());
+        // SAFETY: err is a valid C string
+        unsafe { monty_string_free(err) };
+    }
+
+    #[test]
+    fn ffi_start_success() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is valid
+        let tag = unsafe { monty_start(h, &mut start_err) };
+        assert_eq!(tag, MontyProgressTag::Complete);
+        assert!(start_err.is_null());
+
+        // SAFETY: free
+        unsafe {
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_resume_null_handle() {
+        let val = c("42");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_resume(ptr::null_mut(), val, &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            free_c(val);
+        }
+    }
+
+    #[test]
+    fn ffi_resume_null_value_json() {
+        let code = c("result = my_fn(1)\nresult");
+        let ext = c("my_fn");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code and ext are valid
+        let h = unsafe { monty_create(code, ext, ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is valid
+        let tag = unsafe { monty_start(h, &mut start_err) };
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let mut resume_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null value_json — should return Error
+        let tag = unsafe { monty_resume(h, ptr::null(), &mut resume_err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(!resume_err.is_null());
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(resume_err);
+            monty_free(h);
+            free_c(code);
+            free_c(ext);
+        }
+    }
+
+    #[test]
+    fn ffi_start_resume_cycle() {
+        let code = c("result = my_fn(1)\nresult");
+        let ext = c("my_fn");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: both are valid C strings
+        let h = unsafe { monty_create(code, ext, ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is valid
+        let tag = unsafe { monty_start(h, &mut start_err) };
+        assert_eq!(tag, MontyProgressTag::Pending);
+        assert!(start_err.is_null());
+
+        // Read pending state via FFI accessors
+        // SAFETY: h is in Paused state
+        let fn_name_ptr = unsafe { monty_pending_fn_name(h) };
+        assert!(!fn_name_ptr.is_null());
+        let fn_name = unsafe { c_str(fn_name_ptr) };
+        assert_eq!(fn_name, "my_fn");
+        // SAFETY: fn_name_ptr was allocated by to_c_string
+        unsafe { monty_string_free(fn_name_ptr) };
+
+        let val = c("99");
+        let mut resume_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is in Paused state, val is valid JSON
+        let tag = unsafe { monty_resume(h, val, &mut resume_err) };
+        assert_eq!(tag, MontyProgressTag::Complete);
+        assert!(resume_err.is_null());
+
+        // SAFETY: h is in Complete state
+        let result_ptr = unsafe { monty_complete_result_json(h) };
+        assert!(!result_ptr.is_null());
+        let result_str = unsafe { c_str(result_ptr) };
+        let parsed: serde_json::Value = serde_json::from_str(result_str).unwrap();
+        assert_eq!(parsed["value"], serde_json::json!(99));
+        // SAFETY: result_ptr was allocated by to_c_string
+        unsafe { monty_string_free(result_ptr) };
+
+        // SAFETY: free
+        unsafe {
+            monty_free(h);
+            free_c(code);
+            free_c(ext);
+            free_c(val);
+        }
+    }
+
+    #[test]
+    fn ffi_resume_with_error_null_handle() {
+        let msg = c("boom");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_resume_with_error(ptr::null_mut(), msg, &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            free_c(msg);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Pending accessor FFI functions — null handle returns NULL / MAX / -1
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_pending_accessors_null_handle() {
+        // SAFETY: null handles — all must return safe sentinel values
+        let fn_name = unsafe { monty_pending_fn_name(ptr::null()) };
+        assert!(fn_name.is_null());
+
+        let args = unsafe { monty_pending_fn_args_json(ptr::null()) };
+        assert!(args.is_null());
+
+        let kwargs = unsafe { monty_pending_fn_kwargs_json(ptr::null()) };
+        assert!(kwargs.is_null());
+
+        let call_id = unsafe { monty_pending_call_id(ptr::null()) };
+        assert_eq!(call_id, u32::MAX);
+
+        let method = unsafe { monty_pending_method_call(ptr::null()) };
+        assert_eq!(method, -1);
+    }
+
+    #[test]
+    fn ffi_os_call_accessors_null_handle() {
+        // SAFETY: null handles — all must return safe sentinel values
+        let name = unsafe { monty_os_call_fn_name(ptr::null()) };
+        assert!(name.is_null());
+
+        let args = unsafe { monty_os_call_args_json(ptr::null()) };
+        assert!(args.is_null());
+
+        let kwargs = unsafe { monty_os_call_kwargs_json(ptr::null()) };
+        assert!(kwargs.is_null());
+
+        let id = unsafe { monty_os_call_id(ptr::null()) };
+        assert_eq!(id, u32::MAX);
+    }
+
+    #[test]
+    fn ffi_complete_accessors_null_handle() {
+        // SAFETY: null handles — sentinels
+        let result = unsafe { monty_complete_result_json(ptr::null()) };
+        assert!(result.is_null());
+
+        let is_err = unsafe { monty_complete_is_error(ptr::null()) };
+        assert_eq!(is_err, -1);
+    }
+
+    #[test]
+    fn ffi_pending_future_call_ids_null_handle() {
+        // SAFETY: null handle — must return null
+        let ptr = unsafe { monty_pending_future_call_ids(ptr::null()) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn ffi_pending_accessors_in_wrong_state() {
+        // In Ready (not Paused) state, all accessors return NULL/MAX/-1
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        // SAFETY: h is in Ready state
+        let fn_name = unsafe { monty_pending_fn_name(h) };
+        assert!(fn_name.is_null());
+
+        let args = unsafe { monty_pending_fn_args_json(h) };
+        assert!(args.is_null());
+
+        let call_id = unsafe { monty_pending_call_id(h) };
+        assert_eq!(call_id, u32::MAX);
+
+        let method = unsafe { monty_pending_method_call(h) };
+        assert_eq!(method, -1);
+
+        // SAFETY: free
+        unsafe {
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_complete_is_error_false() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is valid
+        let tag = unsafe { monty_start(h, &mut start_err) };
+        assert_eq!(tag, MontyProgressTag::Complete);
+
+        // SAFETY: h is in Complete state (not error)
+        let is_err = unsafe { monty_complete_is_error(h) };
+        assert_eq!(is_err, 0); // 0 = success
+
+        // SAFETY: free
+        unsafe {
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_complete_is_error_true() {
+        let code = c("1/0");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is valid
+        let tag = unsafe { monty_start(h, &mut start_err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: start_err contains the error message
+        unsafe { monty_string_free(start_err) };
+
+        // SAFETY: h is in Complete state (with error)
+        let is_err = unsafe { monty_complete_is_error(h) };
+        assert_eq!(is_err, 1); // 1 = error
+
+        // SAFETY: free
+        unsafe {
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_snapshot / monty_restore
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_snapshot_null_handle() {
+        let mut out_len: usize = 0;
+        // SAFETY: null handle — must return null
+        let ptr = unsafe { monty_snapshot(ptr::null(), &mut out_len) };
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn ffi_snapshot_null_out_len() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        // SAFETY: null out_len — monty_snapshot must guard this
+        let ptr = unsafe { monty_snapshot(h, ptr::null_mut()) };
+        assert!(ptr.is_null(), "null out_len should cause null return");
+
+        // SAFETY: free
+        unsafe {
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_snapshot_and_restore() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let mut out_len: usize = 0;
+        // SAFETY: h is valid, out_len is a writable usize
+        let snap_ptr = unsafe { monty_snapshot(h, &mut out_len) };
+        assert!(!snap_ptr.is_null());
+        assert!(out_len > 0);
+
+        let mut restore_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: snap_ptr points to out_len bytes of valid snapshot data
+        let h2 = unsafe { monty_restore(snap_ptr, out_len, &mut restore_err) };
+        assert!(!h2.is_null());
+        assert!(restore_err.is_null());
+
+        // Run the restored handle
+        let mut run_result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut run_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h2 is valid
+        let tag = unsafe { monty_run(h2, &mut run_result, &mut run_err) };
+        assert_eq!(tag, MontyResultTag::Ok);
+        // SAFETY: run_result is a valid JSON C string
+        let result_str = unsafe { c_str(run_result) };
+        let parsed: serde_json::Value = serde_json::from_str(result_str).unwrap();
+        assert_eq!(parsed["value"], serde_json::json!(4));
+
+        // SAFETY: free all allocations
+        unsafe {
+            monty_string_free(run_result);
+            monty_bytes_free(snap_ptr, out_len);
+            monty_free(h2);
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_restore_null_data() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null data — must return null and set error
+        let h = unsafe { monty_restore(ptr::null(), 0, &mut err) };
+        assert!(h.is_null());
+        assert!(!err.is_null());
+        // SAFETY: err is a valid C string
+        unsafe { monty_string_free(err) };
+    }
+
+    #[test]
+    fn ffi_restore_invalid_bytes() {
+        let bad: &[u8] = &[0, 1, 2, 3, 4];
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: bad.as_ptr() points to len=5 bytes of invalid snapshot data
+        let h = unsafe { monty_restore(bad.as_ptr(), bad.len(), &mut err) };
+        assert!(h.is_null());
+        assert!(!err.is_null());
+        // SAFETY: err is a valid C string
+        unsafe { monty_string_free(err) };
+    }
+
+    // -----------------------------------------------------------------------
+    // Resource limit setters — null handle is a no-op
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_set_limits_null_handle() {
+        // SAFETY: null handles — must be no-ops
+        unsafe {
+            monty_set_memory_limit(ptr::null_mut(), 1024 * 1024);
+            monty_set_time_limit_ms(ptr::null_mut(), 5000);
+            monty_set_stack_limit(ptr::null_mut(), 100);
+        }
+    }
+
+    #[test]
+    fn ffi_set_limits_then_run() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: code is valid
+        let h = unsafe { monty_create(code, ptr::null(), ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        // SAFETY: h is valid
+        unsafe {
+            monty_set_memory_limit(h, 10 * 1024 * 1024);
+            monty_set_time_limit_ms(h, 5000);
+            monty_set_stack_limit(h, 200);
+        }
+
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut run_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is valid with limits configured
+        let tag = unsafe { monty_run(h, &mut result, &mut run_err) };
+        assert_eq!(tag, MontyResultTag::Ok);
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(result);
+            monty_free(h);
+            free_c(code);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // REPL FFI lifecycle
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_repl_create_null_script_name() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name → defaults to "repl.py"
+        let h = unsafe { monty_repl_create(ptr::null(), &mut err) };
+        assert!(!h.is_null());
+        // SAFETY: h was created by monty_repl_create
+        unsafe { monty_repl_free(h) };
+    }
+
+    #[test]
+    fn ffi_repl_create_with_name() {
+        let name = c("my_repl.py");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: name is a valid C string
+        let h = unsafe { monty_repl_create(name, &mut err) };
+        assert!(!h.is_null());
+        // SAFETY: h was created by monty_repl_create
+        unsafe {
+            monty_repl_free(h);
+            free_c(name);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_free_null() {
+        // SAFETY: null pointer — must be a no-op
+        unsafe { monty_repl_free(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn ffi_repl_free_double() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut err) };
+        assert!(!h.is_null());
+        // SAFETY: first free is legitimate
+        unsafe { monty_repl_free(h) };
+        // SAFETY: second free on a pointer not in LIVE_REPL_HANDLES — must be no-op
+        unsafe { monty_repl_free(h) };
+    }
+
+    #[test]
+    fn ffi_repl_feed_run_null_handle() {
+        let code = c("2 + 2");
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle — must return Error
+        let tag = unsafe { monty_repl_feed_run(ptr::null_mut(), code, &mut result, &mut err) };
+        assert_eq!(tag, MontyResultTag::Error);
+        assert!(!err.is_null());
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_feed_run_null_code() {
+        let mut repl_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut repl_err) };
+        assert!(!h.is_null());
+
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null code — should return Error
+        let tag = unsafe { monty_repl_feed_run(h, ptr::null(), &mut result, &mut err) };
+        assert_eq!(tag, MontyResultTag::Error);
+        assert!(!err.is_null());
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            monty_repl_free(h);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_feed_run_success() {
+        let mut repl_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut repl_err) };
+        assert!(!h.is_null());
+
+        let code = c("2 + 2");
+        let mut result: *mut std::ffi::c_char = ptr::null_mut();
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h and code are valid
+        let tag = unsafe { monty_repl_feed_run(h, code, &mut result, &mut err) };
+        assert_eq!(tag, MontyResultTag::Ok);
+        assert!(!result.is_null());
+        assert!(err.is_null());
+
+        // SAFETY: result is a valid JSON C string
+        let result_str = unsafe { c_str(result) };
+        let parsed: serde_json::Value = serde_json::from_str(result_str).unwrap();
+        assert_eq!(parsed["value"], serde_json::json!(4));
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(result);
+            monty_repl_free(h);
+            free_c(code);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_repl_detect_continuation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_detect_continuation_null() {
+        // SAFETY: null source — must return 0 (complete) without crashing
+        let result = unsafe { monty_repl_detect_continuation(ptr::null()) };
+        assert_eq!(result, 0);
+    }
+
+    #[test]
+    fn ffi_detect_continuation_complete() {
+        let src = c("x = 1");
+        // SAFETY: src is a valid C string
+        let result = unsafe { monty_repl_detect_continuation(src) };
+        assert_eq!(result, 0, "complete statement should return 0");
+        // SAFETY: free
+        unsafe { free_c(src) };
+    }
+
+    #[test]
+    fn ffi_detect_continuation_incomplete_block() {
+        let src = c("def f():");
+        // SAFETY: src is a valid C string
+        let result = unsafe { monty_repl_detect_continuation(src) };
+        assert_eq!(result, 2, "incomplete block should return 2");
+        // SAFETY: free
+        unsafe { free_c(src) };
+    }
+
+    #[test]
+    fn ffi_detect_continuation_incomplete_implicit() {
+        let src = c("x = (1 +");
+        // SAFETY: src is a valid C string
+        let result = unsafe { monty_repl_detect_continuation(src) };
+        assert_eq!(result, 1, "unclosed parens should return 1");
+        // SAFETY: free
+        unsafe { free_c(src) };
+    }
+
+    // -----------------------------------------------------------------------
+    // REPL iterative FFI
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_repl_set_ext_fns_null_handle() {
+        // SAFETY: null handle — must be a no-op
+        unsafe { monty_repl_set_ext_fns(ptr::null_mut(), ptr::null()) };
+    }
+
+    #[test]
+    fn ffi_repl_set_ext_fns_null_fns() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        // SAFETY: h is valid, null ext_fns clears the set
+        unsafe { monty_repl_set_ext_fns(h, ptr::null()) };
+
+        // SAFETY: free
+        unsafe { monty_repl_free(h) };
+    }
+
+    #[test]
+    fn ffi_repl_set_ext_fns_with_names() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut err) };
+        assert!(!h.is_null());
+
+        let fns = c("fn_a,fn_b");
+        // SAFETY: h and fns are valid
+        unsafe { monty_repl_set_ext_fns(h, fns) };
+
+        // SAFETY: free
+        unsafe {
+            monty_repl_free(h);
+            free_c(fns);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_feed_start_null_handle() {
+        let code = c("2 + 2");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_repl_feed_start(ptr::null_mut(), code, &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            free_c(code);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_feed_start_null_code() {
+        let mut create_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut create_err) };
+        assert!(!h.is_null());
+
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null code — should return Error
+        let tag = unsafe { monty_repl_feed_start(h, ptr::null(), &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            monty_repl_free(h);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_feed_start_and_resume_cycle() {
+        let mut create_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut create_err) };
+        assert!(!h.is_null());
+
+        let fns = c("get_val");
+        // SAFETY: h and fns are valid
+        unsafe { monty_repl_set_ext_fns(h, fns) };
+
+        let code = c("result = get_val()\nresult");
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h and code are valid
+        let tag = unsafe { monty_repl_feed_start(h, code, &mut start_err) };
+        assert_eq!(tag, MontyProgressTag::Pending);
+        assert!(start_err.is_null());
+
+        // Read pending fn name
+        // SAFETY: h is in Paused state
+        let fn_name_ptr = unsafe { monty_repl_pending_fn_name(h) };
+        assert!(!fn_name_ptr.is_null());
+        let fn_name = unsafe { c_str(fn_name_ptr) };
+        assert_eq!(fn_name, "get_val");
+        // SAFETY: fn_name_ptr was allocated by to_c_string
+        unsafe { monty_string_free(fn_name_ptr) };
+
+        let val = c("77");
+        let mut resume_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h is in Paused state, val is valid JSON
+        let tag = unsafe { monty_repl_resume(h, val, &mut resume_err) };
+        assert_eq!(tag, MontyProgressTag::Complete);
+
+        // SAFETY: h is in Complete state
+        let result_ptr = unsafe { monty_repl_complete_result_json(h) };
+        assert!(!result_ptr.is_null());
+        let result_str = unsafe { c_str(result_ptr) };
+        let parsed: serde_json::Value = serde_json::from_str(result_str).unwrap();
+        assert_eq!(parsed["value"], serde_json::json!(77));
+        // SAFETY: result_ptr was allocated by to_c_string
+        unsafe { monty_string_free(result_ptr) };
+
+        // SAFETY: free
+        unsafe {
+            monty_repl_free(h);
+            free_c(code);
+            free_c(fns);
+            free_c(val);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_resume_null_handle() {
+        let val = c("42");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_repl_resume(ptr::null_mut(), val, &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            free_c(val);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_resume_null_value_json() {
+        let mut create_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut create_err) };
+        assert!(!h.is_null());
+
+        let fns = c("fn1");
+        // SAFETY: h and fns are valid
+        unsafe { monty_repl_set_ext_fns(h, fns) };
+
+        let code = c("fn1()");
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h and code are valid
+        unsafe { monty_repl_feed_start(h, code, &mut start_err) };
+        // SAFETY: start_err may be null on success
+        unsafe { monty_string_free(start_err) };
+
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null value_json — should return Error
+        let tag = unsafe { monty_repl_resume(h, ptr::null(), &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(!err.is_null());
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            monty_repl_free(h);
+            free_c(code);
+            free_c(fns);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_resume_with_error_null_handle() {
+        let msg = c("boom");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_repl_resume_with_error(ptr::null_mut(), msg, &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            free_c(msg);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_resume_with_error_null_message() {
+        let mut create_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut create_err) };
+        assert!(!h.is_null());
+
+        let fns = c("fn1");
+        // SAFETY: h and fns are valid
+        unsafe { monty_repl_set_ext_fns(h, fns) };
+
+        let code = c("fn1()");
+        let mut start_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: h and code are valid
+        unsafe { monty_repl_feed_start(h, code, &mut start_err) };
+        unsafe { monty_string_free(start_err) };
+
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null error_message — should return Error
+        let tag = unsafe { monty_repl_resume_with_error(h, ptr::null(), &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            monty_repl_free(h);
+            free_c(code);
+            free_c(fns);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // REPL accessor FFI — null handle returns NULL / MAX / -1
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_repl_accessors_null_handle() {
+        // SAFETY: all null-handle accessors must return sentinel values
+        let fn_name = unsafe { monty_repl_pending_fn_name(ptr::null()) };
+        assert!(fn_name.is_null());
+
+        let args = unsafe { monty_repl_pending_fn_args_json(ptr::null()) };
+        assert!(args.is_null());
+
+        let kwargs = unsafe { monty_repl_pending_fn_kwargs_json(ptr::null()) };
+        assert!(kwargs.is_null());
+
+        let call_id = unsafe { monty_repl_pending_call_id(ptr::null()) };
+        assert_eq!(call_id, u32::MAX);
+
+        let method = unsafe { monty_repl_pending_method_call(ptr::null()) };
+        assert_eq!(method, -1);
+
+        let os_name = unsafe { monty_repl_os_call_fn_name(ptr::null()) };
+        assert!(os_name.is_null());
+
+        let os_args = unsafe { monty_repl_os_call_args_json(ptr::null()) };
+        assert!(os_args.is_null());
+
+        let os_kwargs = unsafe { monty_repl_os_call_kwargs_json(ptr::null()) };
+        assert!(os_kwargs.is_null());
+
+        let os_id = unsafe { monty_repl_os_call_id(ptr::null()) };
+        assert_eq!(os_id, u32::MAX);
+
+        let result = unsafe { monty_repl_complete_result_json(ptr::null()) };
+        assert!(result.is_null());
+
+        let is_err = unsafe { monty_repl_complete_is_error(ptr::null()) };
+        assert_eq!(is_err, -1);
+
+        let future_ids = unsafe { monty_repl_pending_future_call_ids(ptr::null()) };
+        assert!(future_ids.is_null());
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_repl_resume_as_future / monty_repl_resume_futures
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_repl_resume_as_future_null_handle() {
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_repl_resume_as_future(ptr::null_mut(), &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: free
+        unsafe { monty_string_free(err) };
+    }
+
+    #[test]
+    fn ffi_repl_resume_futures_null_handle() {
+        let results = c("{}");
+        let errors = c("{}");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null handle
+        let tag = unsafe { monty_repl_resume_futures(ptr::null_mut(), results, errors, &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            free_c(results);
+            free_c(errors);
+        }
+    }
+
+    #[test]
+    fn ffi_repl_resume_futures_null_results_json() {
+        let mut create_err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null script_name is fine
+        let h = unsafe { monty_repl_create(ptr::null(), &mut create_err) };
+        assert!(!h.is_null());
+
+        let errors = c("{}");
+        let mut err: *mut std::ffi::c_char = ptr::null_mut();
+        // SAFETY: null results_json — should return Error
+        let tag = unsafe { monty_repl_resume_futures(h, ptr::null(), errors, &mut err) };
+        assert_eq!(tag, MontyProgressTag::Error);
+
+        // SAFETY: free
+        unsafe {
+            monty_string_free(err);
+            monty_repl_free(h);
+            free_c(errors);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_string_free / monty_bytes_free
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_string_free_null() {
+        // SAFETY: null pointer — must be a no-op
+        unsafe { monty_string_free(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn ffi_string_free_valid() {
+        // to_c_string allocates via CString::into_raw
+        let ptr = to_c_string("hello ffi");
+        assert!(!ptr.is_null());
+        // SAFETY: ptr was allocated by to_c_string (CString::into_raw)
+        unsafe { monty_string_free(ptr) };
+    }
+
+    #[test]
+    fn ffi_bytes_free_null() {
+        // SAFETY: null pointer — must be a no-op
+        unsafe { monty_bytes_free(ptr::null_mut(), 0) };
+    }
+
+    #[test]
+    fn ffi_bytes_free_zero_len() {
+        // SAFETY: non-null pointer but zero len — must be a no-op
+        let mut buf = [0u8; 4];
+        unsafe { monty_bytes_free(buf.as_mut_ptr(), 0) };
+    }
+
+    #[test]
+    fn ffi_bytes_free_valid() {
+        // Allocate via monty_alloc, free via monty_bytes_free
+        let size = 64usize;
+        let ptr = monty_alloc(size);
+        assert!(!ptr.is_null());
+        // SAFETY: ptr was allocated by monty_alloc with size bytes
+        unsafe { monty_bytes_free(ptr, size) };
+    }
+
+    // -----------------------------------------------------------------------
+    // monty_alloc / monty_dealloc
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ffi_alloc_zero_returns_null() {
+        let ptr = monty_alloc(0);
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn ffi_alloc_and_dealloc() {
+        let size = 128usize;
+        let ptr = monty_alloc(size);
+        assert!(!ptr.is_null());
+        // Allocated memory should be zero-initialised
+        // SAFETY: ptr points to `size` bytes of zeroed memory
+        let slice = unsafe { std::slice::from_raw_parts(ptr, size) };
+        assert!(
+            slice.iter().all(|&b| b == 0),
+            "alloc'd memory should be zero"
+        );
+        // SAFETY: ptr was allocated by monty_alloc with size and align=1
+        unsafe { monty_dealloc(ptr, size) };
+    }
+
+    #[test]
+    fn ffi_dealloc_null() {
+        // SAFETY: null pointer — must be a no-op
+        unsafe { monty_dealloc(ptr::null_mut(), 64) };
+    }
+
+    #[test]
+    fn ffi_dealloc_zero_size() {
+        let size = 64usize;
+        let ptr = monty_alloc(size);
+        assert!(!ptr.is_null());
+        // SAFETY: zero size — must be a no-op (ptr stays live)
+        unsafe { monty_dealloc(ptr, 0) };
+        // Now properly free to avoid leak
+        unsafe { monty_dealloc(ptr, size) };
+    }
+}

--- a/native/src/repl_handle.rs
+++ b/native/src/repl_handle.rs
@@ -888,4 +888,361 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed["value"], 200);
     }
+
+    // -----------------------------------------------------------------------
+    // OsCall state tests
+    // -----------------------------------------------------------------------
+
+    fn os_call_snippet() -> &'static str {
+        "from pathlib import Path\np = Path('test.txt')\np.read_text()"
+    }
+
+    #[test]
+    fn feed_start_os_call_pauses() {
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, _) = repl.feed_start(os_call_snippet());
+        assert_eq!(tag, MontyProgressTag::OsCall);
+    }
+
+    #[test]
+    fn repl_os_call_fn_name_accessor() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.feed_start(os_call_snippet());
+        let name = repl.os_call_fn_name();
+        assert!(name.is_some());
+        assert!(
+            name.unwrap().contains("read_text") || name.unwrap().contains("Path"),
+            "expected a Path-related OsCall, got: {:?}",
+            name
+        );
+    }
+
+    #[test]
+    fn repl_os_call_args_json_accessor() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.feed_start(os_call_snippet());
+        let args = repl.os_call_args_json();
+        assert!(args.is_some());
+        let _: serde_json::Value = serde_json::from_str(args.unwrap()).unwrap();
+    }
+
+    #[test]
+    fn repl_os_call_kwargs_json_accessor() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.feed_start(os_call_snippet());
+        let kwargs = repl.os_call_kwargs_json();
+        assert!(kwargs.is_some());
+        let _: serde_json::Value = serde_json::from_str(kwargs.unwrap()).unwrap();
+    }
+
+    #[test]
+    fn repl_os_call_id_accessor() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.feed_start(os_call_snippet());
+        let id = repl.os_call_id();
+        assert!(id.is_some());
+    }
+
+    #[test]
+    fn repl_os_call_accessors_wrong_state() {
+        let repl = MontyReplHandle::new("test.py");
+        assert!(repl.os_call_fn_name().is_none());
+        assert!(repl.os_call_args_json().is_none());
+        assert!(repl.os_call_kwargs_json().is_none());
+        assert!(repl.os_call_id().is_none());
+    }
+
+    #[test]
+    fn repl_resume_from_os_call_with_value() {
+        let code = r#"from pathlib import Path
+p = Path('test.txt')
+result = p.read_text()
+result"#;
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, _) = repl.feed_start(code);
+        assert_eq!(tag, MontyProgressTag::OsCall);
+
+        let (tag, _) = repl.resume("\"file contents\"");
+        assert_eq!(tag, MontyProgressTag::Complete);
+        assert_eq!(repl.complete_is_error(), Some(false));
+        let result_json = repl.complete_result_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(result_json).unwrap();
+        assert_eq!(parsed["value"], "file contents");
+    }
+
+    #[test]
+    fn repl_resume_with_error_from_os_call() {
+        let code = r#"from pathlib import Path
+p = Path('missing.txt')
+try:
+    result = p.read_text()
+except Exception as e:
+    result = str(e)
+result"#;
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, _) = repl.feed_start(code);
+        assert_eq!(tag, MontyProgressTag::OsCall);
+
+        let (tag, _) = repl.resume_with_error("permission denied");
+        assert_eq!(tag, MontyProgressTag::Complete);
+        let result_json = repl.complete_result_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(result_json).unwrap();
+        assert!(
+            parsed["value"]
+                .as_str()
+                .unwrap()
+                .contains("permission denied")
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // resume_with_error from wrong state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resume_with_error_wrong_state() {
+        let mut repl = MontyReplHandle::new("test.py");
+        // Idle state — not Paused or OsCall
+        let (tag, err) = repl.resume_with_error("boom");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("not in Paused or OsCall state"));
+    }
+
+    // -----------------------------------------------------------------------
+    // resume_as_future from wrong state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resume_as_future_wrong_state() {
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, err) = repl.resume_as_future();
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("not in Paused state"));
+    }
+
+    // -----------------------------------------------------------------------
+    // resume_as_future from Paused state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_resume_as_future_single() {
+        let code =
+            "async def main():\n  result = await fetch('x')\n  return result\n\nawait main()";
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["fetch".into()]);
+
+        let (tag, _) = repl.feed_start(code);
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, _) = repl.resume_as_future();
+        assert_eq!(tag, MontyProgressTag::ResolveFutures);
+
+        let ids_str = repl.pending_future_call_ids().unwrap();
+        let ids: Vec<u32> = serde_json::from_str(ids_str).unwrap();
+        assert_eq!(ids.len(), 1);
+
+        let results = format!("{{\"{}\":\"response\"}}", ids[0]);
+        let (tag, _) = repl.resume_futures(&results, "{}");
+        assert_eq!(tag, MontyProgressTag::Complete);
+
+        let result_json = repl.complete_result_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(result_json).unwrap();
+        assert_eq!(parsed["value"], "response");
+    }
+
+    // -----------------------------------------------------------------------
+    // resume_futures from wrong state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_resume_futures_wrong_state() {
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, err) = repl.resume_futures("{}", "{}");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("not in Futures state"));
+    }
+
+    // -----------------------------------------------------------------------
+    // resume_futures with errors map
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_resume_futures_with_error_in_map() {
+        let code =
+            "async def main():\n  result = await fetch('x')\n  return result\n\nawait main()";
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["fetch".into()]);
+
+        let (tag, _) = repl.feed_start(code);
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, _) = repl.resume_as_future();
+        assert_eq!(tag, MontyProgressTag::ResolveFutures);
+
+        let ids_str = repl.pending_future_call_ids().unwrap();
+        let ids: Vec<u32> = serde_json::from_str(ids_str).unwrap();
+
+        // Provide an error for the future
+        let errors = format!("{{\"{}\":\"network timeout\"}}", ids[0]);
+        let (tag, _) = repl.resume_futures("{}", &errors);
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert_eq!(repl.complete_is_error(), Some(true));
+    }
+
+    // -----------------------------------------------------------------------
+    // take_repl error path (not Idle/Complete state)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn feed_run_while_paused_fails() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["get_val".into()]);
+
+        // Pause the REPL
+        let (tag, _) = repl.feed_start("get_val()");
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        // Try feed_run while paused — should error because take_repl fails
+        let (tag, _, err) = repl.feed_run("1 + 1");
+        assert_eq!(tag, MontyResultTag::Error);
+        assert!(err.unwrap().contains("not in Idle or Complete state"));
+    }
+
+    #[test]
+    fn feed_start_while_paused_fails() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["get_val".into()]);
+
+        let (tag, _) = repl.feed_start("get_val()");
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        // Try feed_start while paused — should error
+        let (tag, err) = repl.feed_start("1 + 1");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("not in Idle or Complete state"));
+    }
+
+    // -----------------------------------------------------------------------
+    // State accessors returning None in wrong state
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_pending_accessors_idle_state() {
+        let repl = MontyReplHandle::new("test.py");
+        assert!(repl.pending_fn_name().is_none());
+        assert!(repl.pending_fn_args_json().is_none());
+        assert!(repl.pending_fn_kwargs_json().is_none());
+        assert!(repl.pending_call_id().is_none());
+        assert!(repl.pending_method_call().is_none());
+        assert!(repl.complete_result_json().is_none());
+        assert!(repl.complete_is_error().is_none());
+        assert!(repl.pending_future_call_ids().is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Print output in feed_start/resume cycle
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn feed_start_captures_print_output() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["get_val".into()]);
+
+        let (tag, _) = repl.feed_start("print('before')\nresult = get_val()\nresult");
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, _) = repl.resume("42");
+        assert_eq!(tag, MontyProgressTag::Complete);
+
+        let result_json = repl.complete_result_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(result_json).unwrap();
+        assert_eq!(parsed["print_output"], "before\n");
+        assert_eq!(parsed["value"], 42);
+    }
+
+    #[test]
+    fn feed_run_print_output_cleared_after_run() {
+        let mut repl = MontyReplHandle::new("test.py");
+
+        let (_, json1, _) = repl.feed_run("print('first')");
+        let p1: serde_json::Value = serde_json::from_str(&json1).unwrap();
+        assert_eq!(p1["print_output"], "first\n");
+
+        // Second run should not carry over print from first
+        let (_, json2, _) = repl.feed_run("2 + 2");
+        let p2: serde_json::Value = serde_json::from_str(&json2).unwrap();
+        assert!(p2.get("print_output").is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Debug impl
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_debug_impl() {
+        let repl = MontyReplHandle::new("test.py");
+        let debug_str = format!("{repl:?}");
+        assert!(debug_str.contains("MontyReplHandle"));
+    }
+
+    // -----------------------------------------------------------------------
+    // build_repl_result_json coverage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_result_json_with_error() {
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, json, _) = repl.feed_run("1 / 0");
+        assert_eq!(tag, MontyResultTag::Error);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(parsed.get("error").is_some());
+        assert!(parsed["value"].is_null());
+    }
+
+    #[test]
+    fn repl_result_json_with_print_and_error() {
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, json, _) = repl.feed_run("print('oops')\n1/0");
+        assert_eq!(tag, MontyResultTag::Error);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["print_output"], "oops\n");
+        assert!(parsed.get("error").is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // resume with invalid JSON
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_resume_invalid_json() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["get_val".into()]);
+
+        let (tag, _) = repl.feed_start("get_val()");
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, err) = repl.resume("not-valid-json{{{");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.unwrap().contains("invalid JSON"));
+    }
+
+    // -----------------------------------------------------------------------
+    // NameLookup with registered ext_fn exercises the known-name branch
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn repl_name_lookup_registered_fn() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["compute".into()]);
+
+        let (tag, _) = repl.feed_start("result = compute(5)\nresult");
+        assert_eq!(tag, MontyProgressTag::Pending);
+        assert_eq!(repl.pending_fn_name(), Some("compute"));
+
+        let (tag, _) = repl.resume("25");
+        assert_eq!(tag, MontyProgressTag::Complete);
+        let result_json = repl.complete_result_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(result_json).unwrap();
+        assert_eq!(parsed["value"], 25);
+    }
 }

--- a/native/tests/integration.rs
+++ b/native/tests/integration.rs
@@ -1453,3 +1453,720 @@ fn free_null_is_noop() {
     // NULL has always been safe, but verify it still is.
     unsafe { monty_free(ptr::null_mut()) };
 }
+
+// ---------------------------------------------------------------------------
+// REPL FFI: basic lifecycle
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_create_feed_run_free() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null(), "monty_repl_create returned NULL");
+    assert!(out_error.is_null());
+
+    let code = c("2 + 2");
+    let mut result_json: *mut c_char = ptr::null_mut();
+    let mut error_msg: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_run(repl, code.as_ptr(), &mut result_json, &mut error_msg) };
+    assert_eq!(tag, MontyResultTag::Ok);
+    assert!(!result_json.is_null());
+
+    let json_str = unsafe { read_c_string(result_json) };
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(parsed["value"], 4);
+
+    if !error_msg.is_null() {
+        unsafe { monty_string_free(error_msg) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_create_null_name_uses_default() {
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(ptr::null(), &mut out_error) };
+    assert!(!repl.is_null());
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_free_null_is_noop() {
+    unsafe { monty_repl_free(ptr::null_mut()) };
+}
+
+#[test]
+fn repl_free_double_free_is_noop() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+    unsafe { monty_repl_free(repl) };
+    unsafe { monty_repl_free(repl) }; // should be no-op
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: feed_run error cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_feed_run_null_handle() {
+    let code = c("2 + 2");
+    let mut result: *mut c_char = ptr::null_mut();
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_run(ptr::null_mut(), code.as_ptr(), &mut result, &mut err) };
+    assert_eq!(tag, MontyResultTag::Error);
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+}
+
+#[test]
+fn repl_feed_run_null_code() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let mut result: *mut c_char = ptr::null_mut();
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_run(repl, ptr::null(), &mut result, &mut err) };
+    assert_eq!(tag, MontyResultTag::Error);
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_feed_run_null_output_params() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let code = c("2 + 2");
+    let tag = unsafe { monty_repl_feed_run(repl, code.as_ptr(), ptr::null_mut(), ptr::null_mut()) };
+    assert_eq!(tag, MontyResultTag::Ok);
+
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_feed_run_error_result() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let code = c("1 / 0");
+    let mut result: *mut c_char = ptr::null_mut();
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_run(repl, code.as_ptr(), &mut result, &mut err) };
+    assert_eq!(tag, MontyResultTag::Error);
+    assert!(!err.is_null());
+
+    if !result.is_null() {
+        unsafe { monty_string_free(result) };
+    }
+    unsafe { monty_string_free(err) };
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: state persistence across feed_run calls
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_state_persists_across_calls() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let code1 = c("x = 42");
+    let mut r1: *mut c_char = ptr::null_mut();
+    let mut e1: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_run(repl, code1.as_ptr(), &mut r1, &mut e1) };
+    assert_eq!(tag, MontyResultTag::Ok);
+    if !r1.is_null() {
+        unsafe { monty_string_free(r1) };
+    }
+    if !e1.is_null() {
+        unsafe { monty_string_free(e1) };
+    }
+
+    let code2 = c("x + 1");
+    let mut r2: *mut c_char = ptr::null_mut();
+    let mut e2: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_run(repl, code2.as_ptr(), &mut r2, &mut e2) };
+    assert_eq!(tag, MontyResultTag::Ok);
+    assert!(!r2.is_null());
+
+    let json_str = unsafe { read_c_string(r2) };
+    let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(parsed["value"], 43);
+
+    if !e2.is_null() {
+        unsafe { monty_string_free(e2) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: detect_continuation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_detect_continuation_complete() {
+    let code = c("x = 1");
+    let result = unsafe { monty_repl_detect_continuation(code.as_ptr()) };
+    assert_eq!(result, 0); // CONTINUATION_COMPLETE
+}
+
+#[test]
+fn repl_detect_continuation_incomplete_block() {
+    let code = c("def f():");
+    let result = unsafe { monty_repl_detect_continuation(code.as_ptr()) };
+    assert_eq!(result, 2); // CONTINUATION_INCOMPLETE_BLOCK
+}
+
+#[test]
+fn repl_detect_continuation_null() {
+    let result = unsafe { monty_repl_detect_continuation(ptr::null()) };
+    assert_eq!(result, 0); // treat null as complete
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: set_ext_fns
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_set_ext_fns_null_clears() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    // set_ext_fns with NULL should clear (no crash)
+    unsafe { monty_repl_set_ext_fns(repl, ptr::null()) };
+
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_set_ext_fns_null_handle_noop() {
+    // Should not crash
+    let ext = c("foo,bar");
+    unsafe { monty_repl_set_ext_fns(ptr::null_mut(), ext.as_ptr()) };
+}
+
+#[test]
+fn repl_set_ext_fns_empty_string() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let empty = c("");
+    unsafe { monty_repl_set_ext_fns(repl, empty.as_ptr()) };
+
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_set_ext_fns_and_feed_start() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let ext_fns = c("get_val");
+    unsafe { monty_repl_set_ext_fns(repl, ext_fns.as_ptr()) };
+
+    let code = c("result = get_val()\nresult");
+    let mut feed_err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(repl, code.as_ptr(), &mut feed_err) };
+    assert_eq!(tag, MontyProgressTag::Pending);
+
+    // Check pending fn name
+    let fn_name_ptr = unsafe { monty_repl_pending_fn_name(repl) };
+    assert!(!fn_name_ptr.is_null());
+    let fn_name = unsafe { read_c_string(fn_name_ptr) };
+    assert_eq!(fn_name, "get_val");
+
+    // Resume
+    let val = c("99");
+    let tag = unsafe { monty_repl_resume(repl, val.as_ptr(), &mut feed_err) };
+    assert_eq!(tag, MontyProgressTag::Complete);
+    assert_eq!(unsafe { monty_repl_complete_is_error(repl) }, 0);
+
+    let result_ptr = unsafe { monty_repl_complete_result_json(repl) };
+    assert!(!result_ptr.is_null());
+    let result_str = unsafe { read_c_string(result_ptr) };
+    let result: serde_json::Value = serde_json::from_str(&result_str).unwrap();
+    assert_eq!(result["value"], 99);
+
+    if !feed_err.is_null() {
+        unsafe { monty_string_free(feed_err) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: feed_start null safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_feed_start_null_handle() {
+    let code = c("2 + 2");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(ptr::null_mut(), code.as_ptr(), &mut out_error) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !out_error.is_null() {
+        unsafe { monty_string_free(out_error) };
+    }
+}
+
+#[test]
+fn repl_feed_start_null_code() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(repl, ptr::null(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: resume null safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_resume_null_handle() {
+    let val = c("42");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_resume(ptr::null_mut(), val.as_ptr(), &mut out_error) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !out_error.is_null() {
+        unsafe { monty_string_free(out_error) };
+    }
+}
+
+#[test]
+fn repl_resume_null_value() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let ext_fns = c("get_val");
+    unsafe { monty_repl_set_ext_fns(repl, ext_fns.as_ptr()) };
+
+    let code = c("get_val()");
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(repl, code.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Pending);
+
+    // Pass NULL value
+    let mut err2: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_resume(repl, ptr::null(), &mut err2) };
+    assert_eq!(tag, MontyProgressTag::Error);
+
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+    if !err2.is_null() {
+        unsafe { monty_string_free(err2) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: resume_with_error null safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_resume_with_error_null_handle() {
+    let msg = c("oops");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let tag =
+        unsafe { monty_repl_resume_with_error(ptr::null_mut(), msg.as_ptr(), &mut out_error) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !out_error.is_null() {
+        unsafe { monty_string_free(out_error) };
+    }
+}
+
+#[test]
+fn repl_resume_with_error_null_message() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let ext_fns = c("get_val");
+    unsafe { monty_repl_set_ext_fns(repl, ext_fns.as_ptr()) };
+
+    let code = c("get_val()");
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(repl, code.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Pending);
+
+    let mut err2: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_resume_with_error(repl, ptr::null(), &mut err2) };
+    assert_eq!(tag, MontyProgressTag::Error);
+
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+    if !err2.is_null() {
+        unsafe { monty_string_free(err2) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_resume_with_error_flow() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let ext_fns = c("fetch");
+    unsafe { monty_repl_set_ext_fns(repl, ext_fns.as_ptr()) };
+
+    let code =
+        c("try:\n    result = fetch('url')\nexcept Exception as e:\n    result = str(e)\nresult");
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(repl, code.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Pending);
+
+    let err_msg = c("connection refused");
+    let tag = unsafe { monty_repl_resume_with_error(repl, err_msg.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Complete);
+    assert_eq!(unsafe { monty_repl_complete_is_error(repl) }, 0);
+
+    let result_ptr = unsafe { monty_repl_complete_result_json(repl) };
+    assert!(!result_ptr.is_null());
+    let result_str = unsafe { read_c_string(result_ptr) };
+    assert!(result_str.contains("connection refused"));
+
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: accessor null safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_accessor_null_safety() {
+    // All accessors with NULL handle
+    let p = unsafe { monty_repl_pending_fn_name(ptr::null()) };
+    assert!(p.is_null());
+
+    let p = unsafe { monty_repl_pending_fn_args_json(ptr::null()) };
+    assert!(p.is_null());
+
+    let p = unsafe { monty_repl_pending_fn_kwargs_json(ptr::null()) };
+    assert!(p.is_null());
+
+    let id = unsafe { monty_repl_pending_call_id(ptr::null()) };
+    assert_eq!(id, u32::MAX);
+
+    let mc = unsafe { monty_repl_pending_method_call(ptr::null()) };
+    assert_eq!(mc, -1);
+
+    let p = unsafe { monty_repl_os_call_fn_name(ptr::null()) };
+    assert!(p.is_null());
+
+    let p = unsafe { monty_repl_os_call_args_json(ptr::null()) };
+    assert!(p.is_null());
+
+    let p = unsafe { monty_repl_os_call_kwargs_json(ptr::null()) };
+    assert!(p.is_null());
+
+    let id = unsafe { monty_repl_os_call_id(ptr::null()) };
+    assert_eq!(id, u32::MAX);
+
+    let p = unsafe { monty_repl_complete_result_json(ptr::null()) };
+    assert!(p.is_null());
+
+    let v = unsafe { monty_repl_complete_is_error(ptr::null()) };
+    assert_eq!(v, -1);
+
+    let p = unsafe { monty_repl_pending_future_call_ids(ptr::null()) };
+    assert!(p.is_null());
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: resume_as_future null safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_resume_as_future_null_handle() {
+    let mut out: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_resume_as_future(ptr::null_mut(), &mut out) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !out.is_null() {
+        unsafe { monty_string_free(out) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: resume_futures null safety
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_resume_futures_null_handle() {
+    let r = c("{}");
+    let e = c("{}");
+    let mut out: *mut c_char = ptr::null_mut();
+    let tag =
+        unsafe { monty_repl_resume_futures(ptr::null_mut(), r.as_ptr(), e.as_ptr(), &mut out) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !out.is_null() {
+        unsafe { monty_string_free(out) };
+    }
+}
+
+#[test]
+fn repl_resume_futures_null_results() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let e = c("{}");
+    let mut out: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_resume_futures(repl, ptr::null(), e.as_ptr(), &mut out) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !out.is_null() {
+        unsafe { monty_string_free(out) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+#[test]
+fn repl_resume_futures_null_errors() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let r = c("{}");
+    let mut out: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_resume_futures(repl, r.as_ptr(), ptr::null(), &mut out) };
+    assert_eq!(tag, MontyProgressTag::Error);
+    if !out.is_null() {
+        unsafe { monty_string_free(out) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: async flow (feed_start → resume_as_future → resume_futures)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_async_single_await_via_ffi() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let ext_fns = c("fetch");
+    unsafe { monty_repl_set_ext_fns(repl, ext_fns.as_ptr()) };
+
+    let code = c("async def main():\n  result = await fetch('x')\n  return result\n\nawait main()");
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(repl, code.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Pending);
+
+    let call_id = unsafe { monty_repl_pending_call_id(repl) };
+    assert_ne!(call_id, u32::MAX);
+
+    let tag = unsafe { monty_repl_resume_as_future(repl, &mut err) };
+    assert_eq!(tag, MontyProgressTag::ResolveFutures);
+
+    let ids_ptr = unsafe { monty_repl_pending_future_call_ids(repl) };
+    assert!(!ids_ptr.is_null());
+    let ids_str = unsafe { read_c_string(ids_ptr) };
+    let ids: Vec<u32> = serde_json::from_str(&ids_str).unwrap();
+    assert_eq!(ids.len(), 1);
+
+    let results = CString::new(format!("{{\"{}\":\"response_x\"}}", ids[0])).unwrap();
+    let errors = c("{}");
+    let tag =
+        unsafe { monty_repl_resume_futures(repl, results.as_ptr(), errors.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Complete);
+    assert_eq!(unsafe { monty_repl_complete_is_error(repl) }, 0);
+
+    let result_ptr = unsafe { monty_repl_complete_result_json(repl) };
+    assert!(!result_ptr.is_null());
+    let result_str = unsafe { read_c_string(result_ptr) };
+    let result: serde_json::Value = serde_json::from_str(&result_str).unwrap();
+    assert_eq!(result["value"], "response_x");
+
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: os_call accessors (non-null handle)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_os_call_accessors_via_ffi() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    let code = c("from pathlib import Path\np = Path('test.txt')\np.read_text()");
+    let mut err: *mut c_char = ptr::null_mut();
+    let tag = unsafe { monty_repl_feed_start(repl, code.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::OsCall);
+
+    // os_call_fn_name
+    let fn_ptr = unsafe { monty_repl_os_call_fn_name(repl) };
+    assert!(!fn_ptr.is_null());
+    let fn_name = unsafe { read_c_string(fn_ptr) };
+    assert!(fn_name.contains("read_text") || fn_name.contains("Path"));
+
+    // os_call_args_json
+    let args_ptr = unsafe { monty_repl_os_call_args_json(repl) };
+    assert!(!args_ptr.is_null());
+    let args_str = unsafe { read_c_string(args_ptr) };
+    let _: serde_json::Value = serde_json::from_str(&args_str).unwrap();
+
+    // os_call_kwargs_json
+    let kwargs_ptr = unsafe { monty_repl_os_call_kwargs_json(repl) };
+    assert!(!kwargs_ptr.is_null());
+    let kwargs_str = unsafe { read_c_string(kwargs_ptr) };
+    let _: serde_json::Value = serde_json::from_str(&kwargs_str).unwrap();
+
+    // os_call_id
+    let os_id = unsafe { monty_repl_os_call_id(repl) };
+    assert_ne!(os_id, u32::MAX);
+
+    // Resume with a value to complete
+    let val = c("\"file content\"");
+    let tag = unsafe { monty_repl_resume(repl, val.as_ptr(), &mut err) };
+    assert_eq!(tag, MontyProgressTag::Complete);
+
+    if !err.is_null() {
+        unsafe { monty_string_free(err) };
+    }
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: complete_result_json and complete_is_error in idle/wrong state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_complete_accessors_idle_state() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    // In idle state, complete accessors return NULL/-1
+    let result_ptr = unsafe { monty_repl_complete_result_json(repl) };
+    assert!(result_ptr.is_null());
+
+    let is_error = unsafe { monty_repl_complete_is_error(repl) };
+    assert_eq!(is_error, -1);
+
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: pending accessors in idle state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_pending_accessors_idle_state() {
+    let name = c("test.py");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(name.as_ptr(), &mut out_error) };
+    assert!(!repl.is_null());
+
+    assert!(unsafe { monty_repl_pending_fn_name(repl) }.is_null());
+    assert!(unsafe { monty_repl_pending_fn_args_json(repl) }.is_null());
+    assert!(unsafe { monty_repl_pending_fn_kwargs_json(repl) }.is_null());
+    assert_eq!(unsafe { monty_repl_pending_call_id(repl) }, u32::MAX);
+    assert_eq!(unsafe { monty_repl_pending_method_call(repl) }, -1);
+    assert!(unsafe { monty_repl_os_call_fn_name(repl) }.is_null());
+    assert!(unsafe { monty_repl_os_call_args_json(repl) }.is_null());
+    assert!(unsafe { monty_repl_os_call_kwargs_json(repl) }.is_null());
+    assert_eq!(unsafe { monty_repl_os_call_id(repl) }, u32::MAX);
+    assert!(unsafe { monty_repl_pending_future_call_ids(repl) }.is_null());
+
+    unsafe { monty_repl_free(repl) };
+}
+
+// ---------------------------------------------------------------------------
+// monty_alloc / monty_dealloc
+// ---------------------------------------------------------------------------
+
+#[test]
+fn alloc_dealloc_basic() {
+    let ptr = monty_alloc(64);
+    assert!(!ptr.is_null());
+    // Memory should be zeroed
+    let slice = unsafe { std::slice::from_raw_parts(ptr, 64) };
+    assert!(slice.iter().all(|&b| b == 0));
+    unsafe { monty_dealloc(ptr, 64) };
+}
+
+#[test]
+fn alloc_zero_size_returns_null() {
+    let ptr = monty_alloc(0);
+    assert!(ptr.is_null());
+}
+
+#[test]
+fn dealloc_null_is_noop() {
+    unsafe { monty_dealloc(ptr::null_mut(), 0) };
+    unsafe { monty_dealloc(ptr::null_mut(), 64) };
+}
+
+#[test]
+fn dealloc_zero_size_is_noop() {
+    let ptr = monty_alloc(64);
+    assert!(!ptr.is_null());
+    // Dealloc with 0 size is a no-op (should not crash)
+    unsafe { monty_dealloc(ptr, 0) };
+    // Properly free
+    unsafe { monty_dealloc(ptr, 64) };
+}
+
+// ---------------------------------------------------------------------------
+// REPL FFI: create with non-UTF8 script_name
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repl_create_non_utf8_name() {
+    let bad_name: &[u8] = &[0xFF, 0xFE, 0x00];
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let repl = unsafe { monty_repl_create(bad_name.as_ptr().cast(), &mut out_error) };
+    assert!(repl.is_null());
+    assert!(!out_error.is_null());
+    let err = unsafe { read_c_string(out_error) };
+    assert!(err.contains("not valid UTF-8"), "got: {err}");
+}


### PR DESCRIPTION
## Summary

- Adds comprehensive unit and integration tests targeting previously uncovered code paths in the native Rust crate
- Coverage raised from **60.99% → 90.66%** (1155/1274 lines), well above the 80% gate
- Fixed two pre-existing broken tests in `convert.rs` added by the `chore/monty-0.0.12-upgrade` branch

## Key test areas added

- **OsCall state machine**: `pathlib.Path.read_text()` triggers `OsCall`; tests cover all accessors (`os_call_fn_name`, `os_call_args_json`, `os_call_kwargs_json`, `os_call_id`), resume-with-value, and resume-with-error
- **REPL FFI surface** (`src/lib.rs`): `monty_repl_create/free/feed_run/feed_start/resume/resume_with_error/resume_as_future/resume_futures` with null-safety cases
- **State machine error paths**: `resume_with_error` / `resume_as_future` / `resume_futures` from wrong states
- **REPL async flow**: `feed_start → resume_as_future → resume_futures` via FFI
- **WASM allocator**: `monty_alloc` / `monty_dealloc` basic, zero-size, and null-ptr cases
- **kwargs passthrough**: Python `ext_fn(x=1, y=2)` surfaces in `pending_fn_kwargs_json`
- **NameLookup known-ext-fn branch**: exercises the `ext_fn_names.contains(&name)` path
- **Accessor null/wrong-state sentinels**: all REPL pending/complete/os/futures accessors with NULL handle and idle state

## Test plan

- [ ] `cargo fmt --check` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo test` — 361 tests (282 lib + 79 integration), 0 failures
- [ ] `cargo tarpaulin` reports 90.66% coverage (gate: 70%, goal: 80%+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)