### PR TITLE
docs: clarify the flutter.assets stanza is only for Flutter build hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ dependencies:
   # directly; it does not chase transitive references. Not redundant.
   dart_monty_core: ^<version>
 
+# Only needed by Flutter's build hook — instructs the asset bundler
+# to include dart_monty_core's WASM/JS bridge files. Plain-Dart
+# consumers ignore this stanza.
 flutter:
   assets:
     - package: dart_monty_core

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -33,6 +33,9 @@ dependencies:
   # Do not remove; it is not redundant with dart_monty.
   dart_monty_core: ^<version>
 
+# Only needed by Flutter's build hook — instructs the asset bundler
+# to include dart_monty_core's WASM/JS bridge files. Plain-Dart
+# consumers ignore this stanza.
 flutter:
   assets:
     - package: dart_monty_core


### PR DESCRIPTION
## Summary

The `flutter:` stanza next to a `dependencies: dart_monty_core` entry looks redundant — readers wonder why the package is mentioned twice. Add a short comment on the `flutter:` line explaining what the stanza actually does (instructs Flutter's asset bundler to include dart_monty_core's WASM/JS bridge) and that plain-Dart consumers ignore it.

## Diff

```diff
   dart_monty_core: ^<version>

+# Only needed by Flutter's build hook — instructs the asset bundler
+# to include dart_monty_core's WASM/JS bridge files. Plain-Dart
+# consumers ignore this stanza.
 flutter:
   assets:
     - package: dart_monty_core
```

Mirrored in **`README.md`** and **`docs/user/install.md`**.

## Test plan

- [x] No code paths affected
- [ ] CI green (markdownlint, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)