### PR TITLE
fix(pages): update agent_demo.dart to OsCallHandler API

### DIFF
--- a/example/web/bin/agent_demo.dart
+++ b/example/web/bin/agent_demo.dart
@@ -15,6 +15,7 @@ import 'dart:js_interop';
 
 import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:file/memory.dart';
 
 // ---------------------------------------------------------------------------
 // JS interop — expose API to HTML
@@ -183,10 +184,10 @@ Future<bool> _init() async {
   if (_initialized) return true;
 
   try {
-    final os = OsProvider.compose({
-      'Path.': MemoryFsProvider(),
-      'date.': TimeOsProvider(),
-      'datetime.': TimeOsProvider(),
+    final os = composeOsHandlers({
+      'Path.': fsHandler(MemoryFileSystem()),
+      'date.': timeHandler(),
+      'datetime.': timeHandler(),
     });
 
     final tmplPlugin = JinjaTemplatePlugin();
@@ -195,7 +196,7 @@ Future<bool> _init() async {
 
     final plugins = <MontyPlugin>[tmplPlugin, msgPlugin];
     final sandboxPlugin = SandboxPlugin(
-      platformFactory: () async => Monty().platform,
+      platformFactory: () async => ReplPlatform(repl: MontyRepl()),
     );
     plugins.add(sandboxPlugin);
 


### PR DESCRIPTION
## Problem

GitHub Pages CI fails compiling `bin/agent_demo.dart` after the OsProvider hierarchy was deleted in #335:

```
Error: Method not found: 'MemoryFsProvider'.
Error: Method not found: 'TimeOsProvider'.
Error: Undefined name 'OsProvider'.
Error: The getter 'platform' isn't defined for the type 'Monty'.
```

## Fix

Update `agent_demo.dart` to the replacement API:

| Old (removed in #335) | New |
|---|---|
| `OsProvider.compose({...})` | `composeOsHandlers({...})` |
| `MemoryFsProvider()` | `fsHandler(MemoryFileSystem())` |
| `TimeOsProvider()` | `timeHandler()` |
| `Monty().platform` | `ReplPlatform(repl: MontyRepl())` |

Added `package:file/memory.dart` import for `MemoryFileSystem`.

`dart analyze` — zero issues after fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)