### PR TITLE
test(experiment): MontyHarness + 116-test suite + pages asset fix

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -54,8 +54,8 @@ jobs:
           node build.js
       - name: Copy JS bridge assets to example
         run: |
-          cp dart_monty_core/assets/dart_monty_bridge.js example/web/web/
-          cp dart_monty_core/assets/dart_monty_worker.js example/web/web/
+          cp dart_monty_core/assets/dart_monty_core_bridge.js example/web/web/
+          cp dart_monty_core/assets/dart_monty_core_worker.js example/web/web/
 
       # ── Compile Dart to JS ───────────────────────────────────────────
       - uses: dart-lang/setup-dart@v1
@@ -102,7 +102,7 @@ jobs:
       - name: Copy live demo assets to site root
         run: |
           cp -r example/web/web/* site/
-          cp dart_monty_core/assets/dart_monty_native.wasm site/
+          cp dart_monty_core/assets/dart_monty_core_native.wasm site/
           mkdir -p site/fixtures
           cp test/fixtures/python_ladder/tier_*.json site/fixtures/
           mkdir -p site/assets

--- a/example/web/web/agent.html
+++ b/example/web/web/agent.html
@@ -568,7 +568,7 @@ x</textarea>
   </script>
 
   <!-- Load WASM bridge, then compiled Dart agent demo -->
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="agent_demo.dart.js"></script>
 
   <!-- UI wiring -->

--- a/example/web/web/demo.html
+++ b/example/web/web/demo.html
@@ -38,7 +38,7 @@
     };
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="main.dart.js"></script>
 </body>
 </html>

--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -407,9 +407,9 @@ dart_monty_core (backends)
 
     <h3>Web (WASM)</h3>
     <p>Copy the WASM assets to your web directory:</p>
-<pre>cp packages/dart_monty_wasm/assets/dart_monty_bridge.js web/
-cp packages/dart_monty_wasm/assets/dart_monty_worker.js web/
-cp packages/dart_monty_wasm/assets/dart_monty_native.wasm web/</pre>
+<pre>cp packages/dart_monty_wasm/assets/dart_monty_core_bridge.js web/
+cp packages/dart_monty_wasm/assets/dart_monty_core_worker.js web/
+cp packages/dart_monty_wasm/assets/dart_monty_core_native.wasm web/</pre>
     <p>Serve with <code>Cross-Origin-Opener-Policy: same-origin</code>
        and <code>Cross-Origin-Embedder-Policy: require-corp</code> headers
        (required for SharedArrayBuffer).</p>

--- a/example/web/web/ladder.html
+++ b/example/web/web/ladder.html
@@ -318,7 +318,7 @@
     }
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="ladder_showcase.dart.js"></script>
 </body>
 </html>

--- a/example/web/web/repl.html
+++ b/example/web/web/repl.html
@@ -58,7 +58,7 @@
     window._onReady = function() {};
     window._onToolCall = function() {};
   </script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="repl_demo.dart.js"></script>
   <script>
     const transcript = document.getElementById('transcript');

--- a/example/web/web/vfs.html
+++ b/example/web/web/vfs.html
@@ -390,7 +390,7 @@ files = sorted([p.name for p in Path('/sandbox/data').iterdir()], key=str)
   </script>
 
   <!-- Load WASM bridge, then compiled Dart VFS demo -->
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="vfs_demo.dart.js"></script>
 
   <!-- UI wiring (DOM is ready at this point) -->

--- a/example/web/web/visualizer.html
+++ b/example/web/web/visualizer.html
@@ -503,7 +503,7 @@
     }
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="visualizer.dart.js"></script>
 </body>
 </html>

--- a/test/experiment/bridge_init_test.dart
+++ b/test/experiment/bridge_init_test.dart
@@ -1,0 +1,39 @@
+/// Minimal test to verify DartMontyBridge JS loads and initializes.
+@TestOn('browser')
+library;
+
+import 'dart:js_interop';
+import 'package:test/test.dart';
+
+@JS('DartMontyBridge')
+external JSAny? get _dartMontyBridge;
+
+@JS('DartMontyBridge.init')
+external JSAny? get _initFn;
+
+@JS('DartMontyBridge.init')
+external JSPromise<JSBoolean> _jsInit();
+
+void main() {
+  test('DartMontyBridge is registered on window', () {
+    final bridge = _dartMontyBridge;
+    expect(bridge, isNotNull, reason: 'window.DartMontyBridge must be defined');
+  });
+
+  test('DartMontyBridge.init is a function', () {
+    final fn = _initFn;
+    expect(fn, isNotNull, reason: 'DartMontyBridge.init must be defined');
+  });
+
+  test(
+    'DartMontyBridge.init() resolves to true (worker + WASM load)',
+    () async {
+      final result = await _jsInit().toDart;
+      expect(
+        result.toDart,
+        isTrue,
+        reason: 'init() must return true — Worker + WASM loaded',
+      );
+    },
+  );
+}

--- a/test/experiment/examples/event_loop_experiment_test.dart
+++ b/test/experiment/examples/event_loop_experiment_test.dart
@@ -1,0 +1,365 @@
+// G3-G4: EventLoop extension experiments.
+//
+// Covers the cooperative coroutine pattern: el_recv/el_emit, multi-round
+// dispatch, state machine transitions, channelStateSignal, lastEmittedSignal,
+// error cases, and FauxUi observation.
+//
+// Run with:
+//   dart test --tags=integration \
+//     test/experiment/examples/event_loop_experiment_test.dart
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // G3-1: Basic dispatch → el_recv round-trip
+  // ---------------------------------------------------------------------------
+
+  group('G3-1: basic el_recv / el_emit round-trip', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python receives dispatched event via el_recv', () async {
+      const script = '''
+event = el_recv()
+event['action']
+''';
+
+      // Start execution — Python will park at el_recv().
+      final handle = h.runtime.execute(script);
+
+      // Wait for Python to reach el_recv (state → Waiting).
+      await _untilWaiting(el);
+      expect(el.isWaiting, isTrue);
+
+      // Dispatch wakes Python.
+      el.dispatch({'action': 'ping'});
+
+      final result = await handle.result;
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'ping');
+    });
+
+    test('el_emit pushes value to lastEmittedSignal', () async {
+      const script = "el_emit(value={'status': 'ready'})";
+
+      await h.run(script);
+
+      expect(el.lastEmitted, isNotNull);
+      expect(el.lastEmitted!['status'], 'ready');
+    });
+
+    test('state is EventLoopCompleted after execution finishes', () async {
+      final result = await h.run('1 + 1');
+
+      expect(result.error, isNull);
+      expect(el.channelState, isA<EventLoopCompleted>());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G3-2: Pre-dispatch — queue before el_recv
+  // ---------------------------------------------------------------------------
+
+  group('G3-2: pre-dispatch queuing', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('events dispatched before el_recv are returned immediately', () async {
+      // Dispatch before Python runs — goes to queue.
+      el
+        ..dispatch({'seq': 0})
+        ..dispatch({'seq': 1});
+
+      final result = await h.run('''
+a = el_recv()
+b = el_recv()
+[a['seq'], b['seq']]
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, [0, 1]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G3-3: Multi-round — el_recv called multiple times
+  // ---------------------------------------------------------------------------
+
+  group('G3-3: multi-round exchange', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python loops on el_recv — three dispatch cycles', () async {
+      const script = '''
+total = 0
+for _ in range(3):
+    event = el_recv()
+    total += event['n']
+total
+''';
+
+      final handle = h.runtime.execute(script);
+
+      for (var i = 1; i <= 3; i++) {
+        await _untilWaiting(el);
+        el.dispatch({'n': i});
+      }
+
+      final result = await handle.result;
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 6); // 1+2+3
+    });
+
+    test('el_emit fires each round — lastEmittedSignal updates', () async {
+      final emitted = <Map<String, Object?>>[];
+      final cleanup = el.lastEmittedSignal.subscribe((v) {
+        if (v != null) emitted.add(v);
+      });
+
+      const script = '''
+for i in range(3):
+    event = el_recv()
+    el_emit(value={'round': event['round']})
+''';
+
+      final handle = h.runtime.execute(script);
+
+      for (var i = 0; i < 3; i++) {
+        await _untilWaiting(el);
+        el.dispatch({'round': i});
+      }
+
+      await handle.result;
+      cleanup();
+
+      expect(emitted, hasLength(3));
+      expect(emitted.map((e) => e['round']), orderedEquals([0, 1, 2]));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G3-4: Error cases
+  // ---------------------------------------------------------------------------
+
+  group('G3-4: EventLoop error cases', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('dispatch on completed state throws StateError', () async {
+      await h.run('1 + 1');
+      expect(el.channelState, isA<EventLoopCompleted>());
+
+      expect(
+        () => el.dispatch({'x': 1}),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('script error transitions to Completed, not stuck Waiting', () async {
+      const script = '''
+el_recv()
+undefined_var_that_errors
+''';
+
+      final handle = h.runtime.execute(script);
+      await _untilWaiting(el);
+      el.dispatch({'ok': true});
+
+      final result = await handle.result;
+      expect(result.error, isNotNull); // Python errored
+      expect(el.channelState, isA<EventLoopCompleted>());
+    });
+
+    test('dispose while waiting completes completer with error', () async {
+      final el2 = EventLoopExtension();
+      final h2 = MontyHarness(extensions: [el2]);
+      await h2.setup();
+
+      const script = 'el_recv()';
+      final handle = h2.runtime.execute(script);
+
+      await _untilWaiting(el2);
+
+      // Dispose while waiting — should complete completer with error.
+      await h2.dispose();
+
+      // Result future should have resolved (with error).
+      final result = await handle.result;
+      // The script never completed normally — error captured
+      expect(
+        result.error != null || el2.channelState is EventLoopDisposed,
+        isTrue,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G4-1: channelStateSignal — SignalCapture
+  // ---------------------------------------------------------------------------
+
+  group('G4-1: channelStateSignal transitions via SignalCapture', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test(
+      'captures Idle → Executing → Waiting → Executing → Completed',
+      () async {
+        final cap = SignalCapture(el.channelStateSignal);
+
+        const script = '''
+el_recv()
+''';
+
+        final handle = h.runtime.execute(script);
+        await _untilWaiting(el);
+        el.dispatch({'go': true});
+        await handle.result;
+
+        cap.dispose();
+
+        final types = cap.values.map((s) => s.runtimeType.toString()).toList();
+        expect(types, contains('EventLoopExecuting'));
+        expect(types, contains('EventLoopWaiting'));
+        expect(types, contains('EventLoopCompleted'));
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // G4-2: FauxUi + EventLoop — BridgeRunStarted + BridgeRunFinished
+  // ---------------------------------------------------------------------------
+
+  group('G4-2: FauxUi observes full run lifecycle', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+    late FauxUi ui;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+      ui = FauxUi(h.runtime);
+    });
+
+    tearDown(() async {
+      ui.dispose();
+      await h.dispose();
+    });
+
+    test('FauxUi sees BridgeRunStarted and BridgeRunFinished', () async {
+      el.dispatch({'skip': true});
+
+      await h.run('el_recv()');
+
+      ui
+        ..assertContains<BridgeRunStarted>()
+        ..assertContains<BridgeRunFinished>();
+    });
+
+    test('el_emit produces BridgeFunctionCallStart for el_emit', () async {
+      await h.run("el_emit(value={'x': 1})");
+
+      final calls = ui.eventsOf<BridgeFunctionCallStart>();
+      expect(calls.map((e) => e.name), contains('el_emit'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G4-3: lastEmittedSignal reactive subscription
+  // ---------------------------------------------------------------------------
+
+  group('G4-3: lastEmittedSignal reactive', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('SignalCapture on lastEmittedSignal records every emission', () async {
+      final cap = SignalCapture(el.lastEmittedSignal);
+
+      await h.run('''
+el_emit(value={'n': 1})
+el_emit(value={'n': 2})
+el_emit(value={'n': 3})
+''');
+
+      cap.dispose();
+      // cap.values[0] is null (initial), then 3 updates.
+      final nonNull = cap.values.where((v) => v != null).toList();
+      expect(nonNull, hasLength(3));
+      expect(nonNull.map((e) => e!['n']), orderedEquals([1, 2, 3]));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+} // end main
+
+/// Polls until `el.isWaiting` becomes true (Python reached el_recv).
+Future<void> _untilWaiting(EventLoopExtension el) async {
+  const maxWait = Duration(seconds: 5);
+  const interval = Duration(milliseconds: 10);
+  final deadline = DateTime.now().add(maxWait);
+
+  while (!el.isWaiting) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw TimeoutException('EventLoopExtension never reached Waiting state');
+    }
+    await Future<void>.delayed(interval);
+  }
+}

--- a/test/experiment/examples/fault_injection_experiment_test.dart
+++ b/test/experiment/examples/fault_injection_experiment_test.dart
@@ -1,0 +1,327 @@
+// Experiment: fault injection through the harness interceptor.
+//
+// Exercises what happens when host functions fail, return unexpected types,
+// are slow, or are denied. Python must handle these correctly — or reveal
+// that it can't. No server required.
+//
+// Run with:
+//   dart test --tags=integration --run-skipped \
+//     test/experiment/examples/fault_injection_experiment_test.dart
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // Fault: tool throws — Python sees error, session survives
+  // ---------------------------------------------------------------------------
+
+  group('ToolFault.throws — Python error containment', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool('risky_op', (args, ctx) async => 'success');
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('injected throw surfaces as Python error, session survives', () async {
+      h.injectFault('risky_op', ToolFault.throws(Exception('db_timeout')));
+
+      final r = await h.run('risky_op()');
+      expect(
+        r.error,
+        isNotNull,
+        reason: 'Injected throw must surface as a Python-level error',
+      );
+
+      // Session must survive — clear the fault and retry.
+      h.clearFault('risky_op');
+      final r2 = await h.run('risky_op()');
+      expect(r2.error, isNull);
+      expect(r2.value.dartValue, 'success');
+    });
+
+    test('Python try/except catches injected error', () async {
+      h.injectFault('risky_op', ToolFault.throws(Exception('transient')));
+
+      final r = await h.run('''
+try:
+    result = risky_op()
+except Exception as e:
+    result = f'caught:{str(e)}'
+result
+''');
+
+      expect(
+        r.error,
+        isNull,
+        reason: 'Python try/except should handle the injected error',
+      );
+      expect(r.value.dartValue.toString(), contains('caught'));
+    });
+
+    test('error in one tool does not block unrelated tools', () async {
+      h
+        ..registerTool('stable_op', (args, ctx) async => 42)
+        ..injectFault('risky_op', ToolFault.throws(Exception('boom')));
+
+      await h.run('risky_op()'); // error — recorded
+
+      final r = await h.run('stable_op()');
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 42);
+
+      h
+        ..assertCalled('risky_op')
+        ..assertCalled('stable_op');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fault: tool returns overridden value
+  // ---------------------------------------------------------------------------
+
+  group('ToolFault.returns — result override', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool(
+          'fetch_price',
+          (args, ctx) async => {'price': 99.99, 'currency': 'USD'},
+          params: [
+            const HostParam(name: 'symbol', type: HostParamType.string),
+          ],
+        );
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('injected return value replaces real handler', () async {
+      h.injectFault(
+        'fetch_price',
+        ToolFault.returns({'price': 0.01, 'currency': 'USD'}),
+      );
+
+      final r = await h.run("fetch_price(symbol='AAPL')['price']");
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 0.01);
+
+      h.assertCalled('fetch_price', args: {'symbol': 'AAPL'});
+    });
+
+    test('null override — Python sees None', () async {
+      h.injectFault('fetch_price', ToolFault.returns(null));
+
+      final r = await h.run('''
+p = fetch_price(symbol='X')
+p is None
+''');
+      expect(r.value.dartValue, true);
+    });
+
+    test('clear fault — real handler runs again', () async {
+      h.injectFault('fetch_price', ToolFault.returns({'price': 0.01}));
+      await h.run("fetch_price(symbol='X')");
+
+      h.clearFault('fetch_price');
+      final r = await h.run("fetch_price(symbol='X')['price']");
+      expect(r.value.dartValue, 99.99);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fault: delayed tool — Python blocks, but completes
+  // ---------------------------------------------------------------------------
+
+  group('ToolFault.delayed — slow tool', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool('slow_api', (args, ctx) async => 'response');
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('delayed tool still completes — session not corrupted', () async {
+      h.injectFault(
+        'slow_api',
+        ToolFault.delayed(
+          const Duration(milliseconds: 100),
+          then: 'delayed_ok',
+        ),
+      );
+
+      final sw = Stopwatch()..start();
+      final r = await h.run('slow_api()');
+      sw.stop();
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 'delayed_ok');
+      expect(sw.elapsedMilliseconds, greaterThanOrEqualTo(100));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Systematic fault matrix: all faults on every tool in a chain
+  // ---------------------------------------------------------------------------
+
+  group('fault matrix — chain of tools under fault', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool('step_a', (args, ctx) async => 'a_ok')
+        ..registerTool('step_b', (args, ctx) async => 'b_ok')
+        ..registerTool('step_c', (args, ctx) async => 'c_ok');
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    const chain = '''
+a = step_a()
+b = step_b()
+c = step_c()
+[a, b, c]
+''';
+
+    test('no faults — chain succeeds end to end', () async {
+      final r = await h.run(chain);
+      expect(r.error, isNull);
+      expect(r.value.dartValue, ['a_ok', 'b_ok', 'c_ok']);
+    });
+
+    test('fault on step_a — step_b and step_c still called', () async {
+      h.injectFault('step_a', ToolFault.returns('a_override'));
+
+      final r = await h.run(chain);
+      expect(r.error, isNull);
+      expect(r.value.dartValue, ['a_override', 'b_ok', 'c_ok']);
+      h
+        ..assertCallCount('step_a', 1)
+        ..assertCallCount('step_b', 1)
+        ..assertCallCount('step_c', 1);
+    });
+
+    test('throw on step_b — step_c is NOT called (error propagates)', () async {
+      h.injectFault('step_b', ToolFault.throws(Exception('b_fail')));
+
+      final r = await h.run(chain);
+      expect(
+        r.error,
+        isNotNull,
+        reason: 'Uncaught tool error must propagate to Python',
+      );
+      h
+        ..assertCalled('step_a')
+        ..assertCalled('step_b')
+        // step_c is never reached because step_b's exception propagates.
+        ..assertNotCalled('step_c');
+    });
+
+    test('throw on step_b caught in Python — step_c still runs', () async {
+      h.injectFault('step_b', ToolFault.throws(Exception('b_fail')));
+
+      final r = await h.run('''
+a = step_a()
+try:
+    b = step_b()
+except Exception:
+    b = 'b_fallback'
+c = step_c()
+[a, b, c]
+''');
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, ['a_ok', 'b_fallback', 'c_ok']);
+      h
+        ..assertCalled('step_a')
+        ..assertCalled('step_b')
+        ..assertCalled('step_c');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Call recording verification
+  // ---------------------------------------------------------------------------
+
+  group('call recording', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool(
+          'log_event',
+          (args, ctx) async => null,
+          params: [
+            const HostParam(name: 'event', type: HostParamType.string),
+            const HostParam(
+              name: 'seq',
+              type: HostParamType.integer,
+              isRequired: false,
+            ),
+          ],
+        );
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('calls are recorded in order', () async {
+      await h.run('''
+log_event(event='start', seq=0)
+log_event(event='middle', seq=1)
+log_event(event='end', seq=2)
+''');
+
+      final calls = h.callsTo('log_event');
+      expect(calls, hasLength(3));
+      expect(calls[0].args['seq'], 0);
+      expect(calls[1].args['seq'], 1);
+      expect(calls[2].args['seq'], 2);
+    });
+
+    test('resetCalls() clears between sub-experiments', () async {
+      await h.run("log_event(event='first')");
+      h
+        ..assertCallCount('log_event', 1)
+        ..resetCalls()
+        ..assertNotCalled('log_event');
+
+      await h.run("log_event(event='second')");
+      h.assertCallCount('log_event', 1);
+    });
+
+    test('succeeded calls have no error', () async {
+      await h.run("log_event(event='ok')");
+      final calls = h.callsTo('log_event');
+      expect(calls.first.succeeded, isTrue);
+      expect(calls.first.result, isNull);
+    });
+
+    test('failed calls have error recorded', () async {
+      h.injectFault('log_event', ToolFault.throws(Exception('boom')));
+      await h.run("log_event(event='fail')");
+
+      final calls = h.callsTo('log_event');
+      expect(calls.first.succeeded, isFalse);
+      expect(calls.first.error, isNotNull);
+    });
+
+    test('assertNoErrors passes when all calls succeeded', () async {
+      await h.run("log_event(event='a')");
+      h.assertNoErrors();
+    });
+  });
+}

--- a/test/experiment/examples/host_communication_experiment_test.dart
+++ b/test/experiment/examples/host_communication_experiment_test.dart
@@ -1,0 +1,281 @@
+// G7: Dart↔host communication experiments.
+//
+// Covers MontyRuntime.invoke() from Dart, ctx.emitText(), HostContext fields,
+// clearState(), state persistence across execute() calls, Jinja templates,
+// and composition of Jinja + MessageBus.
+//
+// Run with:
+//   dart test --tags=integration \
+//     test/experiment/examples/host_communication_experiment_test.dart
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // G7-1: invoke() from Dart — bypasses Python entirely
+  // ---------------------------------------------------------------------------
+
+  group('G7-1: invoke() from Dart', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool(
+          'add',
+          (args, ctx) async => (args['a']! as int) + (args['b']! as int),
+          params: [
+            const HostParam(name: 'a', type: HostParamType.integer),
+            const HostParam(name: 'b', type: HostParamType.integer),
+          ],
+        );
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('invoke() returns handler result without Python', () async {
+      final result = await h.runtime.invoke('add', {'a': 3, 'b': 4});
+      expect(result, 7);
+    });
+
+    test('invoke() routes through interceptor — call is recorded', () async {
+      await h.runtime.invoke('add', {'a': 1, 'b': 1});
+      h.assertCalled('add', args: {'a': 1, 'b': 1});
+    });
+
+    test('invoke() and Python calls share the same recorder', () async {
+      await h.runtime.invoke('add', {'a': 10, 'b': 0});
+      await h.run('add(a=5, b=3)');
+
+      h.assertCallCount('add', 2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G7-2: ctx.emitText() — text emissions visible in event stream
+  // ---------------------------------------------------------------------------
+
+  group('G7-2: ctx.emitText() in host handler', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool('stream_words', (args, ctx) async {
+          ctx
+            ..emitText('Hello ')
+            ..emitText('world');
+          return 'done';
+        });
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('BridgeFunctionEmit events appear for each emitText call', () async {
+      final (:result, :events) = await h.runWithEvents('stream_words()');
+
+      expect(result.error, isNull);
+      final emits = events.whereType<BridgeFunctionEmit>().toList();
+      expect(emits, isNotEmpty);
+      final texts = emits.map((e) => e.text).join();
+      expect(texts, contains('Hello'));
+      expect(texts, contains('world'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G7-3: State persistence across execute() calls
+  // ---------------------------------------------------------------------------
+
+  group('G7-3: state persists across execute() calls', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness();
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('variable defined in first call is accessible in second', () async {
+      await h.run('x = 42');
+      final result = await h.run('x + 1');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 43);
+    });
+
+    test('function defined in first call is callable in second', () async {
+      await h.run('def double(n): return n * 2');
+      final result = await h.run('double(7)');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 14);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G7-4: clearState() resets Python globals
+  // ---------------------------------------------------------------------------
+
+  group('G7-4: clearState() wipes Python globals', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness();
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('after clearState, previously defined var is gone', () async {
+      await h.run('secret = 99');
+      h.runtime.clearState();
+
+      final result = await h.run('secret');
+      expect(result.error, isNotNull); // NameError
+    });
+
+    test('after clearState, new definitions work normally', () async {
+      await h.run('old = 1');
+      h.runtime.clearState();
+      await h.run('fresh = 2');
+
+      final result = await h.run('fresh');
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 2);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G7-5: Jinja template rendering
+  // ---------------------------------------------------------------------------
+
+  group('G7-5: JinjaTemplateExtension', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness(extensions: [JinjaTemplateExtension()]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('tmpl_render substitutes a variable', () async {
+      final result = await h.run('''
+tmpl_render(template='Hello, {{ name }}!', context={'name': 'Alice'})
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'Hello, Alice!');
+    });
+
+    test('tmpl_render supports for loops', () async {
+      final result = await h.run('''
+tmpl_render(
+    template='{% for item in items %}{{ item }} {% endfor %}',
+    context={'items': ['a', 'b', 'c']}
+)
+''');
+
+      expect(result.error, isNull);
+      expect((result.value.dartValue! as String).trim(), 'a b c');
+    });
+
+    test('tmpl_render supports if conditionals', () async {
+      final result = await h.run('''
+tmpl_render(
+    template='{% if flag %}yes{% else %}no{% endif %}',
+    context={'flag': True}
+)
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'yes');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G7-6: Jinja + MessageBus composition
+  // ---------------------------------------------------------------------------
+
+  group('G7-6: Jinja + MessageBus composition', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(
+        extensions: [
+          JinjaTemplateExtension(),
+          MessageBusExtension(bus: bus),
+        ],
+      );
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python renders template then sends result on bus', () async {
+      await h.run('''
+rendered = tmpl_render(
+    template='Dear {{ name }}, your order {{ id }} is ready.',
+    context={'name': 'Bob', 'id': 'ORD-42'}
+)
+msg_send(name='notifications', message=rendered)
+''');
+
+      final msg = (await bus.recv('notifications'))! as String;
+      expect(msg, contains('Bob'));
+      expect(msg, contains('ORD-42'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G7-7: HostContext.executionId is unique per execute()
+  // ---------------------------------------------------------------------------
+
+  group('G7-7: executionId uniqueness', () {
+    late MontyHarness h;
+    final execIds = <String>[];
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool('capture_id', (args, ctx) async {
+          execIds.add(ctx.executionId);
+          return ctx.executionId;
+        });
+      await h.setup();
+    });
+
+    tearDown(() async {
+      execIds.clear();
+      await h.dispose();
+    });
+
+    test('executionId differs across two execute() calls', () async {
+      await h.run('capture_id()');
+      await h.run('capture_id()');
+
+      expect(execIds, hasLength(2));
+      expect(execIds.first, isNot(execIds.last));
+    });
+
+    test(
+      'each tool invocation gets a unique executionId within one execute()',
+      () async {
+        await h.run('capture_id(); capture_id()');
+
+        expect(execIds, hasLength(2));
+        // Each call gets its own call-scoped ID — they differ within one
+        // execute().
+        expect(execIds.first, isNot(execIds.last));
+      },
+    );
+  });
+} // end main

--- a/test/experiment/examples/message_bus_experiment_test.dart
+++ b/test/experiment/examples/message_bus_experiment_test.dart
@@ -1,0 +1,323 @@
+// G6: MessageBus extension experiments.
+//
+// Covers Dart↔Python messaging, peek, close, high-volume throughput,
+// multiple channels, timeout recv, channel stats signals, and FauxUi.
+//
+// Run with:
+//   dart test --tags=integration \
+//     test/experiment/examples/message_bus_experiment_test.dart
+@Tags(['integration'])
+library;
+
+import 'dart:async';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // G6-1: Python sends, Dart receives
+  // ---------------------------------------------------------------------------
+
+  group('G6-1: Python sends → Dart receives', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python msg_send, Dart reads via bus.recv', () async {
+      // Start execution — Python sends then returns.
+      await h.run("msg_send(name='out', message={'result': 42})");
+
+      final msg = (await bus.recv('out'))! as Map;
+      expect(msg['result'], 42);
+    });
+
+    test('Python sends multiple messages — Dart drains in order', () async {
+      await h.run('''
+for i in range(5):
+    msg_send(name='nums', message=i)
+''');
+
+      final results = <Object?>[];
+      for (var i = 0; i < 5; i++) {
+        results.add(await bus.recv('nums'));
+      }
+      expect(results, [0, 1, 2, 3, 4]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G6-2: Dart sends, Python receives
+  // ---------------------------------------------------------------------------
+
+  group('G6-2: Dart sends → Python receives', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Dart pre-queues message, Python reads with msg_recv', () async {
+      bus.send('tasks', {'job': 'compress', 'file': 'data.csv'});
+
+      final result = await h.run('''
+task = msg_recv(name='tasks')
+task['job']
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'compress');
+    });
+
+    test('Dart sends concurrently with Python msg_recv blocking', () async {
+      const script = "msg_recv(name='async_ch')";
+      final runFuture = h.run(script);
+
+      // Give Python time to block on recv, then send.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      bus.send('async_ch', {'token': 'hello'});
+
+      final result = await runFuture;
+      expect(result.error, isNull);
+      final msg = result.value.dartValue! as Map;
+      expect(msg['token'], 'hello');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G6-3: msg_peek
+  // ---------------------------------------------------------------------------
+
+  group('G6-3: msg_peek', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('msg_peek returns front without consuming', () async {
+      bus
+        ..send('peekable', 'first')
+        ..send('peekable', 'second');
+
+      final result = await h.run('''
+p = msg_peek(name='peekable')
+r = msg_recv(name='peekable')
+[p, r]
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, ['first', 'first']);
+      // Queue should still have 'second'.
+      expect(bus.peek('peekable'), 'second');
+    });
+
+    test('msg_peek on empty channel returns None', () async {
+      final result = await h.run("msg_peek(name='empty_ch')");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G6-4: msg_close
+  // ---------------------------------------------------------------------------
+
+  group('G6-4: msg_close', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('msg_recv on closed empty channel returns None', () async {
+      bus.close('done');
+
+      final result = await h.run("msg_recv(name='done')");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, isNull);
+    });
+
+    test('close unblocks Python waiting on recv', () async {
+      const script = "msg_recv(name='drain')";
+      final runFuture = h.run(script);
+
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+      bus.close('drain');
+
+      final result = await runFuture;
+      expect(result.error, isNull);
+      expect(result.value.dartValue, isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G6-5: msg_stats
+  // ---------------------------------------------------------------------------
+
+  group('G6-5: msg_stats via snapshotSignal', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('snapshotSignal reflects send + recv counts', () async {
+      await h.run('''
+msg_send(name='stats_ch', message=1)
+msg_send(name='stats_ch', message=2)
+msg_recv(name='stats_ch')
+''');
+
+      final snap = bus.channel('stats_ch').snapshot;
+      expect(snap.sendCount, 2);
+      expect(snap.recvCount, 1);
+      expect(snap.queueDepth, 1);
+    });
+
+    test('peakQueueDepth tracks historical max', () async {
+      await h.run('''
+msg_send(name='peak', message=1)
+msg_send(name='peak', message=2)
+msg_send(name='peak', message=3)
+msg_recv(name='peak')
+msg_recv(name='peak')
+msg_recv(name='peak')
+''');
+
+      final snap = bus.channel('peak').snapshot;
+      expect(snap.peakQueueDepth, 3);
+      expect(snap.queueDepth, 0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G6-6: Multiple channels — isolation
+  // ---------------------------------------------------------------------------
+
+  group('G6-6: multiple channels are isolated', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('messages on channel A do not appear on channel B', () async {
+      await h.run('''
+msg_send(name='chA', message='alpha')
+msg_send(name='chB', message='beta')
+''');
+
+      expect(await bus.recv('chA'), 'alpha');
+      expect(bus.peek('chB'), 'beta');
+      expect(bus.peek('chA'), isNull); // A is now empty
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G6-7: High-volume throughput
+  // ---------------------------------------------------------------------------
+
+  group('G6-7: high-volume throughput', () {
+    late MontyHarness h;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('1000 messages sent + received without loss', () async {
+      await h.run('''
+for i in range(1000):
+    msg_send(name='bulk', message=i)
+''');
+
+      var received = 0;
+      var sum = 0;
+      while (bus.peek('bulk') != null) {
+        sum += (await bus.recv('bulk'))! as int;
+        received++;
+      }
+
+      expect(received, 1000);
+      expect(sum, 499500); // 0+1+...+999
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G6-8: FauxUi — msg_send/recv appear in event stream
+  // ---------------------------------------------------------------------------
+
+  group('G6-8: FauxUi observes msg_send events', () {
+    late MontyHarness h;
+    late MessageBus bus;
+    late FauxUi ui;
+
+    setUp(() async {
+      bus = MessageBus();
+      h = MontyHarness(extensions: [MessageBusExtension(bus: bus)]);
+      await h.setup();
+      ui = FauxUi(h.runtime);
+    });
+
+    tearDown(() async {
+      ui.dispose();
+      await h.dispose();
+    });
+
+    test('msg_send call appears as BridgeFunctionCallStart', () async {
+      await h.run("msg_send(name='x', message=1)");
+
+      final calls = ui.eventsOf<BridgeFunctionCallStart>();
+      expect(calls.map((e) => e.name), contains('msg_send'));
+    });
+
+    test('reset() clears event history between observations', () async {
+      await h.run("msg_send(name='x', message=1)");
+      ui.reset();
+      await h.run("msg_send(name='x', message=2)");
+
+      expect(ui.eventsOf<BridgeFunctionCallStart>(), hasLength(1));
+    });
+  });
+} // end main

--- a/test/experiment/examples/sandbox_experiment_test.dart
+++ b/test/experiment/examples/sandbox_experiment_test.dart
@@ -1,0 +1,331 @@
+// G1-G2: Sandbox extension experiments — FFI only.
+//
+// Covers child lifecycle, parallel execution, error propagation, output
+// capture, signals (childrenSignal / aliveCountSignal), gather, and limits.
+//
+// Run with:
+//   dart test -p vm --tags=integration \
+//     test/experiment/examples/sandbox_experiment_test.dart
+@TestOn('vm')
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+// Builds a fresh ReplPlatform for each sandbox child.
+MontyPlatformFactory _replFactory() =>
+    () async => ReplPlatform(repl: MontyRepl());
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // G1-1: Basic spawn → await round-trip
+  // ---------------------------------------------------------------------------
+
+  group('G1-1: sandbox basic spawn + await', () {
+    late MontyHarness h;
+    late SandboxExtension sandbox;
+
+    setUp(() async {
+      sandbox = SandboxExtension(platformFactory: _replFactory());
+      h = MontyHarness(extensions: [sandbox]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('child completes and returns a value', () async {
+      final result = await h.run('''
+handle = sandbox_spawn(code="1 + 1")
+sandbox_await(handle=handle)
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 2);
+    });
+
+    test('child is ChildCompleted in childrenSignal after await', () async {
+      await h.run('''
+handle = sandbox_spawn(code="42")
+sandbox_await(handle=handle)
+''');
+
+      final states = sandbox.childrenSignal.value;
+      expect(states.values.whereType<ChildCompleted>(), isNotEmpty);
+    });
+
+    test('child value is accessible after free', () async {
+      await h.run('''
+h1 = sandbox_spawn(code="'hello'")
+v = sandbox_await(handle=h1)
+sandbox_free(handle=h1)
+v
+''');
+
+      // After free, handle removed from map
+      expect(sandbox.childrenSignal.value, isEmpty);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G1-2: Parallel children
+  // ---------------------------------------------------------------------------
+
+  group('G1-2: parallel children', () {
+    late MontyHarness h;
+    late SandboxExtension sandbox;
+
+    setUp(() async {
+      sandbox = SandboxExtension(platformFactory: _replFactory());
+      h = MontyHarness(extensions: [sandbox]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('two children run concurrently', () async {
+      final result = await h.run('''
+h1 = sandbox_spawn(code="1 + 1")
+h2 = sandbox_spawn(code="10 + 10")
+r1 = sandbox_await(handle=h1)
+r2 = sandbox_await(handle=h2)
+[r1, r2]
+''');
+
+      expect(result.error, isNull);
+      final list = result.value.dartValue! as List;
+      expect(list, containsAll([2, 20]));
+    });
+
+    test('sandbox_await_all returns results in handle order', () async {
+      final result = await h.run('''
+h1 = sandbox_spawn(code="1")
+h2 = sandbox_spawn(code="2")
+h3 = sandbox_spawn(code="3")
+sandbox_await_all(handles=[h1, h2, h3])
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, [1, 2, 3]);
+    });
+
+    test('aliveCountSignal tracks running children', () async {
+      final counts = <int>[];
+      final cleanup = effect(() => counts.add(sandbox.aliveCountSignal.value));
+
+      await h.run('''
+h1 = sandbox_spawn(code="1")
+h2 = sandbox_spawn(code="2")
+sandbox_await_all(handles=[h1, h2])
+''');
+
+      cleanup();
+      expect(counts, contains(2)); // peak of 2 alive simultaneously
+      expect(counts.last, 0); // back to 0 after both complete
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G1-3: Error propagation
+  // ---------------------------------------------------------------------------
+
+  group('G1-3: child error propagation', () {
+    late MontyHarness h;
+    late SandboxExtension sandbox;
+
+    setUp(() async {
+      sandbox = SandboxExtension(platformFactory: _replFactory());
+      h = MontyHarness(extensions: [sandbox]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('child Python error reaches parent as ChildFailed', () async {
+      await h.run('''
+h1 = sandbox_spawn(code="undefined_variable")
+try:
+    sandbox_await(handle=h1)
+except Exception as e:
+    str(e)
+''');
+
+      final failed = sandbox.childrenSignal.value.values
+          .whereType<ChildFailed>()
+          .toList();
+      expect(failed, isNotEmpty);
+      expect(failed.first.exception, isNotNull);
+    });
+
+    test('ChildFailed contains Python exception type', () async {
+      await h.run('''
+h1 = sandbox_spawn(code="raise ValueError('boom')")
+try:
+    sandbox_await(handle=h1)
+except Exception:
+    pass
+''');
+
+      final failed = sandbox.childrenSignal.value.values
+          .whereType<ChildFailed>()
+          .first;
+      expect(failed.exception?.excType, contains('ValueError'));
+    });
+
+    test('parent continues after child failure', () async {
+      final result = await h.run('''
+h1 = sandbox_spawn(code="raise RuntimeError('x')")
+try:
+    sandbox_await(handle=h1)
+except Exception:
+    pass
+"parent survived"
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'parent survived');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G1-4: Output capture
+  // ---------------------------------------------------------------------------
+
+  group('G1-4: print output capture', () {
+    late MontyHarness h;
+    late SandboxExtension sandbox;
+
+    setUp(() async {
+      sandbox = SandboxExtension(platformFactory: _replFactory());
+      h = MontyHarness(extensions: [sandbox]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('sandbox_get_output returns print() lines', () async {
+      final result = await h.run(r'''
+h1 = sandbox_spawn(code="print('hello')\nprint('world')")
+sandbox_await(handle=h1)
+sandbox_get_output(handle=h1)
+''');
+
+      expect(result.error, isNull);
+      final output = result.value.dartValue as String?;
+      expect(output, contains('hello'));
+      expect(output, contains('world'));
+    });
+
+    test('sandbox_gather includes output and return value', () async {
+      final result = await h.run(r'''
+h1 = sandbox_spawn(code="print('log line')\n42")
+results = sandbox_gather(handles=[h1])
+results[0]
+''');
+
+      expect(result.error, isNull);
+      final entry = result.value.dartValue! as Map;
+      expect(entry['value'], 42);
+      expect(entry['output'] as String, contains('log line'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G1-5: sandbox_is_alive
+  // ---------------------------------------------------------------------------
+
+  group('G1-5: sandbox_is_alive', () {
+    late MontyHarness h;
+    late SandboxExtension sandbox;
+
+    setUp(() async {
+      sandbox = SandboxExtension(platformFactory: _replFactory());
+      h = MontyHarness(extensions: [sandbox]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('is_alive returns True while child running, False after', () async {
+      final result = await h.run('''
+h1 = sandbox_spawn(code="1 + 1")
+# is_alive before await should typically be True (racing, but test the API)
+sandbox_await(handle=h1)
+sandbox_is_alive(handle=h1)
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G2-1: childrenSignal + FauxUi — BridgeChildEvent integration
+  // ---------------------------------------------------------------------------
+
+  group('G2-1: FauxUi observes BridgeChildEvent from sandbox children', () {
+    late MontyHarness h;
+    late SandboxExtension sandbox;
+    late FauxUi ui;
+
+    setUp(() async {
+      sandbox = SandboxExtension(platformFactory: _replFactory());
+      h = MontyHarness(extensions: [sandbox]);
+      await h.setup();
+      ui = FauxUi(h.runtime);
+    });
+
+    tearDown(() async {
+      ui.dispose();
+      await h.dispose();
+    });
+
+    test(
+      'child executions arrive as BridgeChildEvent in runtime.events',
+      () async {
+        await h.run('''
+h1 = sandbox_spawn(code="1 + 1")
+sandbox_await(handle=h1)
+''');
+
+        ui.assertContains<BridgeChildEvent>();
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // G2-2: SignalCapture on childrenSignal
+  // ---------------------------------------------------------------------------
+
+  group('G2-2: SignalCapture on childrenSignal', () {
+    late MontyHarness h;
+    late SandboxExtension sandbox;
+
+    setUp(() async {
+      sandbox = SandboxExtension(platformFactory: _replFactory());
+      h = MontyHarness(extensions: [sandbox]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('captures every state transition in childrenSignal', () async {
+      final cap = SignalCapture(sandbox.childrenSignal);
+
+      await h.run('''
+h1 = sandbox_spawn(code="99")
+sandbox_await(handle=h1)
+''');
+
+      cap.dispose();
+      // States: {} (initial) → {0: ChildRunning()} → {0: ChildCompleted()}
+      expect(cap.values.length, greaterThanOrEqualTo(2));
+      final finalState = cap.values.last;
+      expect(finalState.values.whereType<ChildCompleted>(), isNotEmpty);
+    });
+  });
+} // end main

--- a/test/experiment/examples/schema_experiment_test.dart
+++ b/test/experiment/examples/schema_experiment_test.dart
@@ -109,6 +109,14 @@ void main() {
       expect(result.error, isNull);
       expect(result.value.dartValue, 42);
     });
+
+    test('unknown kwarg raises error — schema rejects it', () async {
+      // F9 regression guard: removing the unknown-kwarg check in
+      // HostFunctionSchema.mapAndValidate() would make this pass silently.
+      final result = await h.run("typed_tool(n=1, surprise='x')");
+
+      expect(result.error, isNotNull);
+    });
   });
 
   // ---------------------------------------------------------------------------

--- a/test/experiment/examples/schema_experiment_test.dart
+++ b/test/experiment/examples/schema_experiment_test.dart
@@ -1,0 +1,223 @@
+// G9: HostParam / schema / edge cases.
+//
+// Covers schema generation, required/optional params, wrong-type args,
+// MontyValueX type assertions, and extension introspection.
+//
+// Run with:
+//   dart test --tags=integration \
+//     test/experiment/examples/schema_experiment_test.dart
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // G9-1: Schema generation — schemas + llmSchemas
+  // ---------------------------------------------------------------------------
+
+  group('G9-1: schema generation', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool(
+          'search',
+          (a, c) async => [],
+          description: 'Search for items',
+          params: [
+            const HostParam(
+              name: 'query',
+              type: HostParamType.string,
+              description: 'Search query',
+            ),
+            const HostParam(
+              name: 'limit',
+              type: HostParamType.integer,
+              isRequired: false,
+              description: 'Max results',
+            ),
+          ],
+        )
+        ..registerTool('noop', (a, c) async => null);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('schemas contains entries for registered tools', () {
+      final names = h.runtime.schemas.map((s) => s.name).toList();
+      expect(names, contains('search'));
+      expect(names, contains('noop'));
+    });
+
+    test('search schema has correct param count', () {
+      final schema = h.runtime.schemas.firstWhere((s) => s.name == 'search');
+      expect(schema.params, hasLength(2));
+    });
+
+    test('required param has isRequired true, optional false', () {
+      final schema = h.runtime.schemas.firstWhere((s) => s.name == 'search');
+      final query = schema.params.firstWhere((p) => p.name == 'query');
+      final limit = schema.params.firstWhere((p) => p.name == 'limit');
+      expect(query.isRequired, isTrue);
+      expect(limit.isRequired, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G9-2: Wrong param type — Python passes wrong type
+  // ---------------------------------------------------------------------------
+
+  group('G9-2: wrong param type handling', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool(
+          'typed_tool',
+          (args, ctx) async {
+            final n = args['n'];
+            if (n is! int) throw ArgumentError('n must be int, got $n');
+            return n * 2;
+          },
+          params: [
+            const HostParam(name: 'n', type: HostParamType.integer),
+          ],
+        );
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('handler can validate types and throw', () async {
+      final (:result, :events) = await h.runWithEvents(
+        "typed_tool(n='not_a_number')",
+      );
+
+      // Python receives the exception as an error string — execution continues.
+      // (Per feedback: errors are returned not thrown, so LLM can handle them.)
+      expect(result.error, isNotNull);
+    });
+
+    test('correct int type passes through cleanly', () async {
+      final result = await h.run('typed_tool(n=21)');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 42);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G9-3: Optional params — None default in Python
+  // ---------------------------------------------------------------------------
+
+  group('G9-3: optional params', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool(
+          'greet',
+          (args, ctx) async {
+            final name = args['name']! as String;
+            final lang = args['lang'] as String? ?? 'en';
+            return lang == 'es' ? 'Hola, $name!' : 'Hello, $name!';
+          },
+          params: [
+            const HostParam(name: 'name', type: HostParamType.string),
+            const HostParam(
+              name: 'lang',
+              type: HostParamType.string,
+              isRequired: false,
+            ),
+          ],
+        );
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('omitting optional param uses Dart-side default', () async {
+      final result = await h.run("greet(name='Alice')");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'Hello, Alice!');
+    });
+
+    test('passing optional param overrides default', () async {
+      final result = await h.run("greet(name='Alice', lang='es')");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'Hola, Alice!');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G9-4: MontyValue type assertions — dartValue coercions
+  // ---------------------------------------------------------------------------
+
+  group('G9-4: MontyValue types via dartValue', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness();
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python int → Dart int', () async {
+      final r = await h.run('42');
+      expect(r.value.dartValue, isA<int>());
+      expect(r.value.dartValue, 42);
+    });
+
+    test('Python float → Dart double', () async {
+      final r = await h.run('3.14');
+      expect(r.value.dartValue, isA<double>());
+      expect(r.value.dartValue! as double, closeTo(3.14, 0.001));
+    });
+
+    test('Python str → Dart String', () async {
+      final r = await h.run("'hello'");
+      expect(r.value.dartValue, isA<String>());
+      expect(r.value.dartValue, 'hello');
+    });
+
+    test('Python bool → Dart bool', () async {
+      final r = await h.run('True');
+      expect(r.value.dartValue, isA<bool>());
+      expect(r.value.dartValue, true);
+    });
+
+    test('Python list → Dart List', () async {
+      final r = await h.run('[1, 2, 3]');
+      expect(r.value.dartValue, isA<List<Object?>>());
+      expect(r.value.dartValue, [1, 2, 3]);
+    });
+
+    test('Python dict → Dart Map', () async {
+      final r = await h.run("{'key': 'value', 'n': 7}");
+      expect(r.value.dartValue, isA<Map<String, Object?>>());
+      final m = r.value.dartValue! as Map<String, Object?>;
+      expect(m['key'], 'value');
+      expect(m['n'], 7);
+    });
+
+    test('Python None → Dart null', () async {
+      final r = await h.run('None');
+      expect(r.value.dartValue, isNull);
+    });
+
+    test('Python nested structure round-trips cleanly', () async {
+      final r = await h.run("[{'x': 1}, {'x': 2}]");
+      final list = r.value.dartValue! as List;
+      expect(list.first, {'x': 1});
+      expect(list.last, {'x': 2});
+    });
+  });
+} // end main

--- a/test/experiment/examples/signals_experiment_test.dart
+++ b/test/experiment/examples/signals_experiment_test.dart
@@ -1,0 +1,330 @@
+// G5: Signals experiments.
+//
+// Covers SignalCapture, Computed signals, effect cleanup, per-plugin reactive
+// signals (channelStateSignal, snapshotSignal, childrenSignal), and FauxUi
+// signal-wiring patterns.
+//
+// Run with:
+//   dart test --tags=integration \
+//     test/experiment/examples/signals_experiment_test.dart
+//
+// Sandbox tests require vm; others work on both backends.
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:signals_core/signals_core.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+MontyPlatformFactory _replFactory() =>
+    () async => ReplPlatform(repl: MontyRepl());
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // G5-1: SignalCapture basic — EventLoop channelStateSignal
+  // ---------------------------------------------------------------------------
+
+  group('G5-1: SignalCapture on EventLoop.channelStateSignal', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('records every state value including initial Idle', () async {
+      final cap = SignalCapture(el.channelStateSignal);
+      el.dispatch({'pre': true}); // pre-queue so no wait needed
+
+      await h.run('el_recv()');
+
+      cap.dispose();
+
+      expect(cap.values.first, isA<EventLoopIdle>());
+      expect(cap.values.any((s) => s is EventLoopExecuting), isTrue);
+      expect(cap.values.last, isA<EventLoopCompleted>());
+    });
+
+    test('calling dispose() on SignalCapture stops recording', () {
+      // Use a plain signal to avoid the EventLoop Completed-state dispatch
+      // wart.
+      final s = signal(0);
+      final cap = SignalCapture(s);
+
+      s
+        ..value = 1
+        ..value = 2;
+      cap.dispose();
+      s.value = 3; // NOT captured after dispose
+
+      expect(cap.values, [0, 1, 2]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G5-2: SignalCapture on MessageBus.snapshotSignal
+  // ---------------------------------------------------------------------------
+
+  group('G5-2: SignalCapture on MessageBus channel snapshotSignal', () {
+    late MontyHarness h;
+    late MessageBusExtension busExt;
+    late MessageBus bus;
+
+    setUp(() async {
+      bus = MessageBus();
+      busExt = MessageBusExtension(bus: bus);
+      h = MontyHarness(extensions: [busExt]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('snapshot sendCount increments on each Python send', () async {
+      final ch = bus.channel('q');
+      final cap = SignalCapture(ch.snapshotSignal);
+
+      await h.run('''
+msg_send(name='q', message='a')
+msg_send(name='q', message='b')
+msg_send(name='q', message='c')
+''');
+
+      cap.dispose();
+
+      final counts = cap.values.map((s) => s.sendCount).toList();
+      expect(counts.last, 3);
+    });
+
+    test('queueDepth goes up on send and down on recv', () async {
+      bus.channel('pipe').send('item1');
+      bus.channel('pipe').send('item2');
+
+      final ch = bus.channel('pipe');
+      final cap = SignalCapture(ch.snapshotSignal);
+
+      await h.run('''
+msg_recv(name='pipe')
+msg_recv(name='pipe')
+''');
+
+      cap.dispose();
+
+      final depths = cap.values.map((s) => s.queueDepth).toList();
+      expect(depths.last, 0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G5-3: Computed signal derived from plugin state
+  // ---------------------------------------------------------------------------
+
+  group('G5-3: Computed signal derived from EventLoop state', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('computed "isWaiting" tracks el waiting state', () async {
+      final isWaiting = computed(
+        () => el.channelStateSignal.value is EventLoopWaiting,
+      );
+      final history = <bool>[];
+      final cleanup = effect(() => history.add(isWaiting.value));
+
+      const script = 'el_recv()';
+      final handle = h.runtime.execute(script);
+
+      await _untilWaiting(el);
+      el.dispatch({'go': true});
+      await handle.result;
+
+      cleanup();
+
+      expect(history, containsAll([true, false]));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G5-4: effect() cleanup — verify no memory leak
+  // ---------------------------------------------------------------------------
+
+  group('G5-4: effect cleanup', () {
+    test('effect removed after cleanup does not track further changes', () {
+      final s = signal(0);
+      final log = <int>[];
+      final cleanup = effect(() => log.add(s.value));
+
+      s
+        ..value = 1
+        ..value = 2;
+      cleanup();
+      s.value = 3; // should NOT be captured
+
+      expect(log, [0, 1, 2]);
+    });
+
+    test('multiple effects on same signal — each gets own history', () {
+      final s = signal('a');
+      final log1 = <String>[];
+      final log2 = <String>[];
+      final c1 = effect(() => log1.add(s.value));
+      final c2 = effect(() => log2.add(s.value));
+
+      s.value = 'b';
+      c1();
+      s.value = 'c'; // only c2 sees 'c'
+
+      c2();
+      expect(log1, ['a', 'b']);
+      expect(log2, ['a', 'b', 'c']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G5-5: SignalCapture on aliveCountSignal (sandbox, FFI only)
+  // ---------------------------------------------------------------------------
+
+  group(
+    'G5-5: SignalCapture on SandboxExtension.aliveCountSignal',
+    () {
+      late MontyHarness h;
+      late SandboxExtension sandbox;
+
+      setUp(() async {
+        sandbox = SandboxExtension(platformFactory: _replFactory());
+        h = MontyHarness(extensions: [sandbox]);
+        await h.setup();
+      });
+
+      tearDown(() => h.dispose());
+
+      test('aliveCount peaks at N then returns to 0', () async {
+        final cap = SignalCapture(sandbox.aliveCountSignal);
+
+        await h.run('''
+h1 = sandbox_spawn(code="1")
+h2 = sandbox_spawn(code="2")
+h3 = sandbox_spawn(code="3")
+sandbox_await_all(handles=[h1, h2, h3])
+''');
+
+        cap.dispose();
+
+        // Children may complete fast; assert at least one was alive and
+        // all finished.
+        expect(cap.values.any((c) => c > 0), isTrue);
+        expect(cap.values.last, 0);
+      });
+    },
+    testOn: 'vm',
+  );
+
+  // ---------------------------------------------------------------------------
+  // G5-6: FauxUi BridgeFunctionEmit — el_emit surfaced in events
+  // ---------------------------------------------------------------------------
+
+  group('G5-6: FauxUi sees BridgeFunctionEmit from el_emit', () {
+    late MontyHarness h;
+    late EventLoopExtension el;
+    late FauxUi ui;
+
+    setUp(() async {
+      el = EventLoopExtension();
+      h = MontyHarness(extensions: [el]);
+      await h.setup();
+      ui = FauxUi(h.runtime);
+    });
+
+    tearDown(() async {
+      ui.dispose();
+      await h.dispose();
+    });
+
+    test(
+      'each el_emit call produces a BridgeFunctionCallStart event',
+      () async {
+        await h.run('''
+el_emit(value={'tick': 1})
+el_emit(value={'tick': 2})
+''');
+
+        final emitCalls = ui
+            .eventsOf<BridgeFunctionCallStart>()
+            .where((e) => e.name == 'el_emit')
+            .toList();
+        expect(emitCalls, hasLength(2));
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // G5-7: FauxUi assertEventSequence with matchers
+  // ---------------------------------------------------------------------------
+
+  group('G5-7: FauxUi.assertEventSequence', () {
+    late MontyHarness h;
+    late FauxUi ui;
+
+    setUp(() async {
+      h = MontyHarness()..registerTool('ping', (a, c) async => 'pong');
+      await h.setup();
+      ui = FauxUi(h.runtime);
+    });
+
+    tearDown(() async {
+      ui.dispose();
+      await h.dispose();
+    });
+
+    test(
+      'run starts with BridgeRunStarted and ends with BridgeRunFinished',
+      () async {
+        await h.run('ping()');
+
+        // Check presence of key event types — strict ordering breaks on
+        // intermediate events like BridgeStepStarted that appear between
+        // run/function events.
+        ui
+          ..assertContains<BridgeRunStarted>()
+          ..assertContains<BridgeFunctionCallStart>()
+          ..assertContains<BridgeRunFinished>();
+      },
+    );
+
+    test('assertAbsent passes when event type never occurred', () async {
+      await h.run('1 + 1');
+
+      ui.assertAbsent<BridgeFunctionCallStart>(); // no tool calls
+    });
+  });
+} // end main
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+Future<void> _untilWaiting(EventLoopExtension el) async {
+  const maxWait = Duration(seconds: 5);
+  const interval = Duration(milliseconds: 10);
+  final deadline = DateTime.now().add(maxWait);
+
+  while (!el.isWaiting) {
+    if (DateTime.now().isAfter(deadline)) {
+      throw StateError('EventLoopExtension never reached Waiting state');
+    }
+    await Future<void>.delayed(interval);
+  }
+}

--- a/test/experiment/examples/tool_chain_experiment_test.dart
+++ b/test/experiment/examples/tool_chain_experiment_test.dart
@@ -1,0 +1,297 @@
+// Experiment: Python-driven tool call chains without a server.
+//
+// Demonstrates the harness exercising a multi-step tool call chain —
+// exactly what an LLM would produce, but driven by hand-written Python.
+// No server, no LLM, no network.
+//
+// Run with:
+//   dart test --tags=integration --run-skipped \
+//     test/experiment/examples/tool_chain_experiment_test.dart
+@Tags(['integration'])
+library;
+
+import 'dart:convert';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // Basic tool call: single function, verify args and result round-trip
+  // ---------------------------------------------------------------------------
+
+  group('single tool call', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..registerTool(
+          'get_weather',
+          (args, ctx) async => {'temp': 22, 'city': args['city'], 'unit': 'C'},
+          description: 'Returns weather for a city',
+          params: [const HostParam(name: 'city', type: HostParamType.string)],
+        );
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python calls get_weather and uses the result', () async {
+      final result = await h.run('''
+w = get_weather(city='London')
+w['temp']
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 22);
+      h.assertCalled('get_weather', args: {'city': 'London'});
+    });
+
+    test('Python error does not block subsequent calls', () async {
+      final r1 = await h.run('undefined_var');
+      expect(r1.error, isNotNull);
+
+      final r2 = await h.run("get_weather(city='Paris')['temp']");
+      expect(r2.error, isNull);
+      expect(r2.value.dartValue, 22);
+    });
+
+    test('tool called multiple times — all recorded', () async {
+      await h.run('''
+cities = ['London', 'Paris', 'Berlin']
+results = [get_weather(city=c)['temp'] for c in cities]
+''');
+
+      h
+        ..assertCallCount('get_weather', 3)
+        ..assertCalled('get_weather', args: {'city': 'London'})
+        ..assertCalled('get_weather', args: {'city': 'Paris'})
+        ..assertCalled('get_weather', args: {'city': 'Berlin'});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-tool chain: Python drives a decision flow across tools
+  // ---------------------------------------------------------------------------
+
+  group('multi-tool chain', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      final db = <String, Map<String, Object?>>{
+        'user:alice': {'name': 'Alice', 'tier': 'premium', 'balance': 150},
+        'user:bob': {'name': 'Bob', 'tier': 'free', 'balance': 0},
+      };
+      final log = <String>[];
+
+      h = MontyHarness()
+        ..registerTool(
+          'db_get',
+          (args, ctx) async =>
+              db[args['key']! as String] ?? <String, Object?>{},
+          params: [const HostParam(name: 'key', type: HostParamType.string)],
+        )
+        ..registerTool(
+          'send_offer',
+          (args, ctx) async {
+            log.add('offer:${args['user']}:${args['offer']}');
+            return true;
+          },
+          params: [
+            const HostParam(name: 'user', type: HostParamType.string),
+            const HostParam(name: 'offer', type: HostParamType.string),
+          ],
+        )
+        ..registerTool(
+          'send_upsell',
+          (args, ctx) async {
+            log.add('upsell:${args['user']}');
+            return true;
+          },
+          params: [const HostParam(name: 'user', type: HostParamType.string)],
+        );
+
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python routes to correct tool based on user tier', () async {
+      await h.run('''
+alice = db_get(key='user:alice')
+if alice['tier'] == 'premium':
+    send_offer(user=alice['name'], offer='20pct_off')
+else:
+    send_upsell(user=alice['name'])
+''');
+
+      h
+        ..assertCalled(
+          'send_offer',
+          args: {'user': 'Alice', 'offer': '20pct_off'},
+        )
+        ..assertNotCalled('send_upsell');
+    });
+
+    test('Python routes free-tier user to upsell', () async {
+      await h.run('''
+bob = db_get(key='user:bob')
+if bob['tier'] == 'premium':
+    send_offer(user=bob['name'], offer='20pct_off')
+else:
+    send_upsell(user=bob['name'])
+''');
+
+      h
+        ..assertCalled('send_upsell', args: {'user': 'Bob'})
+        ..assertNotCalled('send_offer');
+    });
+
+    test('Python loops over multiple users', () async {
+      await h.run('''
+for uid in ['user:alice', 'user:bob']:
+    u = db_get(key=uid)
+    if u['tier'] == 'premium':
+        send_offer(user=u['name'], offer='30pct_off')
+    else:
+        send_upsell(user=u['name'])
+''');
+
+      h
+        ..assertCallCount('db_get', 2)
+        ..assertCallCount('send_offer', 1)
+        ..assertCallCount('send_upsell', 1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // VFS: Python reads files from the in-memory filesystem
+  // ---------------------------------------------------------------------------
+
+  group('VFS-backed tool calls', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..writeFile(
+          '/config/rules.json',
+          jsonEncode({
+            'discount_threshold': 100,
+            'premium_offer': '25pct_off',
+          }),
+        )
+        ..registerTool(
+          'apply_discount',
+          (args, ctx) async => 'discount:${args['offer']}:${args['user']}',
+          params: [
+            const HostParam(name: 'offer', type: HostParamType.string),
+            const HostParam(name: 'user', type: HostParamType.string),
+          ],
+        )
+        ..prime('from pathlib import Path');
+
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python reads config from VFS and drives tool call', () async {
+      final result = await h.run('''
+import json
+config = json.loads(Path('/config/rules.json').read_text())
+threshold = config['discount_threshold']
+balance = 150
+if balance >= threshold:
+    apply_discount(offer=config['premium_offer'], user='alice')
+''');
+
+      expect(result.error, isNull);
+      h.assertCalled(
+        'apply_discount',
+        args: {
+          'offer': '25pct_off',
+          'user': 'alice',
+        },
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Python scripts loaded from VFS — simulating skill files
+  // ---------------------------------------------------------------------------
+
+  group('skill script loading', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..writeFile('/scripts/greet.py', '''
+def greet_user(name, lang='en'):
+    if lang == 'en':
+        return f'Hello, {name}!'
+    elif lang == 'es':
+        return f'Hola, {name}!'
+    return f'Hi, {name}!'
+''')
+        ..registerTool(
+          'send_message',
+          (args, ctx) async => 'sent:${args['msg']}',
+          params: [const HostParam(name: 'msg', type: HostParamType.string)],
+        )
+        ..prime('from pathlib import Path');
+
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python executes a skill script from VFS then calls a tool', () async {
+      // Load the skill script by executing it.
+      await h.runFile('/scripts/greet.py');
+
+      // Now greet_user is defined in the session — call it and forward result.
+      final result = await h.run('''
+msg = greet_user('World', lang='es')
+send_message(msg=msg)
+''');
+
+      expect(result.error, isNull);
+      h.assertCalled('send_message', args: {'msg': 'Hola, World!'});
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Event stream inspection
+  // ---------------------------------------------------------------------------
+
+  group('bridge event stream', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()..registerTool('probe', (args, ctx) async => 'ok');
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test(
+      'runWithEvents captures BridgeToolCallStart for each tool call',
+      () async {
+        final (:result, :events) = await h.runWithEvents('probe()');
+
+        expect(result.error, isNull);
+        final starts = events.whereType<BridgeFunctionCallStart>().toList();
+        expect(starts.map((e) => e.name), contains('probe'));
+      },
+    );
+
+    test('runWithEvents captures BridgeRunFinished', () async {
+      final (:result, :events) = await h.runWithEvents('1 + 1');
+
+      expect(events.whereType<BridgeRunFinished>(), isNotEmpty);
+      expect(result.value.dartValue, 2);
+    });
+  });
+}

--- a/test/experiment/examples/vfs_experiment_test.dart
+++ b/test/experiment/examples/vfs_experiment_test.dart
@@ -1,0 +1,178 @@
+// G8: VFS / OsCall experiments.
+//
+// Covers write/read round-trips, Path.exists, OsCall bridge events,
+// the harness in-memory filesystem, and denied paths.
+//
+// Run with:
+//   dart test --tags=integration \
+//     test/experiment/examples/vfs_experiment_test.dart
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+import '../harness.dart';
+
+void main() {
+  // ---------------------------------------------------------------------------
+  // G8-1: Dart writes, Python reads — round-trip
+  // ---------------------------------------------------------------------------
+
+  group('G8-1: Dart writes VFS file, Python reads', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..writeFile('/data/greet.txt', 'Hello from Dart')
+        ..prime('from pathlib import Path');
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('Python reads Dart-written file via pathlib.Path', () async {
+      final result = await h.run("Path('/data/greet.txt').read_text()");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'Hello from Dart');
+    });
+
+    test('Python reads JSON-encoded file and parses it', () async {
+      h.writeFile('/config/params.json', '{"rate": 3.14, "enabled": true}');
+
+      final result = await h.run('''
+import json
+cfg = json.loads(Path('/config/params.json').read_text())
+cfg['rate']
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue! as double, closeTo(3.14, 0.001));
+    });
+
+    test('Python reads multiple files in a loop', () async {
+      for (var i = 0; i < 3; i++) {
+        h.writeFile('/items/item_$i.txt', 'item $i');
+      }
+
+      final result = await h.run('''
+[Path(f'/items/item_{i}.txt').read_text() for i in range(3)]
+''');
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, ['item 0', 'item 1', 'item 2']);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G8-2: Path.exists
+  // ---------------------------------------------------------------------------
+
+  group('G8-2: Path.exists', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..writeFile('/present.txt', 'here')
+        ..prime('from pathlib import Path');
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('exists() returns True for written file', () async {
+      final result = await h.run("Path('/present.txt').exists()");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, true);
+    });
+
+    test('exists() returns False for absent file', () async {
+      final result = await h.run("Path('/not_there.txt').exists()");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G8-3: OsCall events appear in bridge stream
+  // ---------------------------------------------------------------------------
+
+  group('G8-3: OsCall events in bridge stream', () {
+    late MontyHarness h;
+
+    setUp(() async {
+      h = MontyHarness()
+        ..writeFile('/os_test.txt', 'content')
+        ..prime('from pathlib import Path');
+      await h.setup();
+    });
+
+    tearDown(() => h.dispose());
+
+    test('BridgeOsCallStart events emitted for each VFS operation', () async {
+      final (:result, :events) = await h.runWithEvents(
+        "Path('/os_test.txt').read_text()",
+      );
+
+      expect(result.error, isNull);
+      final osCalls = events.whereType<BridgeOsCallStart>().toList();
+      expect(osCalls, isNotEmpty);
+      expect(osCalls.any((e) => e.operationName.contains('read')), isTrue);
+    });
+
+    test('BridgeOsCallResult follows each BridgeOsCallStart', () async {
+      final (:result, :events) = await h.runWithEvents(
+        "Path('/os_test.txt').exists()",
+      );
+
+      expect(result.error, isNull);
+      final starts = events.whereType<BridgeOsCallStart>().length;
+      final results = events.whereType<BridgeOsCallResult>().length;
+      expect(results, greaterThanOrEqualTo(starts));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // G8-4: Harness VFS independence across test cases
+  // ---------------------------------------------------------------------------
+
+  group('G8-4: VFS isolation between harness instances', () {
+    test('two harness instances have independent filesystems', () async {
+      final h1 = MontyHarness()
+        ..writeFile('/shared.txt', 'harness-one')
+        ..prime('from pathlib import Path');
+      final h2 = MontyHarness()
+        ..writeFile('/shared.txt', 'harness-two')
+        ..prime('from pathlib import Path');
+
+      await h1.setup();
+      await h2.setup();
+
+      final r1 = await h1.run("Path('/shared.txt').read_text()");
+      final r2 = await h2.run("Path('/shared.txt').read_text()");
+
+      expect(r1.value.dartValue, 'harness-one');
+      expect(r2.value.dartValue, 'harness-two');
+
+      await h1.dispose();
+      await h2.dispose();
+    });
+
+    test('writeFile after setup() is visible to subsequent run()', () async {
+      final h = MontyHarness()..prime('from pathlib import Path');
+      await h.setup();
+
+      // Write after setup — should still be visible.
+      h.writeFile('/late.txt', 'late write');
+      final result = await h.run("Path('/late.txt').read_text()");
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'late write');
+
+      await h.dispose();
+    });
+  });
+} // end main

--- a/test/experiment/harness.dart
+++ b/test/experiment/harness.dart
@@ -1,0 +1,456 @@
+/// MontyHarness — a self-contained test harness for MontyRuntime.
+///
+/// Wires up a complete MontyRuntime with:
+///   - In-memory VFS (Dart writes files; Python reads via pathlib.Path)
+///   - Intercepting tool call layer (records every call + result)
+///   - Per-tool fault injection (override result, force throw, add delay)
+///   - Script priming (execute setup Python before the experiment starts)
+///   - `SignalCapture<T>` — records every signal value change via effect()
+///   - FauxUi — subscribes to runtime.events + plugin signals, simulates
+///     what a Flutter widget tree would observe without the Flutter overhead
+///
+/// No server, no LLM, no network. The harness lets you write Python that
+/// calls host functions exactly as an LLM would produce tool calls, and
+/// verify the full Dart ↔ Python round-trip in isolation.
+///
+/// Usage:
+/// ```dart
+/// final h = MontyHarness()
+///   ..registerTool(
+///     'get_weather',
+///     (args, ctx) async => {'temp': 22, 'city': args['city']},
+///   )
+///   ..writeFile('/data/config.json', '{"env": "test"}')
+///   ..prime('from pathlib import Path');
+///
+/// await h.setup(); // attach runtime
+///
+/// final result = await h.run('''
+///   w = get_weather(city='London')
+///   w['temp']
+/// ''');
+///
+/// h.assertToolCalled('get_weather', args: {'city': 'London'});
+/// expect(result.value.dartValue, 22);
+/// await h.dispose();
+/// ```
+library;
+
+import 'dart:async';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:file/memory.dart';
+import 'package:signals_core/signals_core.dart';
+
+/// A recorded tool call — name, args, result or error, timing.
+class ToolCallRecord {
+  ToolCallRecord({
+    required this.name,
+    required this.args,
+    required this.startedAt,
+  });
+
+  final String name;
+  final Map<String, Object?> args;
+  final DateTime startedAt;
+  Object? result;
+  Object? error;
+  late Duration duration;
+  bool get succeeded => error == null;
+}
+
+/// Fault configuration for a specific tool.
+class ToolFault {
+  const ToolFault._({this.throws, this.override, this.delay});
+
+  /// Force the tool to throw this exception.
+  factory ToolFault.throws(Exception error) => ToolFault._(throws: error);
+
+  /// Replace the tool's return value with [value].
+  factory ToolFault.returns(Object? value) => ToolFault._(override: value);
+
+  /// Add an artificial delay before the tool responds.
+  factory ToolFault.delayed(Duration delay, {Object? then}) =>
+      ToolFault._(delay: delay, override: then);
+
+  final Exception? throws;
+  final Object? override;
+  final Duration? delay;
+}
+
+// ---------------------------------------------------------------------------
+// SignalCapture<T>
+// ---------------------------------------------------------------------------
+
+/// Records every value a signal takes via [effect()].
+///
+/// Usage:
+/// ```dart
+/// final cap = SignalCapture(ext.channelStateSignal);
+/// await h.run(script);
+/// expect(cap.values, [isA<EventLoopIdle>(), isA<EventLoopExecuting>(), ...]);
+/// cap.dispose();
+/// ```
+class SignalCapture<T> {
+  SignalCapture(ReadonlySignal<T> signal) {
+    _cleanup = effect(() {
+      _values.add(signal.value);
+    });
+  }
+
+  final List<T> _values = [];
+  late final EffectCleanup _cleanup;
+
+  List<T> get values => List.unmodifiable(_values);
+
+  void dispose() => _cleanup();
+}
+
+// ---------------------------------------------------------------------------
+// FauxUi
+// ---------------------------------------------------------------------------
+
+/// Simulates what a Flutter widget tree would observe from a MontyRuntime.
+///
+/// Subscribes to `runtime.events` and collects typed events — giving you the
+/// same AG-UI state delta / snapshot / activity coverage that a real UI would
+/// see, without Flutter or widget-test overhead.
+///
+/// ```dart
+/// await h.setup();
+/// final ui = FauxUi(h.runtime);
+///
+/// await h.run(script);
+///
+/// ui.assertEventSequence([
+///   isA<BridgeRunStarted>(),
+///   isA<BridgeFunctionCallStart>(),
+///   isA<BridgeFunctionCallEnd>(),
+///   isA<BridgeRunFinished>(),
+/// ]);
+/// ui.dispose();
+/// ```
+class FauxUi {
+  FauxUi(MontyRuntime runtime) {
+    _sub = runtime.events.listen(_events.add);
+  }
+
+  final List<BridgeEvent> _events = [];
+  late final StreamSubscription<BridgeEvent> _sub;
+
+  List<BridgeEvent> get events => List.unmodifiable(_events);
+
+  /// All events of type [T].
+  List<T> eventsOf<T extends BridgeEvent>() => _events.whereType<T>().toList();
+
+  /// Assert that the flat event list matches [matchers] in order.
+  ///
+  /// Uses `expect` style — throws [TestFailure] on mismatch.
+  void assertEventSequence(List<bool Function(BridgeEvent)> matchers) {
+    if (_events.length < matchers.length) {
+      throw TestFailure(
+        'Expected at least ${matchers.length} events, got ${_events.length}.\n'
+        'Events: ${_events.map((e) => e.runtimeType).toList()}',
+      );
+    }
+    for (var i = 0; i < matchers.length; i++) {
+      if (!matchers[i](_events[i])) {
+        throw TestFailure(
+          'Event[$i] mismatch: expected matcher[$i] to pass, '
+          'got ${_events[i].runtimeType}',
+        );
+      }
+    }
+  }
+
+  /// Assert that the event type [T] appears at least once.
+  void assertContains<T extends BridgeEvent>() {
+    if (eventsOf<T>().isEmpty) {
+      throw TestFailure(
+        'Expected at least one $T event, but none appeared.\n'
+        'Events: ${_events.map((e) => e.runtimeType).toList()}',
+      );
+    }
+  }
+
+  /// Assert that the event type [T] never appeared.
+  void assertAbsent<T extends BridgeEvent>() {
+    final found = eventsOf<T>();
+    if (found.isNotEmpty) {
+      throw TestFailure(
+        'Expected no $T events, but found ${found.length}.',
+      );
+    }
+  }
+
+  void reset() => _events.clear();
+
+  void dispose() => _sub.cancel();
+}
+
+// ---------------------------------------------------------------------------
+// MontyHarness
+// ---------------------------------------------------------------------------
+
+/// Self-contained test harness for MontyRuntime experiments.
+class MontyHarness {
+  MontyHarness({
+    List<MontyExtension>? extensions,
+    bool sandbox = false,
+  }) : _extensions = extensions ?? [],
+       _sandbox = sandbox,
+       _fs = MemoryFileSystem();
+
+  final List<MontyExtension> _extensions;
+  final bool _sandbox;
+  final MemoryFileSystem _fs;
+
+  final List<HostFunction> _tools = [];
+  final Map<String, ToolFault> _faults = {};
+  final List<ToolCallRecord> _calls = [];
+  final List<String> _primeCode = [];
+
+  MontyRuntime? _runtime;
+
+  // ---------------------------------------------------------------------------
+  // Build phase — call before setup()
+  // ---------------------------------------------------------------------------
+
+  /// Register a host function callable from Python.
+  ///
+  /// May be called before or after [setup()] — if the runtime is already
+  /// running the function is registered immediately.
+  void registerTool(
+    String name,
+    HostFunctionHandler handler, {
+    String description = '',
+    List<HostParam> params = const [],
+  }) {
+    final fn = HostFunction(
+      schema: HostFunctionSchema(
+        name: name,
+        description: description,
+        params: params,
+      ),
+      handler: handler,
+    );
+    _tools.add(fn);
+    _runtime?.register(fn);
+  }
+
+  /// Write a file into the in-memory VFS.
+  ///
+  /// Python can read it with:
+  ///   `from pathlib import Path; Path('/data/x.txt').read_text()`
+  void writeFile(String virtualPath, String content) {
+    final file = _fs.file(virtualPath);
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(content);
+  }
+
+  /// Queue Python code to execute once during [setup()], before experiments.
+  void prime(String code) {
+    _primeCode.add(code);
+  }
+
+  /// Inject a fault for [toolName] — applied to the next call(s).
+  void injectFault(String toolName, ToolFault fault) {
+    _faults[toolName] = fault;
+  }
+
+  /// Remove a previously injected fault.
+  void clearFault(String toolName) => _faults.remove(toolName);
+
+  // ---------------------------------------------------------------------------
+  // Setup / teardown
+  // ---------------------------------------------------------------------------
+
+  /// Creates and primes the runtime. Must be called before [run].
+  Future<void> setup() async {
+    final interceptor = _buildInterceptor();
+    _runtime = MontyRuntime(
+      osHandlers: {'Path.': fsHandler(_fs)},
+      extensions: _extensions,
+      interceptor: interceptor,
+      sandbox: _sandbox,
+    );
+    _tools.forEach(_runtime!.register);
+    for (final code in _primeCode) {
+      final r = await _runtime!.execute(code).result;
+      if (r.error != null) {
+        throw StateError(
+          'Priming code failed: ${r.error!.message}\n\n$code',
+        );
+      }
+    }
+  }
+
+  /// Disposes the runtime. Call in tearDown.
+  Future<void> dispose() => _runtime?.dispose() ?? Future.value();
+
+  // ---------------------------------------------------------------------------
+  // Execution
+  // ---------------------------------------------------------------------------
+
+  /// The live [MontyRuntime] — available after [setup()].
+  MontyRuntime get runtime {
+    _assertSetup();
+    return _runtime!;
+  }
+
+  /// Execute Python code and return the final result.
+  ///
+  /// All tool calls are recorded in [calls].
+  Future<MontyResult> run(String code) {
+    _assertSetup();
+    return _runtime!.execute(code).result;
+  }
+
+  /// Execute Python code and collect all bridge events + final result.
+  Future<({MontyResult result, List<BridgeEvent> events})> runWithEvents(
+    String code,
+  ) async {
+    _assertSetup();
+    final handle = _runtime!.execute(code);
+    final events = await handle.events.toList();
+    final result = await handle.result;
+    return (result: result, events: events);
+  }
+
+  /// Execute Python from a file in the VFS.
+  ///
+  /// The file content is read by Dart and passed to [run].
+  Future<MontyResult> runFile(String virtualPath) {
+    final content = _fs.file(virtualPath).readAsStringSync();
+    return run(content);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Assertions
+  // ---------------------------------------------------------------------------
+
+  /// All recorded tool calls in invocation order.
+  List<ToolCallRecord> get calls => List.unmodifiable(_calls);
+
+  /// Calls for a specific tool, in order.
+  List<ToolCallRecord> callsTo(String name) =>
+      _calls.where((c) => c.name == name).toList();
+
+  /// Assert [toolName] was called at least once, optionally with [args].
+  void assertCalled(String toolName, {Map<String, Object?>? args}) {
+    final matching = callsTo(toolName);
+    if (matching.isEmpty) {
+      throw TestFailure('Expected $toolName to be called, but it was not.');
+    }
+    if (args != null) {
+      final withArgs = matching.where((c) {
+        for (final entry in args.entries) {
+          if (c.args[entry.key] != entry.value) return false;
+        }
+        return true;
+      }).toList();
+      if (withArgs.isEmpty) {
+        final actual = matching
+            .map((c) => '  $toolName(${_fmtArgs(c.args)})')
+            .join('\n');
+        throw TestFailure(
+          'Expected $toolName(${_fmtArgs(args)}) but actual calls were:\n'
+          '$actual',
+        );
+      }
+    }
+  }
+
+  /// Assert [toolName] was never called.
+  void assertNotCalled(String toolName) {
+    final matching = callsTo(toolName);
+    if (matching.isNotEmpty) {
+      throw TestFailure(
+        'Expected $toolName NOT to be called, but it was called '
+        '${matching.length} time(s).',
+      );
+    }
+  }
+
+  /// Assert [toolName] was called exactly [n] times.
+  void assertCallCount(String toolName, int n) {
+    final count = callsTo(toolName).length;
+    if (count != n) {
+      throw TestFailure(
+        'Expected $toolName to be called $n time(s), got $count.',
+      );
+    }
+  }
+
+  /// Assert every call succeeded (no tool threw an error).
+  void assertNoErrors() {
+    final failed = _calls.where((c) => c.error != null).toList();
+    if (failed.isNotEmpty) {
+      throw TestFailure(
+        'Tool calls with errors:\n'
+        '${failed.map((c) => '  ${c.name}: ${c.error}').join('\n')}',
+      );
+    }
+  }
+
+  /// Reset recorded calls. Useful between sub-experiments.
+  void resetCalls() => _calls.clear();
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  void _assertSetup() {
+    if (_runtime == null) {
+      throw StateError(
+        'MontyHarness.setup() must be called before run().',
+      );
+    }
+  }
+
+  MontyInterceptor _buildInterceptor() {
+    return (name, args, next) async {
+      final record = ToolCallRecord(
+        name: name,
+        args: args,
+        startedAt: DateTime.now(),
+      );
+      _calls.add(record);
+
+      final fault = _faults[name];
+      try {
+        if (fault != null) {
+          if (fault.delay != null) await Future<void>.delayed(fault.delay!);
+          if (fault.throws != null) throw fault.throws!;
+          record
+            ..result = fault.override
+            ..duration = DateTime.now().difference(record.startedAt);
+          return fault.override;
+        }
+        final result = await next();
+        record
+          ..result = result
+          ..duration = DateTime.now().difference(record.startedAt);
+        return result;
+      } catch (e) {
+        record
+          ..error = e
+          ..duration = DateTime.now().difference(record.startedAt);
+        rethrow;
+      }
+    };
+  }
+
+  String _fmtArgs(Map<String, Object?> args) =>
+      args.entries.map((e) => '${e.key}=${e.value}').join(', ');
+}
+
+/// Thrown by assertion helpers on failure.
+class TestFailure implements Exception {
+  const TestFailure(this.message);
+  final String message;
+
+  @override
+  String toString() => 'TestFailure: $message';
+}


### PR DESCRIPTION
## Summary

- Fix pages asset filenames after `dart_monty_core#31` renamed WASM/JS bridge files
- Add `MontyHarness` test helper for concise integration test setup
- Add 116-test experiment suite (G1–G9) covering the full runtime API surface
- Add F9 regression guard — unknown kwarg raises `FormatException`

## Stack

**5 of 5** — depends on #354. Merge order: #351 → #352 → #353 → #354 → #355