### PR TITLE
docs: core terminology and architecture overhaul (PR #1 in stack)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,10 +103,14 @@ dart format --set-exit-if-changed .       # Format check
 
 ## Architecture
 
-Pure Dart with compile-time conditional imports (no Flutter required).
+Pure Dart high-level API for the Monty interpreter.
 
-- `lib/src/platform/` -- abstract contract (pure Dart); concrete implementations in `dart_monty_core`
-- `lib/src/bridge/` -- high-level bridge with plugins and host functions
+- `lib/src/runtime/` -- stateful sessions (`MontyRuntime`)
+- `lib/src/bridge/` -- tool-calling layer (`PlatformBridge`)
+- `lib/src/extension/` -- `MontyExtension` and `ExtensionCoordinator`
+- `lib/src/os_call/` -- `OsCallHandler` and VFS logic
+
+Core interpreter logic and models live in `package:dart_monty_core`.
 
 See [Architecture Overview](docs/architecture/overview.md) for details.
 
@@ -115,9 +119,7 @@ See [Architecture Overview](docs/architecture/overview.md) for details.
 - Follow KISS, YAGNI, SOLID.
 - Match surrounding code style exactly.
 - Run `dart format` before committing.
-- Keep `lib/src/platform/` pure Dart (no Flutter).
-- All JSON keys at the C FFI boundary must be `snake_case`.
-- **Dispose:** `MontyFfi` and `MontyNative` must be disposed to avoid leaks.
+- **Dispose:** `MontyRuntime`, `Monty`, and `MontyRepl` must be disposed to avoid leaks.
 
 ## Commit Messages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,28 @@
 ## Unreleased
 
+### Breaking Changes
+
+- **Plugin renamed to Extension** — `MontyPlugin` → `MontyExtension`, `PluginRegistry` → `ExtensionCoordinator`.
+- **OsProvider replaced by OsCallHandler** — Generic `OsCallHandler` typedef and functional handlers (`fsHandler`, `memoryFsHandler`, etc.) replace the class hierarchy.
+- **ReplSession replaced by MontyRuntime** — High-level session management moved to `MontyRuntime`.
+- **Module Structure** — Core models and base platform moved to `package:dart_monty_core`. `package:dart_monty` now focuses on the high-level bridge and extension layer.
+
 ### Features
 
-- **SandboxPlugin works on WASM** — child interpreters spawn in independent
+- **MontyRuntime** — New primary entry point for stateful sessions with extensions and OS interception.
+- **WASM Sandbox support** — `SandboxExtension` now fully supports WASM via unique `replId` routing in the shared Worker.
+- **ExtensionCoordinator** — Improved lifecycle management with `onAttach` and `spawnChild` for inheritance.
+- **Functional OS Handlers** — Composable handlers for filesystem, environment, and time interception.
+
+### Documentation
+
+- **Complete documentation overhaul** — All guides, tutorials, and deep dives updated to reflect the new architecture.
+- **Stacked PRs** — Documentation updates organized into logical stacks for easier review.
+- **Gaps identified and filled** — Added detailed documentation for `MontyRuntime` and corrected outdated examples.
+
+### Features (previously unreleased)
+
+- **SandboxExtension works on WASM** — child interpreters spawn in independent
   Web Workers via real session ID routing (#291)
 - **No default execution timeout** — removed hardcoded 30s wall-clock
   timeout from native FFI (#278)

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ final r = await repl.feed('double(x)');
 print(r.value); // MontyInt(84)
 ```
 
-**Session with plugins**
+**MontyRuntime session with extensions**
 
 ```dart
-final session = ReplSession(
-  plugins: [DinjaTemplatePlugin(), MessageBusPlugin()],
+final session = MontyRuntime(
+  extensions: [JinjaTemplateExtension(), MessageBusExtension()],
 );
-final r = await session.run(
+final r = await session.execute(
   "tmpl_render(template='Hello {{ name }}!', context={'name': 'World'})",
 );
 print(r.value); // 'Hello World!'
@@ -53,7 +53,7 @@ print(r.value); // 'Hello World!'
 - [**Overview**](docs/help.md) — API summary and quick start
 - [**Architecture**](docs/architecture/overview.md) — Module structure and internals
 - [**REPL Guide**](docs/user/repl.md) — Stateful interactive execution
-- [**Plugins**](docs/user/plugins.md) — Template, MessageBus, Sandbox
+- [**Extensions**](docs/user/extensions.md) — Template, MessageBus, Sandbox
 - [**Contributor Setup**](docs/contributor/setup.md) — Build and test the library
 
 ## License

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -14,10 +14,24 @@ is a facade class, not a platform implementation. No Flutter required.
 ## Internal Module Structure
 
 ```text
-dart_monty                           (single package — Monty() + conditional imports)
-  │  Monty class delegates to createPlatformMonty() + OsProvider support:
-  │    if (dart.library.ffi)           → MontyFfi()
-  │    if (dart.library.js_interop)    → MontyWasm()
+dart_monty                           (high-level API package)
+  │
+  ├── lib/src/runtime/               (session management)
+  │     ├── MontyRuntime              (high-level session facade)
+  │     └── ExecutionHandle           (async execution control)
+  │
+  ├── lib/src/bridge/                (tool-calling layer)
+  │     ├── PlatformBridge            (tool schema + dispatch logic)
+  │     └── BridgeEvent               (streamable execution events)
+  │
+  ├── lib/src/extension/             (extension system)
+  │     ├── MontyExtension            (abstract base)
+  │     └── ExtensionCoordinator      (lifecycle and registration)
+  │
+  └── lib/src/os_call/               (VFS and OS-level interception)
+        └── OsCallHandler             (operation interception logic)
+
+dart_monty_core                      (low-level core engine package)
   │
   ├── lib/src/platform/               (abstract contract, pure Dart)
   │     ├── MontyPlatform              (abstract class)
@@ -26,17 +40,17 @@ dart_monty                           (single package — Monty() + conditional i
   │     ├── MontyStateMixin            (shared state machine lifecycle)
   │     ├── MontySnapshotCapable       (capability: snapshot/restore)
   │     ├── MontyFutureCapable         (capability: resumeAsFuture/resolveFutures)
-  │     ├── MontySession               (stateful sessions — persists globals)
-  │     ├── MontyProgress              (sealed: Pending | Complete | ResolveFutures | OsCall)
   │     └── MontyResult, MontyException, MontyStackFrame, ...
   │
-  └── lib/src/wasm/                    (pure Dart, dart:js_interop)
-  │   [FFI/WASM backends live in dart_monty_core, not dart_monty]
-        ├── WasmBindings               (abstract) → WasmBindingsJs (JS bridge)
-        ├── WasmCoreBindings           (implements MontyCoreBindings)
-        ├── MontyWasm                  (extends BaseMontyPlatform)
-        │     implements MontySnapshotCapable
-        └── js/                        (bridge.js + worker_src.js)
+  ├── lib/src/repl/                   (stateful Python REPL)
+  │     ├── MontyRepl                  (persistent Rust-backed REPL)
+  │     └── ReplPlatform               (adapts MontyRepl to MontyPlatform)
+  │
+  ├── lib/src/ffi/                    (native FFI backend)
+  │     └── MontyFfi                   (FFI implementation)
+  │
+  └── lib/src/wasm/                   (web WASM backend)
+        └── MontyWasm                  (WASM implementation)
 ```
 
 ## Platform Support Matrix
@@ -57,7 +71,7 @@ dart_monty                           (single package — Monty() + conditional i
 | Simple script evaluation | `Monty.exec()` | `await Monty.exec('2+2')` |
 | Multiple runs, same interpreter | `Monty()` + `.run()` | `monty.run(code1); monty.run(code2)` |
 | Stateful session (persist variables) | `MontySession` | `session.run('x=1'); session.run('x+1')` |
-| Host functions + plugins | `MontyBridge` | `bridge.register(...); bridge.execute(code)` |
+| Host functions + extensions | `MontyBridge` | `bridge.register(...); bridge.execute(code)` |
 | LLM tool calling | `MontyBridge` + `bridge.schemas` | Register tools, feed schemas to LLM, execute generated code |
 | Custom filesystem/env | `Monty(os: ...)` | See OsCall section |
 
@@ -92,18 +106,18 @@ LLM sees tool schemas (bridge.schemas)
   Feed `bridge.schemas` directly to an LLM as tool definitions.
 - **`HostFunction`** -- pairs a schema with a Dart handler that executes
   when Python calls the function.
-- **`MontyPlugin` / `PluginRegistry`** -- pre-built tool bundles
-  (e.g., `SandboxPlugin`, `MessageBusPlugin`) that group related functions
+- **`MontyExtension` / `ExtensionCoordinator`** -- pre-built tool bundles
+  (e.g., `SandboxExtension`, `MessageBusExtension`) that group related functions
   under a namespace.
 - **`BridgeEvent` stream** -- `bridge.execute()` returns a
   `Stream<BridgeEvent>` providing real-time observability into tool calls,
   text output, and lifecycle events.
-- **`OsProvider`** -- transparent OS-level interception (filesystem, env,
+- **`OsCallHandler`** -- transparent OS-level interception (filesystem, env,
   time) that Python does not know about. Works alongside explicit tools:
-  `OsProvider` handles the "OS" side, plugins handle the "tool" side.
+  `OsCallHandler` handles the "OS" side, extensions handle the "tool" side.
 
 For a complete example, see the "LLM Tool Calling" section in the
-[README](../README.md). For the OsProvider layer, see
+[README](../README.md). For the OsCallHandler layer, see
 [oscall-vfs.md](oscall-vfs.md).
 
 ## JSON Contract Reference

--- a/docs/help.md
+++ b/docs/help.md
@@ -31,11 +31,11 @@ final r = await repl.feed('double(x)');
 print(r.value); // MontyInt(84)
 ```
 
-**Session with plugins**
+**Session with extensions**
 
 ```dart
 final session = ReplSession(
-  plugins: [DinjaTemplatePlugin(), MessageBusPlugin()],
+  extensions: [DinjaTemplateExtension(), MessageBusExtension()],
 );
 final r = await session.run(
   "tmpl_render(template='Hello {{ name }}!', context={'name': 'World'})",
@@ -48,7 +48,7 @@ print(r.value); // 'Hello World!'
 - [**Installation**](user/install.md) — Add to your project
 - [**Architecture**](architecture/overview.md) — Module structure and internals
 - [**REPL Guide**](user/repl.md) — Stateful interactive execution
-- [**Plugins**](user/plugins.md) — Template, MessageBus, Sandbox
+- [**Extensions**](user/extensions.md) — Template, MessageBus, Sandbox
 - [**Tutorials**](tutorials/host-functions-intro.md) — Bridge functions and LLM rules
 - [**Testing**](contributor/testing.md) — Run tests and quality gates
 - [**Contributor Setup**](contributor/setup.md) — Build and test the library

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ nav:
   - User Guide:
       - Installation: user/install.md
       - REPL: user/repl.md
-      - Plugins: user/plugins.md
+      - Extensions: user/extensions.md
       - API Reference: user/api-reference.md
   - Tutorials:
       - Host Functions Intro: tutorials/host-functions-intro.md
@@ -45,7 +45,7 @@ nav:
       - OsCall / VFS Layer: deep-dives/oscall-vfs.md
       - Error Hierarchy: deep-dives/error-hierarchy.md
       - Lifecycle Management: deep-dives/lifecycles.md
-      - Plugin System: deep-dives/plugin-system.md
+      - Extension System: deep-dives/extension-system.md
   - Technical Reference:
       - Native Crate (Rust): reference/native-crate.md
       - Monty Rust API: reference/monty-rust-api.md


### PR DESCRIPTION
Foundation PR: Renaming Plugins → Extensions, OsProvider → OsCallHandler, and updating core architecture mapping.