### PR TITLE
fix(example): update repl_demo.dart to use AgentSession API

### DIFF
--- a/example/web/bin/repl_demo.dart
+++ b/example/web/bin/repl_demo.dart
@@ -1,14 +1,14 @@
 // Standalone JS-compiled demo, not a package:test file.
 // ignore_for_file: avoid_print, lines_longer_than_80_chars, avoid_catches_without_on_clauses, cast_nullable_to_non_nullable
-/// Interactive REPL Session Demo — ReplSession + real plugins in the browser.
+/// Interactive REPL Session Demo — AgentSession + real plugins in the browser.
 ///
 /// Compiled to JS, exposes window.ReplSessionDemo to HTML.
-/// All host function dispatch (template, message bus, sandbox) runs in
+/// All host function dispatch (template, message bus) runs in
 /// compiled Dart — no JS host functions needed.
 ///
 /// Build:
-///   dart compile js test/wasm/integration/repl_session_demo.dart \
-///     -o test/wasm/integration/web/repl_session_demo.dart.js
+///   dart compile js example/web/bin/repl_demo.dart \
+///     -o example/web/web/repl_demo.dart.js
 library;
 
 import 'dart:convert';
@@ -16,7 +16,6 @@ import 'dart:js_interop';
 
 import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
-import 'package:dart_monty/src/wasm/monty_wasm.dart';
 
 // ---------------------------------------------------------------------------
 // JS interop — expose API to HTML
@@ -35,7 +34,7 @@ external void _jsOnToolCall(JSString jsonPayload);
 // State
 // ---------------------------------------------------------------------------
 
-late ReplSession _session;
+late AgentSession _session;
 
 // ---------------------------------------------------------------------------
 // API
@@ -44,7 +43,7 @@ late ReplSession _session;
 /// Run Python code and return JSON result.
 Future<String> _apiRun(String code) async {
   try {
-    final result = await _session.run(code);
+    final result = await _session.execute(code);
     return jsonEncode(_resultToJson(result));
   } catch (e) {
     return jsonEncode({'ok': false, 'error': e.toString()});
@@ -55,7 +54,7 @@ Future<String> _apiRun(String code) async {
 Future<String> _apiExecute(String code) async {
   try {
     final events = <Map<String, dynamic>>[];
-    await for (final event in _session.execute(code)) {
+    await for (final event in _session.executeStream(code)) {
       final map = _eventToJson(event);
       if (map != null) {
         events.add(map);
@@ -111,14 +110,10 @@ Future<String> _apiReset() async {
 void _createSession() {
   final tmpl = JinjaTemplatePlugin();
   final msgBus = MessageBusPlugin();
-  final sandbox = SandboxPlugin(
-    platformFactory: () async => MontyWasm(),
-    maxChildren: 8,
-    maxDepth: 2,
-  );
 
-  _session = ReplSession(
-    plugins: [tmpl, msgBus, sandbox],
+  // SandboxPlugin is FFI-only and cannot be used in a web build.
+  _session = AgentSession(
+    plugins: [tmpl, msgBus],
   );
 }
 


### PR DESCRIPTION
## Summary

- `ReplSession`, `MontyWasm`, and `src/wasm/monty_wasm.dart` no longer exist — the GitHub Pages deploy job was failing to compile `repl_demo.dart`
- Replace `ReplSession` → `AgentSession`
- `_session.run()` → `_session.execute()` (`Future<MontyResult>`)
- `_session.execute()` stream → `_session.executeStream()` (`Stream<BridgeEvent>`)
- Drop `SandboxPlugin` (FFI-only; `supportedBackends = {MontyBackendKind.ffi}` — unusable in a web/JS build)
- Remove broken import of non-existent `package:dart_monty/src/wasm/monty_wasm.dart`

## Test plan

- [x] `dart compile js bin/repl_demo.dart` compiles cleanly locally (verified)
- [x] Pages deploy job should go green on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)