### PR TITLE
fix(pages): update asset filenames to dart_monty_core_* after dart_monty_core#31

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -54,8 +54,8 @@ jobs:
           node build.js
       - name: Copy JS bridge assets to example
         run: |
-          cp dart_monty_core/assets/dart_monty_bridge.js example/web/web/
-          cp dart_monty_core/assets/dart_monty_worker.js example/web/web/
+          cp dart_monty_core/assets/dart_monty_core_bridge.js example/web/web/
+          cp dart_monty_core/assets/dart_monty_core_worker.js example/web/web/
 
       # ── Compile Dart to JS ───────────────────────────────────────────
       - uses: dart-lang/setup-dart@v1
@@ -102,7 +102,7 @@ jobs:
       - name: Copy live demo assets to site root
         run: |
           cp -r example/web/web/* site/
-          cp dart_monty_core/assets/dart_monty_native.wasm site/
+          cp dart_monty_core/assets/dart_monty_core_native.wasm site/
           mkdir -p site/fixtures
           cp test/fixtures/python_ladder/tier_*.json site/fixtures/
           mkdir -p site/assets

--- a/example/web/web/agent.html
+++ b/example/web/web/agent.html
@@ -568,7 +568,7 @@ x</textarea>
   </script>
 
   <!-- Load WASM bridge, then compiled Dart agent demo -->
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="agent_demo.dart.js"></script>
 
   <!-- UI wiring -->

--- a/example/web/web/demo.html
+++ b/example/web/web/demo.html
@@ -38,7 +38,7 @@
     };
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="main.dart.js"></script>
 </body>
 </html>

--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -407,9 +407,9 @@ dart_monty_core (backends)
 
     <h3>Web (WASM)</h3>
     <p>Copy the WASM assets to your web directory:</p>
-<pre>cp packages/dart_monty_wasm/assets/dart_monty_bridge.js web/
-cp packages/dart_monty_wasm/assets/dart_monty_worker.js web/
-cp packages/dart_monty_wasm/assets/dart_monty_native.wasm web/</pre>
+<pre>cp packages/dart_monty_wasm/assets/dart_monty_core_bridge.js web/
+cp packages/dart_monty_wasm/assets/dart_monty_core_worker.js web/
+cp packages/dart_monty_wasm/assets/dart_monty_core_native.wasm web/</pre>
     <p>Serve with <code>Cross-Origin-Opener-Policy: same-origin</code>
        and <code>Cross-Origin-Embedder-Policy: require-corp</code> headers
        (required for SharedArrayBuffer).</p>

--- a/example/web/web/ladder.html
+++ b/example/web/web/ladder.html
@@ -318,7 +318,7 @@
     }
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="ladder_showcase.dart.js"></script>
 </body>
 </html>

--- a/example/web/web/repl.html
+++ b/example/web/web/repl.html
@@ -58,7 +58,7 @@
     window._onReady = function() {};
     window._onToolCall = function() {};
   </script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="repl_demo.dart.js"></script>
   <script>
     const transcript = document.getElementById('transcript');

--- a/example/web/web/vfs.html
+++ b/example/web/web/vfs.html
@@ -390,7 +390,7 @@ files = sorted([p.name for p in Path('/sandbox/data').iterdir()], key=str)
   </script>
 
   <!-- Load WASM bridge, then compiled Dart VFS demo -->
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="vfs_demo.dart.js"></script>
 
   <!-- UI wiring (DOM is ready at this point) -->

--- a/example/web/web/visualizer.html
+++ b/example/web/web/visualizer.html
@@ -503,7 +503,7 @@
     }
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="visualizer.dart.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `dart_monty_core` PR #31 renamed all deployed assets to avoid a naming collision with the `dart_monty` package:
  - `dart_monty_bridge.js` → `dart_monty_core_bridge.js`
  - `dart_monty_worker.js` → `dart_monty_core_worker.js`
  - `dart_monty_native.wasm` → `dart_monty_core_native.wasm`
- The `pages.yaml` CI workflow and all HTML demo pages still referenced the old names, causing the GitHub Pages build to fail with `cp: cannot stat 'dart_monty_core/assets/dart_monty_bridge.js': No such file or directory`

## Changes

- `.github/workflows/pages.yaml` — update the 3 `cp` commands to use `dart_monty_core_*` filenames
- `example/web/web/{agent,demo,ladder,repl,vfs,visualizer}.html` — update `<script src>` tags
- `example/web/web/index.html` — update setup instructions in the `<pre>` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)