### PR TITLE
fix(web): correct transitive bridge URL; simplify consumer docs + README audit fixes

### DIFF
--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -5,16 +5,11 @@ and native applications.
 
 ## Packages you depend on
 
-- **`dart_monty_core`** — ships the JS bridge, WASM worker, and
-  compiled WASM binary. Also ships the native `hook/build.dart` that
-  compiles a platform dylib on `pub get` for desktop/server targets.
-- **`dart_monty`** — high-level API layered on top of core. This is
-  the package your code imports day-to-day.
-
-Flutter consumers depend on both — `dart_monty` for the API and
-`dart_monty_core` so Flutter's asset bundler can locate the WASM/JS
-files directly. The asset resolver does not chase transitive
-references, so both deps must be listed.
+- **`dart_monty`** — high-level API. This is the only package your
+  app lists as a direct dependency.
+- **`dart_monty_core`** — ships the JS bridge, WASM worker, compiled
+  WASM binary, and native `hook/build.dart`. Comes in transitively
+  through `dart_monty`; you do not need to list it directly.
 
 ## Flutter Web
 
@@ -22,16 +17,12 @@ references, so both deps must be listed.
 # pubspec.yaml
 dependencies:
   dart_monty: ^<version>
-  dart_monty_core: ^<version>  # needed for flutter.assets
-
-flutter:
-  assets:
-    - package: dart_monty_core
 ```
 
 ```dart
 // main.dart
 import 'package:dart_monty/dart_monty.dart';
+import 'package:flutter/widgets.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -40,11 +31,14 @@ Future<void> main() async {
 }
 ```
 
+Flutter bundles `dart_monty_core`'s declared `flutter.assets`
+automatically — no consumer-side redeclaration is needed.
 `DartMonty.ensureInitialized()` injects
-`packages/dart_monty_core/assets/dart_monty_core_bridge.js` into
+`assets/packages/dart_monty_core/lib/assets/dart_monty_core_bridge.js` into
 `document.head` at runtime, awaits load, and verifies
 `window.DartMontyBridge` is defined. No manual `<script>` tag in
-`web/index.html` is required.
+`web/index.html` is required; `--base-href` is honoured
+automatically.
 
 ### Required security headers
 

--- a/lib/src/web/ensure_initialized_web.dart
+++ b/lib/src/web/ensure_initialized_web.dart
@@ -5,25 +5,26 @@ import 'package:web/web.dart' as web;
 
 /// Web implementation of `DartMonty.ensureInitialized()`.
 ///
-/// Dynamically injects
-/// `packages/dart_monty_core/assets/dart_monty_core_bridge.js` into
-/// `document.head`, awaits its load, and verifies that
-/// `window.DartMontyBridge` is defined. Raises [StateError] with a
-/// pointer to the most likely misconfiguration if the bridge fails to
-/// load or doesn't register after load.
+/// Dynamically injects the `dart_monty_core` JS bridge into
+/// `document.head`, awaits its load, and verifies
+/// `window.DartMontyBridge` is defined.
+///
+/// The URL `assets/packages/dart_monty_core/lib/assets/...` is where
+/// Flutter serves transitively-bundled package assets. Consumers do
+/// NOT need to redeclare the three asset files under their own
+/// `flutter.assets` — adding `dart_monty` to pubspec is enough.
 Future<void> ensureInitialized() async {
   if (_isBridgeLoaded()) return;
 
   await _injectScript(
-    'packages/dart_monty_core/assets/dart_monty_core_bridge.js',
+    'assets/packages/dart_monty_core/lib/assets/dart_monty_core_bridge.js',
   );
 
   if (!_isBridgeLoaded()) {
     throw StateError(
-      'dart_monty: bridge script loaded but window.DartMontyBridge is not '
-      'defined. Ensure your app lists "- package: dart_monty_core" under '
-      'flutter.assets in pubspec.yaml and that dart_monty_core is in your '
-      'dependencies.',
+      'dart_monty: bridge script loaded but window.DartMontyBridge is '
+      'not defined. Run `flutter pub upgrade` to refresh dart_monty_core '
+      'and rebuild; if the error persists, file an issue.',
     );
   }
 }
@@ -43,10 +44,10 @@ Future<void> _injectScript(String src) {
     ..onerror = (web.Event _) {
       completer.completeError(
         StateError(
-          'dart_monty: failed to load Monty bridge from $src. Verify '
-          '"- package: dart_monty_core" is listed under flutter.assets '
-          'in pubspec.yaml and that the dart_monty_core package is in '
-          'your dependencies.',
+          'dart_monty: failed to load Monty bridge from $src. '
+          'dart_monty_core should be pulled in transitively via dart_monty; '
+          'check `flutter pub deps` to confirm it is resolved, and that no '
+          'consumer-side flutter.assets block is stripping it.',
         ),
       );
     }.toJS;


### PR DESCRIPTION
## What was wrong

PR #374 landed \`DartMonty.ensureInitialized()\` with a bridge URL of \`packages/dart_monty_core/assets/dart_monty_core_bridge.js\`. That URL only resolves when the consumer explicitly redeclares the three asset files under its own \`flutter.assets\`. Without redeclaration the dev server 404s the URL and \`flutter run\` crashes with \`Refused to execute script from ... ('text/plain')\`.

## Probing the dev server revealed two working URLs

| URL | Serves? |
|---|---|
| \`packages/dart_monty_core/assets/bridge.js\` | 200, but only with consumer redeclaration (Flutter root-maps declared paths and strips the \`lib/\` prefix) |
| \`assets/packages/dart_monty_core/lib/assets/bridge.js\` | 200, with transitive bundling (no consumer work) — Flutter preserves the \`lib/\` segment and serves at the generic \`/assets/\` path |

Both dev-server and release-bundle layouts agree on the transitive URL.

## What this PR does

- **\`lib/src/web/ensure_initialized_web.dart\`:** swap the script src to the transitive URL \`assets/packages/dart_monty_core/lib/assets/dart_monty_core_bridge.js\`. Consumer no longer needs to list \`dart_monty_core\` as a direct dep or redeclare the assets.
- **\`README.md\`:** rewrite Quick Start with the simpler consumer setup (\`dart_monty\` is the only dep). Also apply README audit fixes:
  - Correct \`Monty.run\` → \`Monty.exec\` (static one-shot API).
  - Correct \`runtime.run\` → \`await runtime.execute(...).result\` (the real terminal API).
  - \`await\` the async \`MontyRepl.dispose()\` and \`MontyRuntime.dispose()\`.
  - Add missing \`import 'package:flutter/widgets.dart';\` to the \`main()\` snippet.
  - Point the Documentation link at \`docs/index.md\` (was the broken \`help.md\`).
  - Clarify that \`result.value\` is a \`MontyValue\`; show \`.dartValue\` for primitive extraction.
- **\`docs/user/install.md\`, \`docs/user/deployment.md\`:** same simplification.

## Verified live

\`flutter run -d chrome --dart-define=MONTY_ENABLED=true\` with a consumer pubspec listing only \`dart_monty\` (no \`dart_monty_core\` dep, no redeclared \`flutter.assets\`):

\`\`\`
[DartMontyBridge] Registered on window (Worker pool architecture)
[DartMontyBridge] Session 1 ready
\`\`\`

## Companion PRs

- runyaga/dart_monty_core#<pending> — mirrors the simplified consumer story in dart_monty_core's own README + AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)