### PR TITLE
fix(pages): cp assets/* and reference dart_monty_core_bridge.js

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -52,10 +52,6 @@ jobs:
         run: |
           npm install --force
           node build.js
-      - name: Copy JS bridge assets to example
-        run: |
-          cp dart_monty_core/assets/dart_monty_bridge.js example/web/web/
-          cp dart_monty_core/assets/dart_monty_worker.js example/web/web/
 
       # ── Compile Dart to JS ───────────────────────────────────────────
       - uses: dart-lang/setup-dart@v1
@@ -102,7 +98,7 @@ jobs:
       - name: Copy live demo assets to site root
         run: |
           cp -r example/web/web/* site/
-          cp dart_monty_core/assets/dart_monty_native.wasm site/
+          cp dart_monty_core/assets/* site/
           mkdir -p site/fixtures
           cp test/fixtures/python_ladder/tier_*.json site/fixtures/
           mkdir -p site/assets

--- a/example/web/web/agent.html
+++ b/example/web/web/agent.html
@@ -568,7 +568,7 @@ x</textarea>
   </script>
 
   <!-- Load WASM bridge, then compiled Dart agent demo -->
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="agent_demo.dart.js"></script>
 
   <!-- UI wiring -->

--- a/example/web/web/demo.html
+++ b/example/web/web/demo.html
@@ -38,7 +38,7 @@
     };
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="main.dart.js"></script>
 </body>
 </html>

--- a/example/web/web/ladder.html
+++ b/example/web/web/ladder.html
@@ -318,7 +318,7 @@
     }
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="ladder_showcase.dart.js"></script>
 </body>
 </html>

--- a/example/web/web/repl.html
+++ b/example/web/web/repl.html
@@ -58,7 +58,7 @@
     window._onReady = function() {};
     window._onToolCall = function() {};
   </script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="repl_demo.dart.js"></script>
   <script>
     const transcript = document.getElementById('transcript');

--- a/example/web/web/vfs.html
+++ b/example/web/web/vfs.html
@@ -390,7 +390,7 @@ files = sorted([p.name for p in Path('/sandbox/data').iterdir()], key=str)
   </script>
 
   <!-- Load WASM bridge, then compiled Dart VFS demo -->
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="vfs_demo.dart.js"></script>
 
   <!-- UI wiring (DOM is ready at this point) -->

--- a/example/web/web/visualizer.html
+++ b/example/web/web/visualizer.html
@@ -503,7 +503,7 @@
     }
   </script>
   <script src="coi-serviceworker.js"></script>
-  <script src="dart_monty_bridge.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
   <script src="visualizer.dart.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `cp dart_monty_core/assets/*` instead of naming individual files
- HTML script tags updated to `dart_monty_core_bridge.js` to match what `build.js` produces
- Removes redundant separate WASM copy (already covered by the glob)

## Test plan

- [ ] GitHub Pages deploy succeeds
- [ ] All demo pages load the bridge correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)