### PR TITLE
docs(readme): note upstream map()/filter()/sorted(key=) ext-fn limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ Future<void> main() async {
 }
 ```
 
+## Known upstream limitations
+
+Host functions registered via `MontyRuntime` are first-class Python values
+in most contexts, but currently **cannot** be invoked from inside the
+iterator-consuming C builtins `map()`, `filter()`, or `sorted(key=...)`.
+Calling them that way raises `RuntimeError` with a message from the
+upstream `pydantic/monty` VM:
+
+```
+RuntimeError: Internal error in monty:
+map(): external functions are not yet supported in this context
+```
+
+Wrapping the host function in a `lambda` does not help — the suspension
+point is still inside `map()`'s frame. Pass a plain Python function (or
+unroll the `map` into a `for` loop) as a workaround.
+
+This is tracked upstream; see `dart_monty_core`'s README for details and
+the regression fixtures that will auto-detect when it's fixed.
+
 ## Documentation
 
 - [**Installation**](docs/user/install.md) — Add to your project


### PR DESCRIPTION
## Summary

Documents that host functions registered via \`MontyRuntime\` currently cannot be invoked from inside the iterator-consuming C builtins (\`map\`, \`filter\`, \`sorted(key=)\`). Calling them that way raises \`RuntimeError\` from the upstream pydantic/monty VM.

First-class references in every other context (bare reference, assignment, pass to user HOF, storage in collections) continue to work.

Tracked via regression fixtures in \`dart_monty_core\` (see that repo's companion PR #39 and its README — fixtures with the \`_xfail\` suffix encode the limitation and will auto-fail when upstream fixes it).

## Test plan

- [ ] Render README on GitHub and sanity-check the section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)