### PR TITLE
feat(bridge): route handler emissions on direct invokeHostFunction

### DIFF
--- a/lib/src/bridge/bridge.dart
+++ b/lib/src/bridge/bridge.dart
@@ -59,8 +59,21 @@ abstract class MontyBridge implements AttachContext {
   /// Infra functions (where [HostFunction.isInfra] is `true`) bypass the
   /// interceptor. All others go through it.
   ///
+  /// When [onEvent] is provided, any [BridgeEvent] the handler emits via
+  /// `HostContext.emit` / `HostContext.emitText` is delivered to the callback
+  /// before the returned future completes. When omitted, emissions are
+  /// dropped. Extension-registered stream wrappers apply to [execute] only
+  /// and are NOT run for direct-Dart invocations — direct calls are outside
+  /// Python-execution semantics.
+  ///
+  /// Callback exceptions are logged and swallowed; they never fail the call.
+  ///
   /// Throws [ArgumentError] if [name] is not registered.
-  Future<Object?> invokeHostFunction(String name, Map<String, Object?> args);
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  });
 
   /// Registers an [OsCallHandler] for OS-level calls (pathlib, os, datetime).
   ///

--- a/lib/src/bridge/platform.dart
+++ b/lib/src/bridge/platform.dart
@@ -201,10 +201,14 @@ class PlatformBridge implements MontyBridge, AttachContext {
   OsCallHandler? get currentOsHandler => _osHandler;
 
   @override
-  Future<Object?> invokeHostFunction(String name, Map<String, Object?> args) {
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) {
     if (_isDisposed) throw StateError('Bridge has been disposed');
 
-    return _host.invokeHostFunction(name, args);
+    return _host.invokeHostFunction(name, args, onEvent: onEvent);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/src/host/dispatch.dart
+++ b/lib/src/host/dispatch.dart
@@ -232,7 +232,20 @@ class HostDispatch {
   /// Invokes a registered host function by [name] directly from Dart.
   ///
   /// Infra functions bypass the interceptor; all others go through it.
-  Future<Object?> invokeHostFunction(String name, Map<String, Object?> args) {
+  ///
+  /// When [onEvent] is provided, any [BridgeEvent] the handler emits via
+  /// `HostContext.emit` / `HostContext.emitText` is delivered to the callback
+  /// before the returned future completes. When [onEvent] is omitted, emissions
+  /// are dropped (direct-Dart calls have no stream). Stream wrappers registered
+  /// by extensions apply to Python-`execute` runs only and are NOT applied to
+  /// direct invocations.
+  ///
+  /// Callback exceptions are logged via the bridge logger and swallowed.
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) {
     final fn = _functions[name];
     if (fn == null) throw ArgumentError('Unknown host function: $name');
     final pending = MontyPending(
@@ -241,8 +254,22 @@ class HostDispatch {
       kwargs: args.map((k, v) => MapEntry(k, MontyValue.fromJson(v))),
     );
     final validatedArgs = fn.schema.mapAndValidate(pending);
+    void sink(BridgeEvent event) {
+      if (onEvent == null) return;
+      try {
+        onEvent(event);
+      } on Object catch (err, st) {
+        _log.error(
+          'invokeHostFunction onEvent callback threw',
+          error: err,
+          stackTrace: st,
+          attributes: {'name': name},
+        );
+      }
+    }
+
     final ctx = HostContext(
-      emit: (_) {}, // no stream available for direct Dart invocations
+      emit: sink,
       executionId: name,
       os: osHandler,
       runtime: _runtime,

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -217,11 +217,20 @@ class MontyRuntime implements MontyRuntimeRef {
   /// and there is no persistent registry to invoke against. Callers that
   /// need Dart-side invocation should use shared mode.
   ///
+  /// When [onEvent] is provided, any [BridgeEvent] the handler emits is
+  /// delivered to the callback before the returned future completes. When
+  /// omitted, emissions are dropped (direct-Dart invocations do not route
+  /// through [events]).
+  ///
   /// Throws:
   /// - [StateError] if the runtime is disposed.
   /// - [UnsupportedError] if called on a sandbox-mode runtime.
   /// - [ArgumentError] if [name] is not registered.
-  Future<Object?> invoke(String name, Map<String, Object?> args) async {
+  Future<Object?> invoke(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) async {
     if (_disposed) throw StateError('MontyRuntime has been disposed');
     if (_sandbox) {
       throw UnsupportedError(
@@ -238,7 +247,7 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedAttached = true;
     }
 
-    return _sharedBridge!.invokeHostFunction(name, args);
+    return _sharedBridge!.invokeHostFunction(name, args, onEvent: onEvent);
   }
 
   /// Clears all persisted Python state.

--- a/test/src/bridge/extension_coordinator_test.dart
+++ b/test/src/bridge/extension_coordinator_test.dart
@@ -1138,8 +1138,9 @@ class _MockBridge implements MontyBridge {
   @override
   Future<Object?> invokeHostFunction(
     String name,
-    Map<String, Object?> args,
-  ) => throw UnimplementedError();
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) => throw UnimplementedError();
 
   @override
   void dispose() {}

--- a/test/src/bridge/introspection_functions_test.dart
+++ b/test/src/bridge/introspection_functions_test.dart
@@ -323,8 +323,9 @@ class _FakeBridge implements MontyBridge {
   @override
   Future<Object?> invokeHostFunction(
     String name,
-    Map<String, Object?> args,
-  ) => throw UnimplementedError();
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) => throw UnimplementedError();
 
   @override
   void dispose() {}

--- a/test/src/bridge/monty_extension_test.dart
+++ b/test/src/bridge/monty_extension_test.dart
@@ -134,8 +134,9 @@ class _NoOpBridge implements MontyBridge {
   @override
   Future<Object?> invokeHostFunction(
     String name,
-    Map<String, Object?> args,
-  ) => throw UnimplementedError();
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) => throw UnimplementedError();
 
   @override
   void dispose() {}

--- a/test/src/bridge/platform_bridge_test.dart
+++ b/test/src/bridge/platform_bridge_test.dart
@@ -676,6 +676,186 @@ void main() {
     });
   });
 
+  group('invokeHostFunction onEvent', () {
+    test('default omitted — events dropped, result still returned', () async {
+      bridge.register(
+        HostFunction(
+          schema: const HostFunctionSchema(name: 'streamer', description: ''),
+          handler: (_, ctx) async {
+            ctx
+              ..emitText('progress 1')
+              ..emitText('progress 2');
+            return 'done';
+          },
+        ),
+      );
+
+      final result = await bridge.invokeHostFunction('streamer', const {});
+
+      expect(result, 'done');
+    });
+
+    test('with onEvent — handler emissions surface in order', () async {
+      bridge.register(
+        HostFunction(
+          schema: const HostFunctionSchema(name: 'streamer', description: ''),
+          handler: (_, ctx) async {
+            ctx
+              ..emitText('one')
+              ..emitText('two');
+            return 'done';
+          },
+        ),
+      );
+
+      final received = <BridgeEvent>[];
+      final result = await bridge.invokeHostFunction(
+        'streamer',
+        const {},
+        onEvent: received.add,
+      );
+
+      expect(result, 'done');
+      expect(received, hasLength(2));
+      expect(received[0], isA<BridgeFunctionEmit>());
+      expect((received[0] as BridgeFunctionEmit).text, 'one');
+      expect((received[1] as BridgeFunctionEmit).text, 'two');
+      expect((received[0] as BridgeFunctionEmit).callId, 'streamer');
+    });
+
+    test('with onEvent — interceptor still wraps the call', () async {
+      var interceptorRan = false;
+      final b = MontyBridge(
+        platform: mock,
+        interceptor: (name, args, next) async {
+          interceptorRan = true;
+          return next();
+        },
+      );
+      addTearDown(b.dispose);
+
+      b.register(
+        HostFunction(
+          schema: const HostFunctionSchema(name: 'streamer', description: ''),
+          handler: (_, ctx) async {
+            ctx.emitText('mid');
+            return 'ok';
+          },
+        ),
+      );
+
+      final received = <BridgeEvent>[];
+      final result = await b.invokeHostFunction(
+        'streamer',
+        const {},
+        onEvent: received.add,
+      );
+
+      expect(result, 'ok');
+      expect(interceptorRan, isTrue);
+      expect(received, hasLength(1));
+      expect((received.single as BridgeFunctionEmit).text, 'mid');
+    });
+
+    test('with onEvent — infra bypasses interceptor; events deliver', () async {
+      var interceptorRan = false;
+      final b = MontyBridge(
+        platform: mock,
+        interceptor: (name, args, next) async {
+          interceptorRan = true;
+          return next();
+        },
+      );
+      addTearDown(b.dispose);
+
+      b.register(
+        HostFunction(
+          schema: const HostFunctionSchema(name: 'infra_fn', description: ''),
+          isInfra: true,
+          handler: (_, ctx) async {
+            ctx.emitText('infra');
+            return null;
+          },
+        ),
+      );
+
+      final received = <BridgeEvent>[];
+      await b.invokeHostFunction(
+        'infra_fn',
+        const {},
+        onEvent: received.add,
+      );
+
+      expect(interceptorRan, isFalse);
+      expect(received, hasLength(1));
+      expect((received.single as BridgeFunctionEmit).text, 'infra');
+    });
+
+    test(
+      'with onEvent — custom BridgeEvent subtypes deliver verbatim',
+      () async {
+        bridge.register(
+          HostFunction(
+            schema: const HostFunctionSchema(
+              name: 'os_caller',
+              description: '',
+            ),
+            handler: (_, ctx) async {
+              ctx.emit(
+                const BridgeOsCallStart(
+                  callId: 'os-1',
+                  operationName: 'os.getenv',
+                  argumentSummary: "'HOME'",
+                ),
+              );
+              return null;
+            },
+          ),
+        );
+
+        final received = <BridgeEvent>[];
+        await bridge.invokeHostFunction(
+          'os_caller',
+          const {},
+          onEvent: received.add,
+        );
+
+        expect(received, hasLength(1));
+        final event = received.single;
+        expect(event, isA<BridgeOsCallStart>());
+        expect((event as BridgeOsCallStart).operationName, 'os.getenv');
+        expect(event.argumentSummary, "'HOME'");
+      },
+    );
+
+    test('onEvent throws — swallowed, handler result returns', () async {
+      bridge.register(
+        HostFunction(
+          schema: const HostFunctionSchema(name: 'streamer', description: ''),
+          handler: (_, ctx) async {
+            ctx
+              ..emitText('first')
+              ..emitText('second');
+            return 'done';
+          },
+        ),
+      );
+
+      var callCount = 0;
+      final result = await bridge.invokeHostFunction(
+        'streamer',
+        const {},
+        onEvent: (_) {
+          callCount++;
+          throw StateError('callback blew up');
+        },
+      );
+
+      expect(result, 'done');
+      expect(callCount, 2);
+    });
+  });
+
   group('error handling in _run', () {
     test('MontyError thrown during execution emits BridgeRunError', () async {
       final throwingMock = _ThrowingOnResumePlatform(


### PR DESCRIPTION
## Summary
- `MontyBridge.invokeHostFunction` / `MontyRuntime.invoke` now accept an optional `onEvent` callback that receives every `BridgeEvent` the handler emits via `HostContext.emit` / `emitText`.
- Omitting `onEvent` preserves the prior emit-noop behavior — all existing callers unchanged.
- Callback exceptions are logged via the bridge logger and swallowed, so a misbehaving observer cannot fail the tool call. Extension stream-wrappers remain `execute()`-only and are intentionally NOT applied to direct-Dart invocations.

Implements Option A of `~/dev/plans/dart-monty-invoke-host-function-emit.md` — unblocks LLM tool-dispatch consumers (soliplex_agent) that need streaming progress from direct-Dart host function calls.

## Files
- `lib/src/host/dispatch.dart` — core change; wires `onEvent` into `HostContext.emit` with exception guard
- `lib/src/bridge/bridge.dart` — interface signature + doc
- `lib/src/bridge/platform.dart` — delegate forwards `onEvent`
- `lib/src/runtime/runtime.dart` — public `invoke` mirrors the signature
- 3 test-double fakes updated (extension_coordinator, monty_extension, introspection_functions)
- 6 new test cases in `platform_bridge_test.dart` covering: default-omitted, emission delivery + order, interceptor interaction, infra bypass, custom `BridgeEvent` subtypes, callback-throw isolation

## Test plan
- [x] `dart analyze --fatal-infos lib/` — clean
- [x] `dcm analyze` on touched files — clean
- [x] `dart test -p vm` — 463 pass / 22 skipped
- [x] `dart test -p chrome` on the new group — 6/6 pass (FFI + WASM parity)
- [ ] Reviewer spot-check: no downstream caller needs a migration
- [ ] Soliplex integration confirms it can pass `onEvent: _session.emit` (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)