### PR TITLE
feat(bridge): HasStateSignal mixin + PluginRegistry.statefulObservations()

### DIFF
--- a/lib/src/bridge/bridge/plugin_registry.dart
+++ b/lib/src/bridge/bridge/plugin_registry.dart
@@ -8,9 +8,11 @@ import 'package:dart_monty/src/bridge/bridge/introspection_functions.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_backend_kind.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_plugin.dart';
+import 'package:dart_monty/src/bridge/bridge/stateful_plugin.dart';
 import 'package:dart_monty/src/bridge/os_call/decorator_handlers.dart';
 import 'package:dart_monty/src/bridge/os_call/fs_handlers.dart';
 import 'package:dart_monty/src/bridge/os_call/os_handlers.dart';
+import 'package:signals_core/signals_core.dart';
 
 /// How a child sandbox's `Path.` handler is derived from the parent's.
 ///
@@ -523,6 +525,20 @@ class PluginRegistry {
     }
 
     return buffer.toString().trimRight();
+  }
+
+  /// Returns one `(namespace, signal)` pair per plugin that mixes in
+  /// [StatefulPlugin].
+  ///
+  /// Consumers (e.g., an ag-ui session adapter) use these pairs to subscribe
+  /// to plugin state and emit `STATE_SNAPSHOT` + `STATE_DELTA` frames keyed
+  /// as `plugin.<namespace>`.
+  Iterable<(String, ReadonlySignal<Object?>)> statefulObservations() sync* {
+    for (final plugin in _plugins) {
+      if (plugin is HasStateSignal) {
+        yield (plugin.namespace, plugin.stateSignalAsObject);
+      }
+    }
   }
 
   /// Builds a composed child [OsCallHandler] from the parent's captured

--- a/lib/src/bridge/bridge/stateful_plugin.dart
+++ b/lib/src/bridge/bridge/stateful_plugin.dart
@@ -28,7 +28,7 @@ import 'package:signals_core/signals_core.dart';
 ///
 /// Subclasses MUST call [setInitialState] once before any reactive read; the
 /// recommended spot is the plugin's constructor body.
-mixin StatefulPlugin<T> on MontyPlugin {
+mixin StatefulPlugin<T> on MontyPlugin implements HasStateSignal {
   Signal<T>? _stateSignal;
 
   /// The reactive primary state of this plugin.
@@ -49,6 +49,9 @@ mixin StatefulPlugin<T> on MontyPlugin {
 
   /// Current non-reactive value of [stateSignal].
   T get state => stateSignal.value;
+
+  @override
+  ReadonlySignal<Object?> get stateSignalAsObject => stateSignal;
 
   /// Sets the initial state for [stateSignal]. Call once from the plugin's
   /// constructor body, before any handler runs.
@@ -76,4 +79,14 @@ mixin StatefulPlugin<T> on MontyPlugin {
     await super.onDispose();
     _stateSignal?.dispose();
   }
+}
+
+/// Non-generic base for type-safe introspection of [StatefulPlugin] plugins.
+///
+/// Provides a covariant-safe `stateSignal` accessor that returns
+/// `ReadonlySignal<Object?>`, allowing callers to subscribe to any
+/// [StatefulPlugin] without knowing its concrete type parameter.
+mixin HasStateSignal on MontyPlugin {
+  /// Returns [StatefulPlugin.stateSignal] typed as `ReadonlySignal<Object?>`.
+  ReadonlySignal<Object?> get stateSignalAsObject;
 }

--- a/test/bridge/src/bridge/plugin_registry_test.dart
+++ b/test/bridge/src/bridge/plugin_registry_test.dart
@@ -1,6 +1,7 @@
 import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
 import 'package:dart_monty/dart_monty_testing.dart';
+import 'package:signals_core/signals_core.dart' show ReadonlySignal;
 import 'package:test/test.dart';
 
 /// Minimal test plugin with configurable namespace and functions.
@@ -970,7 +971,73 @@ void main() {
         expect(alphaIdx, lessThan(betaIdx));
       });
     });
+
+    group('statefulObservations', () {
+      test('returns empty iterable when no stateful plugins registered', () {
+        registry.register(_TestPlugin(namespace: 'ns', functions: []));
+
+        expect(registry.statefulObservations(), isEmpty);
+      });
+
+      test('yields one pair per StatefulPlugin', () {
+        registry
+          ..register(_StatefulTestPlugin(namespace: 'alpha', initial: 'a'))
+          ..register(_StatefulTestPlugin(namespace: 'beta', initial: 'b'));
+
+        final observations = registry.statefulObservations().toList();
+
+        expect(observations, hasLength(2));
+        expect(observations[0].$1, 'alpha');
+        expect(observations[1].$1, 'beta');
+      });
+
+      test('skips plain (non-stateful) plugins', () {
+        registry
+          ..register(_TestPlugin(namespace: 'plain', functions: []))
+          ..register(_StatefulTestPlugin(namespace: 'stateful', initial: 0));
+
+        final observations = registry.statefulObservations().toList();
+
+        expect(observations, hasLength(1));
+        expect(observations.first.$1, 'stateful');
+      });
+
+      test('signal value reflects current plugin state', () {
+        final plugin = _StatefulTestPlugin(namespace: 'counter', initial: 0);
+        registry.register(plugin);
+
+        final (_, signal) = registry.statefulObservations().first;
+
+        expect(signal.value, 0);
+
+        plugin.state = 42;
+        expect(signal.value, 42);
+      });
+
+      test('stateSignalAsObject returns covariant-erased signal', () {
+        final plugin = _StatefulTestPlugin(namespace: 'typed', initial: 'x');
+        registry.register(plugin);
+
+        final (_, signal) = registry.statefulObservations().first;
+
+        expect(signal, isA<ReadonlySignal<Object?>>());
+        expect(signal.value, 'x');
+      });
+    });
   });
+}
+
+/// Plugin that mixes in `StatefulPlugin` for testing `statefulObservations`.
+class _StatefulTestPlugin<T> extends MontyPlugin with StatefulPlugin<T> {
+  _StatefulTestPlugin({required this.namespace, required T initial}) {
+    setInitialState(initial);
+  }
+
+  @override
+  final String namespace;
+
+  @override
+  List<HostFunction> get functions => [];
 }
 
 /// Plugin with configurable lifecycle callbacks for testing.


### PR DESCRIPTION
## Summary

- Adds `HasStateSignal` mixin (on `MontyPlugin`) with a `stateSignalAsObject` getter returning `ReadonlySignal<Object?>` — covariant-safe bridge for ag-ui consumers that don't know the concrete type parameter
- Makes `StatefulPlugin<T>` implement `HasStateSignal`, implementing `stateSignalAsObject` by returning its own `stateSignal`
- Adds `PluginRegistry.statefulObservations()` — iterates registered plugins and yields `(namespace, signal)` pairs for every `HasStateSignal` plugin, enabling the ag-ui session adapter to emit `STATE_SNAPSHOT` + `STATE_DELTA` frames keyed as `plugin.<namespace>`

## Test plan

- [x] `dart format --set-exit-if-changed .` — no changes
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dcm analyze .` — no issues
- [x] `dart test -p vm` — all 473 tests pass

Part of the ag-ui adapter milestone (A6). Off M1 (`refactor/plugin-surface-m1`, now merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)