### PR TITLE
feat(bridge): stream handler emits through invokeHostFunction

### DIFF
--- a/lib/src/bridge/bridge.dart
+++ b/lib/src/bridge/bridge.dart
@@ -59,8 +59,19 @@ abstract class MontyBridge implements AttachContext {
   /// Infra functions (where [HostFunction.isInfra] is `true`) bypass the
   /// interceptor. All others go through it.
   ///
+  /// When [onEvent] is provided, any `BridgeEvent` the handler emits via
+  /// `HostContext.emit` / `HostContext.emitText` is delivered to the callback
+  /// before the returned future completes. When omitted, emitted events are
+  /// silently dropped. Exceptions thrown by [onEvent] are caught and logged;
+  /// they do not fail the call. Extension-registered stream wrappers applied
+  /// to [execute] are NOT applied here.
+  ///
   /// Throws [ArgumentError] if [name] is not registered.
-  Future<Object?> invokeHostFunction(String name, Map<String, Object?> args);
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  });
 
   /// Registers an [OsCallHandler] for OS-level calls (pathlib, os, datetime).
   ///

--- a/lib/src/bridge/platform.dart
+++ b/lib/src/bridge/platform.dart
@@ -201,10 +201,14 @@ class PlatformBridge implements MontyBridge, AttachContext {
   OsCallHandler? get currentOsHandler => _osHandler;
 
   @override
-  Future<Object?> invokeHostFunction(String name, Map<String, Object?> args) {
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) {
     if (_isDisposed) throw StateError('Bridge has been disposed');
 
-    return _host.invokeHostFunction(name, args);
+    return _host.invokeHostFunction(name, args, onEvent: onEvent);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/src/host/dispatch.dart
+++ b/lib/src/host/dispatch.dart
@@ -232,7 +232,20 @@ class HostDispatch {
   /// Invokes a registered host function by [name] directly from Dart.
   ///
   /// Infra functions bypass the interceptor; all others go through it.
-  Future<Object?> invokeHostFunction(String name, Map<String, Object?> args) {
+  ///
+  /// When [onEvent] is provided, any [BridgeEvent] the handler emits via
+  /// [HostContext.emit] / [HostContext.emitText] is delivered to the callback
+  /// before the returned future completes. When omitted, emitted events are
+  /// silently dropped (preserving prior behavior). Exceptions thrown by
+  /// [onEvent] are caught and logged as warnings; they do not fail the call.
+  ///
+  /// Note: extension-registered stream wrappers (applied to `execute`) are
+  /// NOT applied here — they are Python-execution-specific.
+  Future<Object?> invokeHostFunction(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) {
     final fn = _functions[name];
     if (fn == null) throw ArgumentError('Unknown host function: $name');
     final pending = MontyPending(
@@ -242,7 +255,7 @@ class HostDispatch {
     );
     final validatedArgs = fn.schema.mapAndValidate(pending);
     final ctx = HostContext(
-      emit: (_) {}, // no stream available for direct Dart invocations
+      emit: _safeEmit(onEvent),
       executionId: name,
       os: osHandler,
       runtime: _runtime,
@@ -450,4 +463,24 @@ class HostDispatch {
   /// Called from `PlatformBridge._run`'s `finally` block to avoid leaking
   /// futures across executions when a run ends unexpectedly.
   void clearPendingFutures() => _pendingFutures.clear();
+
+  /// Wraps [onEvent] so exceptions thrown by the caller's callback are caught
+  /// and logged rather than propagated into the handler. Returns a no-op sink
+  /// when [onEvent] is `null`.
+  void Function(BridgeEvent) _safeEmit(void Function(BridgeEvent)? onEvent) {
+    if (onEvent == null) return (_) {};
+
+    return (event) {
+      try {
+        onEvent(event);
+      } on Object catch (e, st) {
+        _log.warning(
+          'invokeHostFunction onEvent callback threw; event dropped',
+          attributes: {'eventType': event.runtimeType.toString()},
+          error: e,
+          stackTrace: st,
+        );
+      }
+    };
+  }
 }

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -221,7 +221,11 @@ class MontyRuntime implements MontyRuntimeRef {
   /// - [StateError] if the runtime is disposed.
   /// - [UnsupportedError] if called on a sandbox-mode runtime.
   /// - [ArgumentError] if [name] is not registered.
-  Future<Object?> invoke(String name, Map<String, Object?> args) async {
+  Future<Object?> invoke(
+    String name,
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) async {
     if (_disposed) throw StateError('MontyRuntime has been disposed');
     if (_sandbox) {
       throw UnsupportedError(
@@ -238,7 +242,7 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedAttached = true;
     }
 
-    return _sharedBridge!.invokeHostFunction(name, args);
+    return _sharedBridge!.invokeHostFunction(name, args, onEvent: onEvent);
   }
 
   /// Clears all persisted Python state.

--- a/test/src/bridge/extension_coordinator_test.dart
+++ b/test/src/bridge/extension_coordinator_test.dart
@@ -1138,8 +1138,9 @@ class _MockBridge implements MontyBridge {
   @override
   Future<Object?> invokeHostFunction(
     String name,
-    Map<String, Object?> args,
-  ) => throw UnimplementedError();
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) => throw UnimplementedError();
 
   @override
   void dispose() {}

--- a/test/src/bridge/introspection_functions_test.dart
+++ b/test/src/bridge/introspection_functions_test.dart
@@ -323,8 +323,9 @@ class _FakeBridge implements MontyBridge {
   @override
   Future<Object?> invokeHostFunction(
     String name,
-    Map<String, Object?> args,
-  ) => throw UnimplementedError();
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) => throw UnimplementedError();
 
   @override
   void dispose() {}

--- a/test/src/bridge/monty_extension_test.dart
+++ b/test/src/bridge/monty_extension_test.dart
@@ -134,8 +134,9 @@ class _NoOpBridge implements MontyBridge {
   @override
   Future<Object?> invokeHostFunction(
     String name,
-    Map<String, Object?> args,
-  ) => throw UnimplementedError();
+    Map<String, Object?> args, {
+    void Function(BridgeEvent)? onEvent,
+  }) => throw UnimplementedError();
 
   @override
   void dispose() {}

--- a/test/src/bridge/platform_bridge_test.dart
+++ b/test/src/bridge/platform_bridge_test.dart
@@ -674,6 +674,186 @@ void main() {
 
       expect(() => bridge.invokeHostFunction('fn', {}), throwsStateError);
     });
+
+    group('onEvent', () {
+      test('omitted — emitted events are dropped silently', () async {
+        bridge.register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'emits', description: ''),
+            handler: (_, ctx) async {
+              ctx.emitText('dropped');
+
+              return 'ok';
+            },
+          ),
+        );
+
+        final result = await bridge.invokeHostFunction('emits', const {});
+
+        expect(result, 'ok');
+      });
+
+      test('provided — handler emissions surface in order', () async {
+        bridge.register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'emits', description: ''),
+            handler: (_, ctx) async {
+              ctx
+                ..emitText('first')
+                ..emitText('second');
+
+              return 'done';
+            },
+          ),
+        );
+
+        final received = <BridgeEvent>[];
+        final result = await bridge.invokeHostFunction(
+          'emits',
+          const {},
+          onEvent: received.add,
+        );
+
+        expect(result, 'done');
+        expect(received, hasLength(2));
+        expect(received[0], isA<BridgeFunctionEmit>());
+        expect(received[1], isA<BridgeFunctionEmit>());
+        expect((received[0] as BridgeFunctionEmit).text, 'first');
+        expect((received[1] as BridgeFunctionEmit).text, 'second');
+      });
+
+      test('interceptor runs + emits still deliver', () async {
+        var interceptorCalls = 0;
+        final b = MontyBridge(
+          platform: mock,
+          interceptor: (name, args, next) {
+            interceptorCalls++;
+
+            return next();
+          },
+        );
+        addTearDown(b.dispose);
+
+        b.register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'emits', description: ''),
+            handler: (_, ctx) async {
+              ctx.emitText('via interceptor');
+
+              return 'ok';
+            },
+          ),
+        );
+
+        final received = <BridgeEvent>[];
+        final result = await b.invokeHostFunction(
+          'emits',
+          const {},
+          onEvent: received.add,
+        );
+
+        expect(result, 'ok');
+        expect(interceptorCalls, 1);
+        expect(received, hasLength(1));
+      });
+
+      test('infra bypasses interceptor + emits still deliver', () async {
+        var interceptorCalls = 0;
+        final b = MontyBridge(
+          platform: mock,
+          interceptor: (name, args, next) {
+            interceptorCalls++;
+
+            return next();
+          },
+        );
+        addTearDown(b.dispose);
+
+        b.register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'emits', description: ''),
+            handler: (_, ctx) async {
+              ctx.emitText('infra');
+
+              return 'ok';
+            },
+            isInfra: true,
+          ),
+        );
+
+        final received = <BridgeEvent>[];
+        final result = await b.invokeHostFunction(
+          'emits',
+          const {},
+          onEvent: received.add,
+        );
+
+        expect(result, 'ok');
+        expect(interceptorCalls, 0);
+        expect(received, hasLength(1));
+      });
+
+      test('custom BridgeEvent subtypes deliver verbatim', () async {
+        bridge.register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'emits', description: ''),
+            handler: (_, ctx) async {
+              ctx.emit(
+                const BridgeOsCallStart(
+                  callId: 'custom',
+                  operationName: 'Path.exists',
+                ),
+              );
+
+              return null;
+            },
+          ),
+        );
+
+        final received = <BridgeEvent>[];
+        await bridge.invokeHostFunction(
+          'emits',
+          const {},
+          onEvent: received.add,
+        );
+
+        expect(received, hasLength(1));
+        final event = received.single;
+        expect(event, isA<BridgeOsCallStart>());
+        expect((event as BridgeOsCallStart).operationName, 'Path.exists');
+      });
+
+      test('onEvent throws — swallowed; handler returns', () async {
+        bridge.register(
+          HostFunction(
+            schema: const HostFunctionSchema(name: 'emits', description: ''),
+            handler: (_, ctx) async {
+              ctx
+                ..emitText('first')
+                ..emitText('second');
+
+              return 'final';
+            },
+          ),
+        );
+
+        final received = <BridgeEvent>[];
+        final result = await bridge.invokeHostFunction(
+          'emits',
+          const {},
+          onEvent: (event) {
+            received.add(event);
+            if (received.length == 1) {
+              throw StateError('callback kaboom');
+            }
+          },
+        );
+
+        expect(result, 'final');
+        // Both emits delivered — second NOT blocked by first's throw.
+        expect(received, hasLength(2));
+      });
+    });
   });
 
   group('error handling in _run', () {


### PR DESCRIPTION
## Summary

- Adds an opt-in `onEvent` callback to `MontyBridge.invokeHostFunction` so host handlers invoked directly from Dart can stream `BridgeEvent`s — previously they were silently dropped because `HostDispatch` built the `HostContext` with a no-op `emit`.
- Threads the parameter through `PlatformBridge.invokeHostFunction`, `HostDispatch.invokeHostFunction`, and `MontyRuntime.invoke`, with a `_safeEmit` helper that catches & logs callback exceptions rather than letting them fail the call.
- Non-breaking: omitting `onEvent` preserves the prior drop-silently behavior. Callers that already use the bridge as a tool dispatcher (e.g. soliplex_agent) can now subscribe to progress events without going through the Python execution path.

## Why

This is the keystone blocker flagged as Finding 02 in the dart_monty ↔ soliplex_agent integration audit: `invoke-host-function-emit-noop`. Design rationale, rejected alternatives (record return, new method, bridge event bus), and rollout considerations are in `~/dev/plans/dart-monty-invoke-host-function-emit.md`.

## Test plan

- [x] `dart analyze --fatal-infos` — clean on all touched files
- [x] `dcm analyze` — clean on all touched lib files
- [x] `dart test -p vm` — 463 tests pass
- [x] `dart test test/src/bridge/platform_bridge_test.dart -p chrome` — 43 tests pass (includes the 6 new onEvent tests)
- [ ] New tests cover: omitted callback (events dropped), provided callback (order preserved), interceptor path, infra bypass path, custom `BridgeEvent` subtypes, throwing callback (swallowed, handler result still returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)