### PR TITLE
fix(agent-demo): fix GitHub Pages JS compile errors

### DIFF
--- a/example/web/bin/agent_demo.dart
+++ b/example/web/bin/agent_demo.dart
@@ -195,7 +195,7 @@ Future<bool> _init() async {
 
     final plugins = <MontyPlugin>[tmplPlugin, msgPlugin];
     final sandboxPlugin = SandboxPlugin(
-      platformFactory: () async => Monty(os: os).platform,
+      platformFactory: () async => Monty().platform,
       parentPlugins: plugins,
       parentOs: os,
     );
@@ -348,6 +348,15 @@ Map<String, dynamic> _eventToMap(BridgeEvent event) {
       'callId': callId,
       'result': result,
       if (durationMs != null) 'durationMs': durationMs,
+    },
+    BridgeEventLoopWaiting() => {'type': 'EventLoopWaiting'},
+    BridgeEventLoopResumed(:final event) => {
+      'type': 'EventLoopResumed',
+      'event': event,
+    },
+    BridgeUiRendered(:final schema) => {
+      'type': 'UiRendered',
+      'schema': schema,
     },
   };
 }


### PR DESCRIPTION
## Summary

- `Monty(os: os)` → `Monty()`: `dart_monty_core`'s `Monty` constructor has no `os:` named parameter. The `OsProvider` is already wired via `parentOs` on `SandboxPlugin`.
- Adds `BridgeEventLoopWaiting`, `BridgeEventLoopResumed`, and `BridgeUiRendered` to the exhaustive `switch` in `_eventToMap()` — these three cases were added to the sealed `BridgeEvent` hierarchy but the demo switch was never updated.

## Test plan

- [ ] GitHub Pages CI: `dart compile js bin/agent_demo.dart` completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)