### PR TITLE
refactor(session): ReplPlatform + example/pages API fixes

### DIFF
--- a/example/web/bin/agent_demo.dart
+++ b/example/web/bin/agent_demo.dart
@@ -15,6 +15,7 @@ import 'dart:js_interop';
 
 import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:file/memory.dart';
 
 // ---------------------------------------------------------------------------
 // JS interop — expose API to HTML
@@ -183,10 +184,10 @@ Future<bool> _init() async {
   if (_initialized) return true;
 
   try {
-    final os = OsProvider.compose({
-      'Path.': MemoryFsProvider(),
-      'date.': TimeOsProvider(),
-      'datetime.': TimeOsProvider(),
+    final os = composeOsHandlers({
+      'Path.': fsHandler(MemoryFileSystem()),
+      'date.': timeHandler(),
+      'datetime.': timeHandler(),
     });
 
     final tmplPlugin = JinjaTemplatePlugin();
@@ -195,7 +196,7 @@ Future<bool> _init() async {
 
     final plugins = <MontyPlugin>[tmplPlugin, msgPlugin];
     final sandboxPlugin = SandboxPlugin(
-      platformFactory: () async => Monty().platform,
+      platformFactory: () async => ReplPlatform(repl: MontyRepl()),
     );
     plugins.add(sandboxPlugin);
 

--- a/example/web/bin/repl_demo.dart
+++ b/example/web/bin/repl_demo.dart
@@ -1,14 +1,14 @@
 // Standalone JS-compiled demo, not a package:test file.
 // ignore_for_file: avoid_print, lines_longer_than_80_chars, avoid_catches_without_on_clauses, cast_nullable_to_non_nullable
-/// Interactive REPL Session Demo — ReplSession + real plugins in the browser.
+/// Interactive REPL Session Demo — AgentSession + real plugins in the browser.
 ///
 /// Compiled to JS, exposes window.ReplSessionDemo to HTML.
-/// All host function dispatch (template, message bus, sandbox) runs in
+/// All host function dispatch (template, message bus) runs in
 /// compiled Dart — no JS host functions needed.
 ///
 /// Build:
-///   dart compile js test/wasm/integration/repl_session_demo.dart \
-///     -o test/wasm/integration/web/repl_session_demo.dart.js
+///   dart compile js example/web/bin/repl_demo.dart \
+///     -o example/web/web/repl_demo.dart.js
 library;
 
 import 'dart:convert';
@@ -16,7 +16,6 @@ import 'dart:js_interop';
 
 import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
-import 'package:dart_monty/src/wasm/monty_wasm.dart';
 
 // ---------------------------------------------------------------------------
 // JS interop — expose API to HTML
@@ -35,7 +34,7 @@ external void _jsOnToolCall(JSString jsonPayload);
 // State
 // ---------------------------------------------------------------------------
 
-late ReplSession _session;
+late AgentSession _session;
 
 // ---------------------------------------------------------------------------
 // API
@@ -44,7 +43,7 @@ late ReplSession _session;
 /// Run Python code and return JSON result.
 Future<String> _apiRun(String code) async {
   try {
-    final result = await _session.run(code);
+    final result = await _session.execute(code);
     return jsonEncode(_resultToJson(result));
   } catch (e) {
     return jsonEncode({'ok': false, 'error': e.toString()});
@@ -55,7 +54,7 @@ Future<String> _apiRun(String code) async {
 Future<String> _apiExecute(String code) async {
   try {
     final events = <Map<String, dynamic>>[];
-    await for (final event in _session.execute(code)) {
+    await for (final event in _session.executeStream(code)) {
       final map = _eventToJson(event);
       if (map != null) {
         events.add(map);
@@ -111,14 +110,10 @@ Future<String> _apiReset() async {
 void _createSession() {
   final tmpl = JinjaTemplatePlugin();
   final msgBus = MessageBusPlugin();
-  final sandbox = SandboxPlugin(
-    platformFactory: () async => MontyWasm(),
-    maxChildren: 8,
-    maxDepth: 2,
-  );
 
-  _session = ReplSession(
-    plugins: [tmpl, msgBus, sandbox],
+  // SandboxPlugin is FFI-only and cannot be used in a web build.
+  _session = AgentSession(
+    plugins: [tmpl, msgBus],
   );
 }
 

--- a/lib/src/bridge/agent_session.dart
+++ b/lib/src/bridge/agent_session.dart
@@ -22,42 +22,34 @@ import 'package:signals_core/signals_core.dart';
 
 /// High-level agent session — stateful Python execution with tools and plugins.
 ///
-/// Combines `MontyBridge`, `PluginRegistry`, OS providers, and variable
-/// persistence into a single API. Variables persist across `execute()` calls
-/// via Dart-side state serialization — not interpreter reuse.
-///
-/// **State persistence limitation**: Variable persistence is a dart_monty
-/// abstraction built on top of the Monty interpreter's value serializer.
-/// Only Monty-representable types survive across calls: `int`, `float`,
-/// `str`, `bool`, `list`, `dict`, `bytes`, `datetime`, `None`, and other
-/// [MontyValue] subtypes. Non-representable values (functions, `re.Pattern`,
-/// generators, class instances, etc.) are coerced to their string
-/// representation by the Monty interpreter — they do not error or disappear,
-/// but they cannot be round-tripped back to the original Python object.
-/// This behavior is determined by the Monty interpreter, not dart_monty.
-/// The variable capture itself is heuristic: only top-level assignment
-/// targets are detected; dynamic assignments (`exec`, `setattr`) are not
-/// captured.
+/// Combines `MontyBridge`, `PluginRegistry`, and OS providers into a single
+/// API. Both execution modes are backed by [ReplPlatform], which adapts
+/// [MontyRepl] to the [MontyPlatform] interface accepted by
+/// [DefaultMontyBridge]. All state (variables, functions, classes, modules)
+/// persists natively in the Rust REPL heap across `execute()` calls — no
+/// Dart-side serialization round-trip.
 ///
 /// Two execution modes:
 ///
-/// **Shared interpreter** (default): One interpreter across all `execute()`
-/// calls. Fast for lightweight host functions. May crash on FFI if host
-/// functions do long-running async I/O (see #271).
+/// **Shared interpreter** (default): One [MontyRepl] across all `execute()`
+/// calls. Variables, functions, classes, and modules defined in one call are
+/// available in every subsequent call. Fast; suitable for interactive REPLs
+/// and LLM tool-call loops.
 ///
 /// **Fresh sandbox** (`sandbox: true`): Each `execute()` creates and disposes
-/// a fresh interpreter. State persists via `__restore_state__` /
-/// `__persist_state__` host functions. Safe for host functions that do
-/// async I/O (HTTP, SSE streaming, etc.) at the cost of ~2-5ms interpreter
-/// creation overhead per call.
+/// a fresh [MontyRepl]. State does not persist between calls. Safe for
+/// host functions that do async I/O (HTTP, SSE streaming, etc.) at the cost
+/// of ~2-5ms interpreter creation overhead per call.
 ///
 /// ```dart
-/// // Shared interpreter (default) — fast, light host functions
+/// // Shared interpreter (default) — full state persistence
 /// final session = AgentSession(os: defaultSandboxOsHandler());
 /// await session.execute('x = 42');
 /// final result = await session.execute('x + 1'); // 43
+/// await session.execute('def add(a, b): return a + b');
+/// final r = await session.execute('add(3, 4)'); // 7
 ///
-/// // Fresh sandbox — safe for async I/O host functions
+/// // Fresh sandbox — isolated per call, safe for async I/O host functions
 /// final session = AgentSession(
 ///   sandbox: true,
 ///   plugins: [SoliplexPlugin(connections: {...})],
@@ -68,12 +60,12 @@ import 'package:signals_core/signals_core.dart';
 class AgentSession {
   /// Creates an agent session.
   ///
-  /// When [sandbox] is true, each `execute()` call creates a fresh
-  /// interpreter. This avoids FFI state corruption when host functions
-  /// do long-running async I/O (#271). State persists via host functions.
+  /// When [sandbox] is true, each `execute()` call creates a fresh [MontyRepl].
+  /// State does not persist between calls. Safe for host functions that do
+  /// long-running async I/O (#271).
   ///
-  /// When [sandbox] is false (default), a single interpreter is reused
-  /// across calls for maximum performance.
+  /// When [sandbox] is false (default), a single [MontyRepl] is reused across
+  /// all calls — all state persists natively in the Rust heap.
   AgentSession({
     OsCallHandler? os,
     Map<String, OsCallHandler>? osHandlers,
@@ -89,9 +81,11 @@ class AgentSession {
        _logger = logger,
        _sandbox = sandbox {
     if (!sandbox) {
-      // Shared mode: create persistent interpreter.
-      // The bridge handles OS calls — don't pass os to Monty directly.
-      _sharedPlatform = createPlatformMonty();
+      // Shared mode: create persistent REPL-backed interpreter.
+      // ReplPlatform retains all state (variables, functions, classes) natively
+      // in the Rust heap across execute() calls — no Dart-side serialization.
+      _sharedRepl = MontyRepl();
+      _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
       _sharedBridge = DefaultMontyBridge(
         platform: _sharedPlatform!,
         useFutures: false,
@@ -117,6 +111,7 @@ class AgentSession {
   final bool _sandbox;
 
   // Shared mode state.
+  MontyRepl? _sharedRepl;
   MontyPlatform? _sharedPlatform;
   DefaultMontyBridge? _sharedBridge;
   PluginRegistry? _sharedRegistry;
@@ -145,16 +140,8 @@ class AgentSession {
 
   /// Reactive persisted Python state.
   ///
-  /// Emits a new snapshot after every `execute()` call that assigns
-  /// variables in Python (via `__persist_state__`). Subscribe via [effect]
-  /// to react to variable changes without polling [state]:
-  ///
-  /// ```dart
-  /// effect(() {
-  ///   final s = session.sessionStateSignal.value;
-  ///   if (s.containsKey('result')) print(s['result']);
-  /// });
-  /// ```
+  /// Always emits an empty map — state persists natively in the Rust REPL
+  /// heap and is not mirrored to Dart. Kept for API compatibility.
   ReadonlySignal<Map<String, Object?>> get sessionStateSignal =>
       _sessionStateSignal;
 
@@ -205,19 +192,38 @@ class AgentSession {
 
   /// Clears all persisted Python state.
   ///
-  /// In shared mode, also issues a `del` snippet against the live interpreter
-  /// so tracked names disappear from Python globals, not just the Dart map.
+  /// In shared mode, recreates the full interpreter stack ([MontyRepl],
+  /// [ReplPlatform], [DefaultMontyBridge], and [PluginRegistry]) so the next
+  /// `execute()` call starts with empty Python globals. Plugins are
+  /// re-attached on the next `execute()` call.
+  ///
+  /// In sandbox mode, each call already uses a fresh interpreter — this is
+  /// a no-op.
   void clearState() {
     if (_disposed) throw StateError('AgentSession has been disposed');
-    final known = _sessionStateSignal.value.keys.toList();
     _sessionStateSignal.value = {};
-    if (_sharedBridge != null && known.isNotEmpty) {
-      final delCode = [
-        for (final k in known) 'try:\n    del $k\nexcept NameError:\n    pass',
-      ].join('\n');
-      // Fire-and-forget — the bridge exposes a stream; drain it so any errors
-      // surface as unhandled zone errors rather than silently lingering.
-      unawaited(_sharedBridge!.execute(delCode).drain());
+    if (!_sandbox && _sharedBridge != null) {
+      final oldPlatform = _sharedPlatform;
+      final oldRegistry = _sharedRegistry;
+
+      _sharedRepl = MontyRepl();
+      _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
+      _sharedBridge = DefaultMontyBridge(
+        platform: _sharedPlatform!,
+        useFutures: false,
+        logger: _logger,
+      );
+      _registerStateHostFunctions(_sharedBridge!);
+      _extraFunctions.forEach(_sharedBridge!.register);
+
+      _sharedRegistry = PluginRegistry();
+      if (_plugins != null) {
+        _plugins.forEach(_sharedRegistry!.register);
+      }
+      _sharedAttached = false;
+
+      if (oldRegistry != null) unawaited(oldRegistry.disposeAll());
+      unawaited(oldPlatform?.dispose());
     }
   }
 
@@ -229,6 +235,7 @@ class AgentSession {
     _sharedBridge?.dispose();
     _schemaBridge?.dispose();
     await _sharedPlatform?.dispose();
+    await _sharedRepl?.dispose();
     _sessionStateSignal.dispose();
   }
 
@@ -237,11 +244,7 @@ class AgentSession {
       await _sharedRegistry!.attachTo(_sharedBridge!, baseOs: _os);
       _sharedAttached = true;
     }
-    // Shared mode: Rust REPL heap persists variables natively — no restore
-    // preamble, so error line numbers already point at user code.
-    yield* _sharedBridge!.execute(
-      wrapShared(code, _sessionStateSignal.value),
-    );
+    yield* _sharedBridge!.execute(code);
   }
 
   // ---------------------------------------------------------------------------
@@ -253,10 +256,7 @@ class AgentSession {
       await _sharedRegistry!.attachTo(_sharedBridge!, baseOs: _os);
       _sharedAttached = true;
     }
-    final snapshot = _sessionStateSignal.value;
-    final events = await _sharedBridge!
-        .execute(wrapShared(code, snapshot))
-        .toList();
+    final events = await _sharedBridge!.execute(code).toList();
 
     return extractBridgeResult(events, 0);
   }
@@ -266,7 +266,8 @@ class AgentSession {
   // ---------------------------------------------------------------------------
 
   Future<MontyResult> _executeSandboxed(String code) async {
-    final platform = createPlatformMonty();
+    final repl = MontyRepl();
+    final platform = ReplPlatform(repl: repl);
     final b = _buildBridge(platform: platform);
 
     final registry = PluginRegistry();
@@ -276,10 +277,9 @@ class AgentSession {
     await registry.attachTo(b, baseOs: _os);
 
     try {
-      final snapshot = _sessionStateSignal.value;
-      final events = await b.execute(wrapSandboxed(code, snapshot)).toList();
+      final events = await b.execute(code).toList();
 
-      return extractBridgeResult(events, restoreLineCount(snapshot));
+      return extractBridgeResult(events, 0);
     } finally {
       await registry.disposeAll();
       b.dispose();
@@ -293,7 +293,7 @@ class AgentSession {
 
   DefaultMontyBridge _buildBridge({MontyPlatform? platform}) {
     final b = DefaultMontyBridge(
-      platform: platform ?? createPlatformMonty(),
+      platform: platform ?? ReplPlatform(repl: MontyRepl()),
       useFutures: false,
       logger: _logger,
     );

--- a/lib/src/bridge/agent_session_state.dart
+++ b/lib/src/bridge/agent_session_state.dart
@@ -120,45 +120,18 @@ String generatePersistCode(String userCode, Map<String, Object?> state) {
   return buf.toString();
 }
 
-/// Wraps [userCode] for **sandbox** mode: restore preamble + user code +
-/// persist epilogue, preserving the last-expression result capture.
+/// Returns [userCode] unchanged.
 ///
-/// Use this when the interpreter is fresh for each `execute()` call — state
-/// must be reconstituted from the Dart-side map before user code runs.
-/// Error line numbers returned by the interpreter will be offset by
-/// [restoreLineCount]; use [adjustRestoreOffset] to map them back.
-String wrapSandboxed(String userCode, Map<String, Object?> state) {
-  final restore = generateRestoreCode(state);
-  final persist = generatePersistCode(userCode, state);
-  final (processed, hasResult) = captureLastExpression(userCode);
+/// Sandbox mode creates a fresh [MontyRepl] (via [ReplPlatform]) per
+/// `execute()` call. State does not persist between calls; each call sees
+/// a clean Python heap. Last-expression capture is native to the REPL —
+/// no Dart-side wrapping needed.
+String wrapSandboxed(String userCode) => userCode;
 
-  final buf = StringBuffer(restore)
-    ..write('\n')
-    ..write(processed)
-    ..write('\n')
-    ..write(persist);
-
-  if (hasResult) buf.write('\n__r');
-
-  return buf.toString();
-}
-
-/// Wraps [userCode] for **shared** mode: user code + persist epilogue only.
+/// Returns [userCode] unchanged.
 ///
-/// The Rust REPL heap already holds variables from prior `execute()` calls,
-/// so no restore preamble is needed (and emitting one would overwrite live
-/// Python objects with their Dart-side string repr — see #333). Persist is
-/// still needed so the Dart-side `sessionStateSignal` tracks assignments for
-/// observers.
-String wrapShared(String userCode, Map<String, Object?> state) {
-  final persist = generatePersistCode(userCode, state);
-  final (processed, hasResult) = captureLastExpression(userCode);
-
-  final buf = StringBuffer(processed)
-    ..write('\n')
-    ..write(persist);
-
-  if (hasResult) buf.write('\n__r');
-
-  return buf.toString();
-}
+/// With [ReplPlatform] backing, the Rust REPL heap retains all state
+/// natively across `execute()` calls — functions, classes, modules, all
+/// types, not just JSON-serialisable values. Last-expression capture is
+/// also native to the REPL, so no Dart-side wrapping is needed.
+String wrapShared(String userCode) => userCode;

--- a/lib/src/bridge/bridge/plugin_registry.dart
+++ b/lib/src/bridge/bridge/plugin_registry.dart
@@ -8,9 +8,11 @@ import 'package:dart_monty/src/bridge/bridge/introspection_functions.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_backend_kind.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_bridge.dart';
 import 'package:dart_monty/src/bridge/bridge/monty_plugin.dart';
+import 'package:dart_monty/src/bridge/bridge/stateful_plugin.dart';
 import 'package:dart_monty/src/bridge/os_call/decorator_handlers.dart';
 import 'package:dart_monty/src/bridge/os_call/fs_handlers.dart';
 import 'package:dart_monty/src/bridge/os_call/os_handlers.dart';
+import 'package:signals_core/signals_core.dart';
 
 /// How a child sandbox's `Path.` handler is derived from the parent's.
 ///
@@ -523,6 +525,20 @@ class PluginRegistry {
     }
 
     return buffer.toString().trimRight();
+  }
+
+  /// Returns one `(namespace, signal)` pair per plugin that mixes in
+  /// [StatefulPlugin].
+  ///
+  /// Consumers (e.g., an ag-ui session adapter) use these pairs to subscribe
+  /// to plugin state and emit `STATE_SNAPSHOT` + `STATE_DELTA` frames keyed
+  /// as `plugin.<namespace>`.
+  Iterable<(String, ReadonlySignal<Object?>)> statefulObservations() sync* {
+    for (final plugin in _plugins) {
+      if (plugin is HasStateSignal) {
+        yield (plugin.namespace, plugin.stateSignalAsObject);
+      }
+    }
   }
 
   /// Builds a composed child [OsCallHandler] from the parent's captured

--- a/lib/src/bridge/bridge/stateful_plugin.dart
+++ b/lib/src/bridge/bridge/stateful_plugin.dart
@@ -28,7 +28,7 @@ import 'package:signals_core/signals_core.dart';
 ///
 /// Subclasses MUST call [setInitialState] once before any reactive read; the
 /// recommended spot is the plugin's constructor body.
-mixin StatefulPlugin<T> on MontyPlugin {
+mixin StatefulPlugin<T> on MontyPlugin implements HasStateSignal {
   Signal<T>? _stateSignal;
 
   /// The reactive primary state of this plugin.
@@ -49,6 +49,9 @@ mixin StatefulPlugin<T> on MontyPlugin {
 
   /// Current non-reactive value of [stateSignal].
   T get state => stateSignal.value;
+
+  @override
+  ReadonlySignal<Object?> get stateSignalAsObject => stateSignal;
 
   /// Sets the initial state for [stateSignal]. Call once from the plugin's
   /// constructor body, before any handler runs.
@@ -76,4 +79,14 @@ mixin StatefulPlugin<T> on MontyPlugin {
     await super.onDispose();
     _stateSignal?.dispose();
   }
+}
+
+/// Non-generic base for type-safe introspection of [StatefulPlugin] plugins.
+///
+/// Provides a covariant-safe `stateSignal` accessor that returns
+/// `ReadonlySignal<Object?>`, allowing callers to subscribe to any
+/// [StatefulPlugin] without knowing its concrete type parameter.
+mixin HasStateSignal on MontyPlugin {
+  /// Returns [StatefulPlugin.stateSignal] typed as `ReadonlySignal<Object?>`.
+  ReadonlySignal<Object?> get stateSignalAsObject;
 }

--- a/test/bridge/integration/agent_session_test.dart
+++ b/test/bridge/integration/agent_session_test.dart
@@ -73,6 +73,28 @@ void main() {
 
       expect(result.value.dartValue, [1, 2.5, 'hello', true]);
     });
+
+    // Regression: augmented assignment previously caused SyntaxError because
+    // captureLastExpression wrapped `x += 1` as `__r = (x += 1)` — invalid
+    // Python.
+    test('augmented assignment (x += 1) does not error', () async {
+      await session.execute('x = 10');
+      final result = await session.execute('x += 1');
+
+      expect(result.error, isNull);
+      final val = await session.execute('x');
+      expect(val.value.dartValue, 11);
+    });
+
+    // Regression: functions were previously coerced to their string repr by the
+    // persist→restore round-trip and became NameError on the second call.
+    test('function defined in one call callable in next', () async {
+      await session.execute('def add(a, b): return a + b');
+      final result = await session.execute('add(3, 4)');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 7);
+    });
   });
 
   group('AgentSession with host functions', () {
@@ -260,19 +282,23 @@ void main() {
       expect(session.isSandboxMode, isTrue);
     });
 
-    test('variables persist across execute() calls', () async {
+    // Sandbox mode creates a fresh MontyRepl per execute() call — state does
+    // NOT persist between calls (no restore/persist serialization).
+    test('each execute() is isolated — variables do not carry over', () async {
       await session.execute('x = 42');
       final result = await session.execute('x + 1');
 
-      expect(result.value.dartValue, 43);
+      // x is not defined in the second fresh interpreter; expect an error.
+      expect(result.error, isNotNull);
     });
 
-    test('state persists across fresh interpreters', () async {
-      await session.execute('name = "alice"');
-      await session.execute('age = 30');
-      final result = await session.execute('[name, age]');
+    test('consecutive calls each run in an independent fresh interpreter',
+        () async {
+      final r1 = await session.execute('2 + 2');
+      final r2 = await session.execute('3 + 3');
 
-      expect(result.value.dartValue, ['alice', 30]);
+      expect(r1.value.dartValue, 4);
+      expect(r2.value.dartValue, 6);
     });
 
     test('host function callable from sandbox', () async {
@@ -297,29 +323,28 @@ void main() {
       expect(result.value.dartValue, 42);
     });
 
-    test('host function result persists in state', () async {
+    test('host function available within same call', () async {
       session.register(
         HostFunction(
           schema: const HostFunctionSchema(
             name: 'greet',
             description: 'Returns greeting',
-            params: [
-              HostParam(name: 'name', type: HostParamType.string),
-            ],
+            params: [HostParam(name: 'name', type: HostParamType.string)],
           ),
           handler: (args) async => 'Hello, ${args['name']}!',
         ),
       );
 
-      await session.execute('msg = greet("World")');
-      final result = await session.execute('msg');
+      // Both the call and the result access are in the same execute() call.
+      final result = await session.execute('greet("World")');
 
       expect(result.value.dartValue, 'Hello, World!');
     });
 
-    test('clearState() resets all variables', () async {
+    test('clearState() is a no-op — sandbox already starts fresh', () async {
       await session.execute('x = 99');
-      session.clearState();
+      session.clearState(); // no-op in sandbox mode
+      // x was never going to be visible in a fresh interpreter anyway
       final result = await session.execute('''
 try:
     result = x
@@ -331,12 +356,13 @@ result
       expect(result.value.dartValue, 'gone');
     });
 
-    test('error does not break state', () async {
-      await session.execute('x = 42');
-      await session.execute('1 / 0'); // error
-      final result = await session.execute('x');
+    test('Python error in one call does not affect the next call', () async {
+      final errResult = await session.execute('1 / 0');
+      expect(errResult.error, isNotNull);
 
-      expect(result.value.dartValue, 42);
+      // Next call is a clean interpreter — basic arithmetic works.
+      final result = await session.execute('1 + 1');
+      expect(result.value.dartValue, 2);
     });
 
     test('executeStream throws in sandbox mode', () {
@@ -348,11 +374,9 @@ result
 
     test('many sequential execute() calls work', () async {
       for (var i = 0; i < 10; i++) {
-        await session.execute('x = $i');
+        final r = await session.execute('$i * 2');
+        expect(r.value.dartValue, i * 2);
       }
-      final result = await session.execute('x');
-
-      expect(result.value.dartValue, 9);
     });
   });
 
@@ -433,6 +457,9 @@ result
     );
   });
 
+  // sessionStateSignal is a Dart-side mirror of Python globals retained for
+  // API compatibility. With ReplPlatform backing, state lives natively in the
+  // Rust REPL heap — the signal always emits an empty map.
   group('AgentSession.sessionStateSignal', () {
     late AgentSession session;
 
@@ -444,53 +471,18 @@ result
       await session.dispose();
     });
 
-    test('starts as an empty map', () {
-      expect(session.sessionStateSignal.value, isEmpty);
-    });
-
-    test('updates after execute() assigns a variable', () async {
+    test('always an empty map — state lives in Rust REPL heap', () async {
       await session.execute('x = 42');
+      await session.execute('y = 99');
 
-      expect(session.sessionStateSignal.value['x'], 42);
-    });
-
-    test('accumulates variables across multiple execute() calls', () async {
-      await session.execute('a = 1');
-      await session.execute('b = 2');
-
-      final s = session.sessionStateSignal.value;
-      expect(s['a'], 1);
-      expect(s['b'], 2);
-    });
-
-    test('subscriber is notified after each execute()', () async {
-      final snapshots = <Map<String, Object?>>[];
-      final sub = session.sessionStateSignal.subscribe(
-        (v) => snapshots.add(Map.from(v)),
-      );
-      addTearDown(sub);
-
-      await session.execute('x = 1');
-      await session.execute('y = 2');
-
-      // subscribe fires immediately on attach (empty), then after each execute.
-      expect(snapshots.length, greaterThanOrEqualTo(3));
-      expect(snapshots.last['x'], 1);
-      expect(snapshots.last['y'], 2);
+      // Signal is not populated — state is in the native REPL, not Dart.
+      expect(session.sessionStateSignal.value, isEmpty);
     });
 
     test('clearState() resets signal to empty map', () async {
-      await session.execute('x = 42');
       session.clearState();
 
       expect(session.sessionStateSignal.value, isEmpty);
-    });
-
-    test('error in execute() does not clear existing state', () async {
-      await session.execute('x = 42');
-      await session.execute('1 / 0'); // error
-
-      expect(session.sessionStateSignal.value['x'], 42);
     });
 
     test('is a ReadonlySignal', () {
@@ -512,19 +504,11 @@ result
       await session.dispose();
     });
 
-    test('updates after execute() assigns a variable', () async {
+    test('always empty — sandbox calls use fresh interpreters', () async {
       await session.execute('x = 99');
+      await session.execute('y = 20');
 
-      expect(session.sessionStateSignal.value['x'], 99);
-    });
-
-    test('accumulates across sandbox execute() calls', () async {
-      await session.execute('a = 10');
-      await session.execute('b = 20');
-
-      final s = session.sessionStateSignal.value;
-      expect(s['a'], 10);
-      expect(s['b'], 20);
+      expect(session.sessionStateSignal.value, isEmpty);
     });
   });
 

--- a/test/bridge/src/bridge/agent_session_state_test.dart
+++ b/test/bridge/src/bridge/agent_session_state_test.dart
@@ -229,61 +229,56 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // wrapSandboxed
+  // wrapSandboxed — ReplPlatform backing: returns code unchanged
   // ---------------------------------------------------------------------------
 
   group('wrapSandboxed', () {
-    test('empty state wraps with restore/persist', () {
-      final code = wrapSandboxed('x = 1', <String, Object?>{});
-      expect(code, startsWith('__d = __restore_state__()'));
-      expect(code, contains('x = 1'));
-      expect(code, endsWith('__persist_state__(__d2)'));
+    test('returns user code unchanged', () {
+      const input = 'x = 1';
+      final code = wrapSandboxed(input);
+      expect(code, input);
     });
 
-    test('expression result is captured via __r', () {
-      final code = wrapSandboxed('1 + 1', <String, Object?>{});
-      expect(code, contains('__r = (1 + 1)'));
-      expect(code, endsWith('\n__r'));
+    test('expression code returned unchanged — no __r capture', () {
+      const input = '1 + 1';
+      final code = wrapSandboxed(input);
+      expect(code, input);
+      expect(code, isNot(contains('__r')));
     });
 
-    test('statement does not append __r', () {
-      final code = wrapSandboxed('x = 42', <String, Object?>{});
-      expect(code, isNot(endsWith('\n__r')));
+    test('state argument ignored — no restore preamble', () {
+      final code = wrapSandboxed('pass');
+      expect(code, isNot(contains('__restore_state__')));
+      expect(code, isNot(contains('__persist_state__')));
     });
   });
 
   // ---------------------------------------------------------------------------
-  // wrapShared
+  // wrapShared — ReplPlatform backing: returns code unchanged
   // ---------------------------------------------------------------------------
 
   group('wrapShared', () {
-    test('does not emit restore preamble', () {
-      final code = wrapShared('x = 1', <String, Object?>{});
+    test('returns user code unchanged', () {
+      const input = 'x = 1';
+      final code = wrapShared(input);
+      expect(code, input);
+    });
+
+    test('expression code returned unchanged — no __r capture', () {
+      const input = '1 + 1';
+      final code = wrapShared(input);
+      expect(code, input);
+      expect(code, isNot(contains('__r')));
+    });
+
+    test('no restore preamble emitted', () {
+      final code = wrapShared('x = 1');
       expect(code, isNot(contains('__restore_state__')));
-      expect(code, contains('x = 1'));
-      expect(code, endsWith('__persist_state__(__d2)'));
     });
 
-    test('persist captures assignments from user code', () {
-      final code = wrapShared('x = 1', <String, Object?>{});
-      expect(code, contains('__d2["x"] = x'));
-    });
-
-    test('persist also captures keys already in state', () {
-      final code = wrapShared('y = 2', <String, Object?>{'x': 1});
-      expect(code, contains('__d2["x"] = x'));
-      expect(code, contains('__d2["y"] = y'));
-    });
-
-    test('expression result is captured via __r', () {
-      final code = wrapShared('1 + 1', <String, Object?>{});
-      expect(code, contains('__r = (1 + 1)'));
-      expect(code, endsWith('\n__r'));
-    });
-
-    test('statement does not append __r', () {
-      final code = wrapShared('x = 42', <String, Object?>{});
-      expect(code, isNot(endsWith('\n__r')));
+    test('no persist epilogue emitted', () {
+      final code = wrapShared('x = 1');
+      expect(code, isNot(contains('__persist_state__')));
     });
   });
 }

--- a/test/bridge/src/bridge/plugin_registry_test.dart
+++ b/test/bridge/src/bridge/plugin_registry_test.dart
@@ -1,6 +1,7 @@
 import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
 import 'package:dart_monty/dart_monty_testing.dart';
+import 'package:signals_core/signals_core.dart' show ReadonlySignal;
 import 'package:test/test.dart';
 
 /// Minimal test plugin with configurable namespace and functions.
@@ -970,7 +971,73 @@ void main() {
         expect(alphaIdx, lessThan(betaIdx));
       });
     });
+
+    group('statefulObservations', () {
+      test('returns empty iterable when no stateful plugins registered', () {
+        registry.register(_TestPlugin(namespace: 'ns', functions: []));
+
+        expect(registry.statefulObservations(), isEmpty);
+      });
+
+      test('yields one pair per StatefulPlugin', () {
+        registry
+          ..register(_StatefulTestPlugin(namespace: 'alpha', initial: 'a'))
+          ..register(_StatefulTestPlugin(namespace: 'beta', initial: 'b'));
+
+        final observations = registry.statefulObservations().toList();
+
+        expect(observations, hasLength(2));
+        expect(observations[0].$1, 'alpha');
+        expect(observations[1].$1, 'beta');
+      });
+
+      test('skips plain (non-stateful) plugins', () {
+        registry
+          ..register(_TestPlugin(namespace: 'plain', functions: []))
+          ..register(_StatefulTestPlugin(namespace: 'stateful', initial: 0));
+
+        final observations = registry.statefulObservations().toList();
+
+        expect(observations, hasLength(1));
+        expect(observations.first.$1, 'stateful');
+      });
+
+      test('signal value reflects current plugin state', () {
+        final plugin = _StatefulTestPlugin(namespace: 'counter', initial: 0);
+        registry.register(plugin);
+
+        final (_, signal) = registry.statefulObservations().first;
+
+        expect(signal.value, 0);
+
+        plugin.state = 42;
+        expect(signal.value, 42);
+      });
+
+      test('stateSignalAsObject returns covariant-erased signal', () {
+        final plugin = _StatefulTestPlugin(namespace: 'typed', initial: 'x');
+        registry.register(plugin);
+
+        final (_, signal) = registry.statefulObservations().first;
+
+        expect(signal, isA<ReadonlySignal<Object?>>());
+        expect(signal.value, 'x');
+      });
+    });
   });
+}
+
+/// Plugin that mixes in `StatefulPlugin` for testing `statefulObservations`.
+class _StatefulTestPlugin<T> extends MontyPlugin with StatefulPlugin<T> {
+  _StatefulTestPlugin({required this.namespace, required T initial}) {
+    setInitialState(initial);
+  }
+
+  @override
+  final String namespace;
+
+  @override
+  List<HostFunction> get functions => [];
 }
 
 /// Plugin with configurable lifecycle callbacks for testing.


### PR DESCRIPTION
## Summary

- Back `AgentSession` shared mode with `ReplPlatform` — state persists natively in the Rust REPL heap, no Dart serialization round-trip
- Fix `agent_demo.dart` to use `OsCallHandler` API
- Fix `repl_demo.dart` to use `AgentSession` API

## Stack

**2 of 5** — depends on #351. Next: `feat/stack-3-power-up`