### PR TITLE
feat(m1): optional description, DescriptionProvider, exposedSchemas

### DIFF
--- a/lib/src/bridge/bridge.dart
+++ b/lib/src/bridge/bridge.dart
@@ -39,9 +39,8 @@ abstract class MontyBridge implements AttachContext {
   @override
   List<HostFunctionSchema> get schemas;
 
-  /// Schemas for functions visible to the LLM (where `surfaces` includes
-  /// [FunctionSurface.llm]).
-  List<HostFunctionSchema> get llmSchemas;
+  /// Schemas for functions that declare [FunctionSurface.llm].
+  List<HostFunctionSchema> get exposedSchemas;
 
   /// All registered function schemas, grouped by category.
   Map<String, List<HostFunctionSchema>> get schemasByCategory;

--- a/lib/src/bridge/platform.dart
+++ b/lib/src/bridge/platform.dart
@@ -161,7 +161,7 @@ class PlatformBridge implements MontyBridge, AttachContext {
   List<HostFunctionSchema> get schemas => _host.schemas;
 
   @override
-  List<HostFunctionSchema> get llmSchemas => _host.llmSchemas;
+  List<HostFunctionSchema> get exposedSchemas => _host.exposedSchemas;
 
   @override
   Map<String, List<HostFunctionSchema>> get schemasByCategory =>

--- a/lib/src/extension/coordinator.dart
+++ b/lib/src/extension/coordinator.dart
@@ -13,6 +13,20 @@ import 'package:dart_monty/src/os_call/os_handlers.dart';
 import 'package:dart_monty/src/runtime/backend_kind.dart';
 import 'package:signals_core/signals_core.dart';
 
+/// Provides a human-readable description for a named host function.
+///
+/// Return `null` to leave the function's existing description unchanged.
+/// Return a non-null string to override or supply the description —
+/// typically used by callers that want to inject LLM-optimised prose
+/// without embedding it in the core function definition.
+///
+/// ```dart
+/// MontyRuntime(
+///   descriptionProvider: (name) => myDescriptions[name],
+/// )
+/// ```
+typedef DescriptionProvider = String? Function(String functionName);
+
 /// How a child sandbox's `Path.` handler is derived from the parent's.
 ///
 /// Passed to [ExtensionCoordinator.spawnChild] to control filesystem visibility
@@ -44,15 +58,36 @@ enum ChildVfsStrategy {
 // Top-level helpers used by ExtensionCoordinator.attachTo.
 // ---------------------------------------------------------------------------
 
+/// Returns [fn] with its schema description overridden by [provider], or [fn]
+/// unchanged when [provider] is `null` or returns `null` for the function name.
+HostFunction _enrichFunction(HostFunction fn, DescriptionProvider? provider) {
+  if (provider == null) return fn;
+  final desc = provider(fn.schema.name);
+  if (desc == null) return fn;
+
+  return HostFunction(
+    schema: fn.schema.copyWithDescription(desc),
+    ffiHandler: fn.ffiHandler,
+    wasmHandler: fn.wasmHandler,
+    isInfra: fn.isInfra,
+    surfaces: fn.surfaces,
+    childPropagation: fn.childPropagation,
+  );
+}
+
 /// Injects scoped loggers and registers all extension functions with [bridge].
 void _attachExtensionFunctions(
   List<MontyExtension> attachOrder,
   MontyBridge bridge,
+  DescriptionProvider? descriptionProvider,
 ) {
   for (final ext in attachOrder) {
     ext.logger = bridge.logger.child(ext.namespace);
     for (final fn in ext.functions) {
-      bridge.register(fn, category: ext.namespace);
+      bridge.register(
+        _enrichFunction(fn, descriptionProvider),
+        category: ext.namespace,
+      );
     }
   }
 }
@@ -109,9 +144,13 @@ void _attachExtraFunctions(
   List<HostFunction> extraFunctions,
   MontyBridge bridge,
   BridgeLogger log,
+  DescriptionProvider? descriptionProvider,
 ) {
   for (final fn in extraFunctions) {
-    bridge.register(fn, category: 'extra');
+    bridge.register(
+      _enrichFunction(fn, descriptionProvider),
+      category: 'extra',
+    );
   }
   log.debug(
     'Registered extra functions',
@@ -309,6 +348,7 @@ class ExtensionCoordinator {
     List<HostFunction>? extraFunctions,
     bool enableIntrospection = true,
     OsCallHandler? baseOs,
+    DescriptionProvider? descriptionProvider,
   }) async {
     if (_attached) {
       throw StateError(
@@ -331,7 +371,7 @@ class ExtensionCoordinator {
     // (e.g. SandboxExtension) can reach it during lifecycle hooks.
     _injectCoordinators(attachOrder, this);
 
-    _attachExtensionFunctions(attachOrder, bridge);
+    _attachExtensionFunctions(attachOrder, bridge, descriptionProvider);
     _logExtensionsRegistered(attachOrder, _log);
     final contributions = _collectOsContributions(attachOrder);
     _osContributions = contributions;
@@ -339,7 +379,7 @@ class ExtensionCoordinator {
     _applyOsContributions(bridge, contributions, baseOs);
     if (extraFunctions != null && extraFunctions.isNotEmpty) {
       _extraFunctions = List.unmodifiable(extraFunctions);
-      _attachExtraFunctions(extraFunctions, bridge, _log);
+      _attachExtraFunctions(extraFunctions, bridge, _log, descriptionProvider);
     }
 
     final errors = await _runExtensionOnAttaches(attachOrder, bridge, _log);
@@ -490,9 +530,12 @@ class ExtensionCoordinator {
                   ': ${p.type.jsonSchemaType}',
             )
             .join(', ');
+        final fnName = fn.schema.name;
+        final desc = fn.schema.description;
         buffer.writeln(
-          '- `${fn.schema.name}($params)`:'
-          ' ${fn.schema.description}',
+          desc != null
+              ? '- `$fnName($params)`: $desc'
+              : '- `$fnName($params)`',
         );
       }
       buffer.writeln();

--- a/lib/src/host/dispatch.dart
+++ b/lib/src/host/dispatch.dart
@@ -194,8 +194,8 @@ class HostDispatch {
   List<HostFunctionSchema> get schemas =>
       _functions.values.map((f) => f.schema).toList(growable: false);
 
-  /// Schemas for functions visible to the LLM.
-  List<HostFunctionSchema> get llmSchemas => _functions.values
+  /// Schemas for functions that declare [FunctionSurface.llm].
+  List<HostFunctionSchema> get exposedSchemas => _functions.values
       .where((f) => f.surfaces.contains(FunctionSurface.llm))
       .map((f) => f.schema)
       .toList(growable: false);

--- a/lib/src/host/function.dart
+++ b/lib/src/host/function.dart
@@ -60,7 +60,7 @@ class HostFunction {
   /// Which surfaces this function is visible on.
   ///
   /// Defaults to `{FunctionSurface.python}`. Add [FunctionSurface.llm] to
-  /// expose the schema via `MontyRuntime.llmSchemas`.
+  /// expose the schema via `MontyRuntime.exposedSchemas`.
   final Set<FunctionSurface> surfaces;
 
   /// Whether this function is visible inside child sandboxes spawned from

--- a/lib/src/host/function_surface.dart
+++ b/lib/src/host/function_surface.dart
@@ -4,11 +4,11 @@ import 'package:dart_monty/src/host/function.dart' show HostFunction;
 ///
 /// Defaults to `{FunctionSurface.python}` — existing extensions register as
 /// Python-only with no change. Add [FunctionSurface.llm] to expose the
-/// function schema via `MontyRuntime.llmSchemas`.
+/// function schema via `MontyRuntime.exposedSchemas`.
 enum FunctionSurface {
   /// Callable from Python scripts via the host-function dispatch bridge.
   python,
 
-  /// Schema exposed to LLM consumers via `MontyRuntime.llmSchemas`.
+  /// Schema exposed to LLM consumers via `MontyRuntime.exposedSchemas`.
   llm,
 }

--- a/lib/src/host/schema.dart
+++ b/lib/src/host/schema.dart
@@ -10,9 +10,13 @@ import 'package:meta/meta.dart';
 @immutable
 class HostFunctionSchema {
   /// Creates a [HostFunctionSchema].
+  ///
+  /// [description] is optional. Infrastructure functions (e.g. `help`) may
+  /// omit it. Runtimes that expose functions to an LLM can inject descriptions
+  /// at registration time via `MontyRuntime`'s `descriptionProvider`.
   const HostFunctionSchema({
     required this.name,
-    required this.description,
+    this.description,
     this.params = const [],
   });
 
@@ -20,13 +24,24 @@ class HostFunctionSchema {
   final String name;
 
   /// Human-readable description for tool export.
-  final String description;
+  ///
+  /// `null` when no description has been provided. Omitted from JSON schema
+  /// and system-prompt output when `null`.
+  final String? description;
 
   /// Ordered parameter definitions.
   ///
   /// Positional args from Monty are mapped to params by insertion order.
   /// Keyword args overlay by name.
   final List<HostParam> params;
+
+  /// Returns a copy with [newDescription] as the description.
+  HostFunctionSchema copyWithDescription(String newDescription) =>
+      HostFunctionSchema(
+        name: name,
+        description: newDescription,
+        params: params,
+      );
 
   /// Returns a JSON Schema object describing this function's input.
   ///

--- a/lib/src/introspection_functions.dart
+++ b/lib/src/introspection_functions.dart
@@ -74,7 +74,7 @@ Map<String, Object?> _serializeParam(HostParam param) {
 Map<String, Object?> _serializeSchema(HostFunctionSchema schema) {
   return {
     'name': schema.name,
-    'description': schema.description,
+    if (schema.description != null) 'description': schema.description,
     'params': [for (final p in schema.params) _serializeParam(p)],
   };
 }

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -73,6 +73,7 @@ class MontyRuntime implements MontyRuntimeRef {
     BridgeLogger? logger,
     MontyInterceptor? interceptor,
     bool sandbox = false,
+    DescriptionProvider? descriptionProvider,
   }) : assert(
          os == null || osHandlers == null,
          'Pass either os or osHandlers, not both.',
@@ -81,7 +82,8 @@ class MontyRuntime implements MontyRuntimeRef {
        _extensions = extensions,
        _logger = logger,
        _interceptor = interceptor,
-       _sandbox = sandbox {
+       _sandbox = sandbox,
+       _descriptionProvider = descriptionProvider {
     if (!sandbox) {
       // Shared mode: create persistent REPL-backed interpreter.
       // ReplPlatform retains all state (variables, functions, classes) natively
@@ -113,6 +115,7 @@ class MontyRuntime implements MontyRuntimeRef {
   final BridgeLogger? _logger;
   final MontyInterceptor? _interceptor;
   final bool _sandbox;
+  final DescriptionProvider? _descriptionProvider;
 
   // Shared mode state.
   MontyRepl? _sharedRepl;
@@ -134,10 +137,11 @@ class MontyRuntime implements MontyRuntimeRef {
   List<HostFunctionSchema> get schemas =>
       (_sharedBridge ?? _schemaBridge)?.schemas ?? [];
 
-  /// Schemas for functions visible to the LLM (where [FunctionSurface.llm] is
-  /// declared). Feed these to an LLM alongside `execute_python`.
-  List<HostFunctionSchema> get llmSchemas =>
-      (_sharedBridge ?? _schemaBridge)?.llmSchemas ?? [];
+  /// Schemas for functions that declare [FunctionSurface.llm].
+  ///
+  /// Feed these to an LLM as tool definitions.
+  List<HostFunctionSchema> get exposedSchemas =>
+      (_sharedBridge ?? _schemaBridge)?.exposedSchemas ?? [];
 
   /// Broadcast stream of all [BridgeEvent]s emitted across every execution,
   /// including child executions spawned via extensions such as
@@ -167,10 +171,11 @@ class MontyRuntime implements MontyRuntimeRef {
   /// In sandbox mode, the function is registered on every fresh bridge.
   void register(HostFunction function) {
     if (_disposed) throw StateError('MontyRuntime has been disposed');
+    final fn = _applyDescription(function);
     if (_sharedBridge != null) {
-      _sharedBridge!.register(function);
+      _sharedBridge!.register(fn);
     }
-    _extraFunctions.add(function);
+    _extraFunctions.add(fn);
   }
 
   /// Executes Python [code] with state persistence and full tool access.
@@ -225,7 +230,11 @@ class MontyRuntime implements MontyRuntimeRef {
       );
     }
     if (!_sharedAttached) {
-      await _sharedRegistry!.attachTo(_sharedBridge!, baseOs: _os);
+      await _sharedRegistry!.attachTo(
+        _sharedBridge!,
+        baseOs: _os,
+        descriptionProvider: _descriptionProvider,
+      );
       _sharedAttached = true;
     }
 
@@ -296,7 +305,11 @@ class MontyRuntime implements MontyRuntimeRef {
         final overrideActive = osOverride != null;
         try {
           if (!_sharedAttached) {
-            await _sharedRegistry!.attachTo(_sharedBridge!, baseOs: _os);
+            await _sharedRegistry!.attachTo(
+              _sharedBridge!,
+              baseOs: _os,
+              descriptionProvider: _descriptionProvider,
+            );
             _sharedAttached = true;
           }
           if (overrideActive) {
@@ -355,7 +368,11 @@ class MontyRuntime implements MontyRuntimeRef {
         Object? error;
         StackTrace? stackTrace;
         try {
-          await registry.attachTo(b, baseOs: osOverride ?? _os);
+          await registry.attachTo(
+            b,
+            baseOs: osOverride ?? _os,
+            descriptionProvider: _descriptionProvider,
+          );
           final collected = <BridgeEvent>[];
           await for (final event in b.execute(code)) {
             collected.add(event);
@@ -414,5 +431,20 @@ class MontyRuntime implements MontyRuntimeRef {
     _extraFunctions.forEach(b.register);
 
     return b;
+  }
+
+  HostFunction _applyDescription(HostFunction fn) {
+    if (_descriptionProvider == null) return fn;
+    final desc = _descriptionProvider(fn.schema.name);
+    if (desc == null) return fn;
+
+    return HostFunction(
+      schema: fn.schema.copyWithDescription(desc),
+      ffiHandler: fn.ffiHandler,
+      wasmHandler: fn.wasmHandler,
+      isInfra: fn.isInfra,
+      surfaces: fn.surfaces,
+      childPropagation: fn.childPropagation,
+    );
   }
 }

--- a/test/src/bridge/extension_coordinator_test.dart
+++ b/test/src/bridge/extension_coordinator_test.dart
@@ -1097,7 +1097,7 @@ class _MockBridge implements MontyBridge {
       _functions.values.map((f) => f.schema).toList(growable: false);
 
   @override
-  List<HostFunctionSchema> get llmSchemas => const [];
+  List<HostFunctionSchema> get exposedSchemas => const [];
 
   @override
   Map<String, List<HostFunctionSchema>> get schemasByCategory {

--- a/test/src/bridge/introspection_functions_test.dart
+++ b/test/src/bridge/introspection_functions_test.dart
@@ -285,7 +285,7 @@ class _FakeBridge implements MontyBridge {
       _functions.values.map((f) => f.schema).toList(growable: false);
 
   @override
-  List<HostFunctionSchema> get llmSchemas => const [];
+  List<HostFunctionSchema> get exposedSchemas => const [];
 
   @override
   Map<String, List<HostFunctionSchema>> get schemasByCategory {

--- a/test/src/bridge/monty_extension_test.dart
+++ b/test/src/bridge/monty_extension_test.dart
@@ -114,7 +114,7 @@ class _NoOpBridge implements MontyBridge {
   List<HostFunctionSchema> get schemas => [];
 
   @override
-  List<HostFunctionSchema> get llmSchemas => [];
+  List<HostFunctionSchema> get exposedSchemas => [];
 
   @override
   Map<String, List<HostFunctionSchema>> get schemasByCategory => {};


### PR DESCRIPTION
## Summary

- `HostFunctionSchema.description` made optional (`String?`) — infra functions and extensions that inject descriptions at runtime no longer need a placeholder
- `DescriptionProvider` typedef injected at `MontyRuntime(descriptionProvider:)` — applied once at registration, separates LLM-facing copy from core function definitions
- `llmSchemas` → `exposedSchemas` across bridge/dispatch/runtime layers
- `HostFunctionSchema.copyWithDescription(String)` for creating enriched copies

## Stack

**4 of 5** — depends on #353. Next: `feat/stack-5-pages-experiments`