### PR TITLE
fix(bridge): compose excType + message for BridgeRunError surface

### DIFF
--- a/lib/src/bridge/platform.dart
+++ b/lib/src/bridge/platform.dart
@@ -19,6 +19,18 @@ import 'package:struct_log/struct_log.dart';
 // Top-level helpers — pure utilities that do not need bridge instance state.
 // ---------------------------------------------------------------------------
 
+/// Composes `excType: message` for the human-readable [BridgeRunError.message]
+/// surface, falling back to just the message when no exception type is known.
+///
+/// `dart_monty_core` ≥ post-PR-#48 splits `excType` and `message` into
+/// orthogonal fields — the `message` field on [MontyException] no longer
+/// carries the Python exception type prefix that `summary()` previously
+/// embedded. Bridge consumers display [BridgeRunError.message] directly in
+/// UIs and logs, so we restore the prefixed form here. Consumers who want
+/// the structured fields read [BridgeRunError.exception] instead.
+String _composeMessage(String? excType, String message) =>
+    (excType == null || excType.isEmpty) ? message : '$excType: $message';
+
 /// Handles the [MontyComplete] terminal step — emits [BridgeRunFinished] or
 /// [BridgeRunError] depending on the result.
 ///
@@ -34,7 +46,7 @@ void _emitComplete(
     final e = complete.result.error!;
     controller.add(
       BridgeRunError(
-        message: e.message,
+        message: _composeMessage(e.excType, e.message),
         printOutput: complete.result.printOutput,
         exception: e,
       ),
@@ -57,7 +69,9 @@ void _emitScriptError(
   StreamController<BridgeEvent> controller,
   BridgeLogger log,
 ) {
-  final msg = e.exception?.message ?? e.message;
+  final excType = e.exception?.excType ?? e.excType;
+  final rawMessage = e.exception?.message ?? e.message;
+  final msg = _composeMessage(excType, rawMessage);
   log.warning('Python error', attributes: {'error': msg});
   controller.add(BridgeRunError(message: msg, exception: e.exception));
 }


### PR DESCRIPTION
## Summary

`dart_monty_core` PR #48 (`drop exception-type prefix from MontyException.message`) merged into core's main on 2026-04-25 01:51. It made `excType` and `message` orthogonal fields, dropping the `"ExcType: msg"` prefix from `MontyException.message`.

That's the right shape for the structured API, but `BridgeRunError.message` is consumed directly by UIs and log lines, where the human-readable prefixed form is expected. After core's main updated, dart_monty's bridge silently degraded:

| | Before | After (silent regression) |
|---|---|---|
| `BridgeRunError.message` | `"NameError: name 'x' is not defined"` | `"name 'x' is not defined"` |

`test/integration/sandbox_error_structure_test.dart:74` (`expect(caught.message, contains('NameError'))`) was the canary — it would have failed on the next CI run, but dart_monty's main hasn't run CI since PR #48 merged.

## Change

One file: `lib/src/bridge/platform.dart`. Adds a 1-line `_composeMessage(excType, message)` helper. Applied at the two `BridgeRunError` emission sites (`_emitComplete`, `_emitScriptError`). Consumers needing the structured fields keep reading `BridgeRunError.exception` (`MontyException` with `excType` + `message` separate) — unchanged.

```diff
-        message: e.message,
+        message: _composeMessage(e.excType, e.message),
```

## Test plan

- [x] `dart analyze` — clean
- [x] `dcm analyze` on the edited file — clean
- [x] `dart format` — no changes
- [x] `dart test` — 463/463 unit
- [x] `dart test --run-skipped --tags=integration` — 250/250 (incl. `sandbox_error_structure_test.dart` which would have regressed)
- [ ] CI on this branch green

## Why this fix vs. updating tests

Two valid responses to PR #48's regression:

| Option | Cost | Trade-off |
|---|---|---|
| **A — compose at the bridge** (this PR) | 16 lines | UI-friendly. Anyone reading `BridgeRunError.message` keeps the prefixed form. No surprise migration for consumers. |
| B — update test assertions | ~5 line tweaks | Strict orthogonality at the bridge layer too — UI consumers compose for themselves. |

Picked A: `BridgeRunError.message` is documented as the human-readable display surface, and the API has a separate `BridgeRunError.exception` for callers who want the structured fields. The bridge is the right layer to bridge the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)