### PR TITLE
Slim toward dart_monty_core: align API + adopt new helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ See [Architecture Overview](docs/architecture/overview.md) for details.
 - Run `dart format` before committing.
 - Keep `lib/src/platform/` pure Dart (no Flutter).
 - All JSON keys at the C FFI boundary must be `snake_case`.
-- **Dispose:** `MontyFfi` and `MontyNative` must be disposed to avoid leaks.
+- **Dispose:** `MontyRepl` and `MontyRuntime` must be disposed to avoid leaks.
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ For interactive, stateful sessions, use a `MontyRepl`:
 ```dart
 Future<void> main() async {
   final repl = MontyRepl();
-  await repl.feed('x = 42');
-  await repl.feed('def double(n): return n * 2');
-  final result = await repl.feed('double(x)');
+  await repl.feedRun('x = 42');
+  await repl.feedRun('def double(n): return n * 2');
+  final result = await repl.feedRun('double(x)');
   print(result.value); // MontyInt(84)
-  repl.dispose();
+  await repl.dispose();
 }
 ```
 
@@ -90,11 +90,11 @@ Future<void> main() async {
   final runtime = MontyRuntime(
     extensions: [JinjaTemplateExtension(), MessageBusExtension()],
   );
-  final result = await runtime.run(
+  final result = await runtime.execute(
     "tmpl_render(template='Hello {{ name }}!', context={'name': 'World'})",
-  );
+  ).result;
   print(result.value); // 'Hello World!'
-  runtime.dispose();
+  await runtime.dispose();
 }
 ```
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -80,7 +80,7 @@ sequenceDiagram
 
     User->>RT: execute("my_tool()")
     RT->>PB: execute("my_tool()")
-    PB->>MR: feed("my_tool()")
+    PB->>MR: feedRun("my_tool()")
     MR-->>PB: Yields (Pending Tool Call)
     PB->>HF: Invoke handler for "my_tool"
     HF-->>PB: Returns result
@@ -144,7 +144,7 @@ dart_monty_core                      (low-level core engine package)
 | Use case | API | Example |
 |----------|-----|---------|
 | Stateful session with tools | `MontyRuntime` | `final session = MontyRuntime(extensions: ...)` |
-| Simple stateful evaluation | `MontyRepl` | `final repl = MontyRepl(); repl.feed('x=1')` |
+| Simple stateful evaluation | `MontyRepl` | `final repl = MontyRepl(); repl.feedRun('x=1')` |
 | One-shot stateless evaluation | `Monty.exec()` | `await Monty.exec('2+2')` |
 
 ## Tool Calling & LLM Integration

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,9 +29,9 @@ print(result.value); // 4
 
 ```dart
 final repl = MontyRepl();
-await repl.feed('x = 42');
-await repl.feed('def double(n): return n * 2');
-final r = await repl.feed('double(x)');
+await repl.feedRun('x = 42');
+await repl.feedRun('def double(n): return n * 2');
+final r = await repl.feedRun('double(x)');
 print(r.value); // MontyInt(84)
 ```
 
@@ -41,9 +41,9 @@ print(r.value); // MontyInt(84)
 final session = MontyRuntime(
   extensions: [JinjaTemplateExtension(), MessageBusExtension()],
 );
-final r = await session.run(
+final r = await session.execute(
   "tmpl_render(template='Hello {{ name }}!', context={'name': 'World'})",
-);
+).result;
 print(r.value); // 'Hello World!'
 ```
 

--- a/docs/reference/ffi-handle-lifecycle.md
+++ b/docs/reference/ffi-handle-lifecycle.md
@@ -29,9 +29,9 @@ then creating a 3rd and calling an HTTP host function, causes a SEGFAULT.
 6. **Dart `BaseMontyPlatform`** (`lib/src/platform/base_monty_platform.dart`) —
    calls `_bindings.dispose()` on platform disposal.
 
-7. **Dart `MontyRuntime`** (`lib/src/bridge/monty_runtime.dart`) —
-   creates `Monty` → `MontyFfi` → `FfiCoreBindings`. Dispose chain:
-   `session.dispose()` → `bridge.dispose()` → `monty.dispose()` →
+7. **Dart `MontyRuntime`** (`lib/src/runtime/runtime.dart`) —
+   creates `MontyRepl` → `MontyFfi` → `FfiCoreBindings`. Dispose chain:
+   `session.dispose()` → `bridge.dispose()` → `repl.dispose()` →
    `platform.dispose()` → `bindings.dispose()` → `_freeHandle()`.
 
 ### The race condition

--- a/docs/reference/monty-rust-api.md
+++ b/docs/reference/monty-rust-api.md
@@ -246,7 +246,7 @@ Python print("hello") → Monty PrintWriter::Collect → MontyHandle.print_outpu
 **Dart API:**
 
 ```dart
-final result = await monty.run('print("hello")\n42');
+final result = await Monty.exec('print("hello")\n42');
 print(result.value);        // 42
 print(result.printOutput);  // "hello\n"
 ```

--- a/docs/tutorials/host-functions-advanced.md
+++ b/docs/tutorials/host-functions-advanced.md
@@ -32,7 +32,7 @@ import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty_bridge/dart_monty_bridge.dart';
 
 final extension = SandboxExtension(
-  platformFactory: () async => Monty(),
+  platformFactory: () async => createPlatformMonty(),
   maxChildren: 16,      // Max concurrent children (default: 16)
   maxDepth: 3,          // Max recursion depth (default: 3)
   currentDepth: 0,      // This extension's depth level (default: 0)
@@ -159,13 +159,13 @@ recursion can go:
 
 ```dart
 SandboxExtension(
-  platformFactory: () async => Monty(),
+  platformFactory: () async => createPlatformMonty(),
   maxDepth: 3,
   currentDepth: 0,
   childExtensionCoordinatorFactory: (context) async {
     final registry = ExtensionCoordinator();
     registry.register(SandboxExtension(
-      platformFactory: () async => Monty(),
+      platformFactory: () async => createPlatformMonty(),
       maxDepth: 3,
       currentDepth: 1,  // One level deeper
     ));
@@ -194,7 +194,7 @@ give children access to host functions:
 
 ```dart
 SandboxExtension(
-  platformFactory: () async => Monty(),
+  platformFactory: () async => createPlatformMonty(),
   childExtensionCoordinatorFactory: (context) async {
     final registry = ExtensionCoordinator();
     registry.register(MathExtension());
@@ -222,7 +222,7 @@ inherit extensions from `parentExtensions` that opt in via
 
 ```dart
 SandboxExtension(
-  platformFactory: () async => Monty(),
+  platformFactory: () async => createPlatformMonty(),
   parentExtensions: registry.extensions,  // Pass parent's extension list
 )
 ```
@@ -237,7 +237,7 @@ The `sandboxBaseDir` parameter enables per-child working directories:
 
 ```dart
 SandboxExtension(
-  platformFactory: () async => Monty(),
+  platformFactory: () async => createPlatformMonty(),
   sandboxBaseDir: '/data',
   parentExtensions: registry.extensions,
 )
@@ -261,7 +261,7 @@ prompt content from `ChildSpawnContext`:
 
 ```dart
 SandboxExtension(
-  platformFactory: () async => Monty(),
+  platformFactory: () async => createPlatformMonty(),
   sandboxBaseDir: '/data',
   systemPromptBuilder: (context) =>
       'You are child ${context.childId}. '
@@ -428,7 +428,7 @@ Future<(MontyBridge, ExtensionCoordinator)> createSession() async {
     ..register(StorageExtension())  // Fresh instance per session
     ..register(MathExtension());
 
-  final bridge = MontyBridge(platform: Monty());
+  final bridge = MontyBridge(platform: createPlatformMonty());
   await registry.attachTo(bridge);
 
   return (bridge, registry);

--- a/docs/tutorials/host-functions-beginner.md
+++ b/docs/tutorials/host-functions-beginner.md
@@ -255,7 +255,7 @@ consistent with `type` to avoid mismatches.
 
 ```dart
 MontyBridge(
-  platform: Monty(),          // Required: MontyPlatform backend
+  platform: createPlatformMonty(), // Required: MontyPlatform backend
   limits: MontyLimits(        // Optional: resource constraints
     timeoutMs: 5000,
     memoryBytes: 10 * 1024 * 1024,

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -31,17 +31,48 @@ await session.dispose();
 
 ## Monty (Low-level)
 
-The `Monty` class provides a simple stateful REPL wrapper from `dart_monty_core`.
+`Monty` from `dart_monty_core` is the low-level execution surface. It has
+three shapes:
 
 ```dart
-final monty = Monty();
-final r = await monty.run('import pathlib; x=1');
-await monty.dispose();
+// One-shot, stateless.
+final result = await Monty.exec('2 + 2');
+
+// Compiled-program holder — re-run with different inputs.
+final program = Monty('x * 2');
+final r1 = await program.run(inputs: {'x': 21});
+final r2 = await program.run(inputs: {'x': 100});
+
+// Stateful REPL — variables, functions, classes persist across calls.
+final repl = MontyRepl();
+await repl.feedRun('x = 42');
+final r3 = await repl.feedRun('x + 1');
+await repl.dispose();
 ```
 
-One-shot execution:
+Each `Monty(code).run(...)` call runs in a fresh interpreter — state from
+earlier calls does not persist. Use `MontyRepl` when you need accumulated
+state.
+
+### Static type checking
+
+`Monty.typeCheck` analyses code without executing it:
+
 ```dart
-final result = await Monty.exec('2 + 2');
+final errors = await Monty.typeCheck('x: int = "not an int"');
+for (final e in errors) {
+  print('${e.path}:${e.line}:${e.column} ${e.code}: ${e.message}');
+}
+```
+
+`prefixCode` lets you declare input or external-function shapes so the
+checker knows their types:
+
+```dart
+final errors = await Monty.typeCheck(
+  'result: str = fetch("https://example.com")',
+  prefixCode: 'def fetch(url: str) -> str: ...',
+);
 ```
 
 ## Host Functions

--- a/docs/user/extensions.md
+++ b/docs/user/extensions.md
@@ -204,7 +204,7 @@ for r in results:
 
 ```dart
 SandboxExtension(
-  platformFactory: () async => MontyFfi(),  // or MontyWasm()
+  platformFactory: () async => createPlatformMonty(),
   parentExtensions: [tmpl, msgBus],  // children inherit these
   maxChildren: 16,       // concurrent child limit
   maxDepth: 3,           // grandchild recursion limit
@@ -225,17 +225,17 @@ final session = MontyRuntime(
     JinjaTemplateExtension(),
     MessageBusExtension(),
     SandboxExtension(
-      platformFactory: () async => MontyFfi(),
+      platformFactory: () async => createPlatformMonty(),
       parentExtensions: [JinjaTemplateExtension()],
     ),
   ],
 );
 
 // All extension functions are now available in Python
-await session.run("help()");  // lists all functions
-await session.run("tmpl_render(template='{{ x }}', context={'x': 1})");
-await session.run("msg_send('ch', 'hello')");
-await session.run("h = sandbox_spawn(code='42')");
+await session.execute("help()").result;  // lists all functions
+await session.execute("tmpl_render(template='{{ x }}', context={'x': 1})").result;
+await session.execute("msg_send('ch', 'hello')").result;
+await session.execute("h = sandbox_spawn(code='42')").result;
 
 await session.dispose();
 ```

--- a/docs/user/repl.md
+++ b/docs/user/repl.md
@@ -3,29 +3,28 @@
 ## Overview
 
 The REPL provides stateful Python execution where variables, functions,
-classes, and closures persist natively across calls. Unlike `MontySession`
-which serializes state to JSON between calls (losing non-serializable
-objects), the REPL maintains a persistent Rust heap — everything
-survives.
+classes, and closures persist natively across calls. The REPL maintains
+a persistent Rust heap — everything survives, including non-serialisable
+objects.
 
 ## Three API Levels
 
 ### 1. MontyRepl — Low-Level
 
-Direct access to `feed()` (run to completion) and
+Direct access to `feedRun()` (run to completion) and
 `feedStart()`/`resume()` (suspend at host function calls).
 
 ```dart
 final repl = MontyRepl();
 
 // Run to completion
-final result = await repl.feed('x = 42');
-final r2 = await repl.feed('x + 1');
+final result = await repl.feedRun('x = 42');
+final r2 = await repl.feedRun('x + 1');
 print(r2.value); // MontyInt(43)
 
 // Functions persist
-await repl.feed('def double(n):\n    return n * 2');
-final r3 = await repl.feed('double(21)');
+await repl.feedRun('def double(n):\n    return n * 2');
+final r3 = await repl.feedRun('double(21)');
 print(r3.value); // MontyInt(42)
 
 await repl.dispose();
@@ -62,20 +61,20 @@ final session = MontyRuntime(
     JinjaTemplateExtension(),
     MessageBusExtension(),
     SandboxExtension(
-      platformFactory: () async => MontyFfi(),
+      platformFactory: () async => createPlatformMonty(),
     ),
   ],
 );
 
 // Python calls tmpl_render() -> real Dart Jinja engine
-final r = await session.run(
+final r = await session.execute(
   "tmpl_render(template='Hello {{ name }}!', context={'name': 'World'})",
-);
+).result;
 print(r.value); // MontyString('Hello World!')
 
 // State persists — x is still 42
-await session.run('x = 42');
-final r2 = await session.run('x + 1');
+await session.execute('x = 42').result;
+final r2 = await session.execute('x + 1').result;
 print(r2.value); // MontyInt(43)
 
 // Event stream for real-time visibility
@@ -166,18 +165,15 @@ The REPL works on both FFI (native) and WASM (browser):
   and message bus extensions. Sandbox support requires multi-session
   Workers (see issue #280)
 
-## Comparison with MontySession
+## Comparison with `Monty` / `Monty.exec`
 
-**MontySession** serializes state to JSON between calls:
+**`Monty(code)` and `Monty.exec`** run in a fresh interpreter every call —
+state from earlier calls does not persist. Use them for one-shot or
+parameterised re-runs of the same program.
 
-- Functions, classes, closures are lost
-- Non-serializable objects are lost
-- State wrapping via code generation (`__restore_state__`/`__persist_state__`)
-
-**MontyRepl** maintains a native Rust heap:
+**`MontyRepl`** maintains a native Rust heap across calls:
 
 - Functions, classes, closures persist
 - All heap objects survive across calls
-- No serialization overhead
 - Continuation detection for REPL UIs
-- Direct feedStart/resume for host function dispatch
+- Direct `feedStart`/`resume` for host function dispatch

--- a/example/example.dart
+++ b/example/example.dart
@@ -3,24 +3,20 @@
 import 'package:dart_monty/dart_monty.dart';
 
 Future<void> main() async {
-  final monty = Monty();
-
   // Run a simple Python expression.
-  final result = await monty.run('2 + 2');
+  final result = await Monty.exec('2 + 2');
   print('Result: ${result.value}'); // 4
 
   // Run with resource limits.
-  final limited = await monty.run(
+  final limited = await Monty.exec(
     'sum(range(100))',
     limits: const MontyLimits(timeoutMs: 5000, memoryBytes: 10 * 1024 * 1024),
   );
   print('Sum: ${limited.value}'); // 4950
 
   // Handle errors.
-  final bad = await monty.run('1 / 0');
+  final bad = await Monty.exec('1 / 0');
   if (bad.isError) {
     print('Error: ${bad.error!.message}');
   }
-
-  monty.dispose();
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -16,7 +16,8 @@ Future<void> main() async {
 
   // Handle errors.
   final bad = await Monty.exec('1 / 0');
-  if (bad.isError) {
-    print('Error: ${bad.error!.message}');
+  final err = bad.error;
+  if (err != null) {
+    print('Error: ${err.message}');
   }
 }

--- a/example/native/bin/type_check_demo.dart
+++ b/example/native/bin/type_check_demo.dart
@@ -37,6 +37,7 @@ Future<void> _check(String code, {String? prefixCode}) async {
   final errors = await Monty.typeCheck(code, prefixCode: prefixCode);
   if (errors.isEmpty) {
     print('  OK — no diagnostics.');
+
     return;
   }
   for (final e in errors) {

--- a/example/native/bin/type_check_demo.dart
+++ b/example/native/bin/type_check_demo.dart
@@ -1,0 +1,45 @@
+// Printing to stdout is expected in an example.
+// ignore_for_file: avoid_print
+/// Static type-checking example — Monty.typeCheck on the FFI backend.
+///
+/// Run:
+///   dart run bin/type_check_demo.dart
+library;
+
+import 'package:dart_monty/dart_monty.dart';
+
+Future<void> main() async {
+  print('── Clean code ──');
+  await _check('x: int = 1\ny: str = "hello"');
+
+  print('\n── Type error ──');
+  await _check('x: int = "not an int"');
+
+  // prefixCode lets you declare types that exist in the runtime
+  // environment but not in the snippet you're checking — e.g. external
+  // functions injected by the host.
+  const fetchStub = 'def fetch(url: str) -> str: return ""';
+
+  print('\n── prefixCode: declare external function shape ──');
+  await _check(
+    'result: str = fetch("https://example.com")',
+    prefixCode: fetchStub,
+  );
+
+  print('\n── prefixCode mismatch: result typed as int instead of str ──');
+  await _check(
+    'result: int = fetch("https://example.com")',
+    prefixCode: fetchStub,
+  );
+}
+
+Future<void> _check(String code, {String? prefixCode}) async {
+  final errors = await Monty.typeCheck(code, prefixCode: prefixCode);
+  if (errors.isEmpty) {
+    print('  OK — no diagnostics.');
+    return;
+  }
+  for (final e in errors) {
+    print('  ${e.path}:${e.line}:${e.column} ${e.code}: ${e.message}');
+  }
+}

--- a/example/native/run.sh
+++ b/example/native/run.sh
@@ -38,3 +38,7 @@ cd "$EXAMPLE"
 dart pub get
 echo ""
 DART_MONTY_LIB_PATH="$LIB_PATH" dart run bin/main.dart
+
+echo ""
+echo "--- Type-check demo ---"
+DART_MONTY_LIB_PATH="$LIB_PATH" dart run bin/type_check_demo.dart

--- a/example/native/run.sh
+++ b/example/native/run.sh
@@ -40,5 +40,7 @@ echo ""
 DART_MONTY_LIB_PATH="$LIB_PATH" dart run bin/main.dart
 
 echo ""
-echo "--- Type-check demo ---"
-DART_MONTY_LIB_PATH="$LIB_PATH" dart run bin/type_check_demo.dart
+echo "--- Type-check demo (platform-agnostic) ---"
+cd "$ROOT"
+dart pub get >/dev/null
+DART_MONTY_LIB_PATH="$LIB_PATH" dart run example/type_check_demo.dart

--- a/example/type_check_demo.dart
+++ b/example/type_check_demo.dart
@@ -1,9 +1,13 @@
 // Printing to stdout is expected in an example.
 // ignore_for_file: avoid_print
-/// Static type-checking example — Monty.typeCheck on the FFI backend.
+/// Static type-checking example — `Monty.typeCheck`.
+///
+/// Works on every backend that ships in dart_monty_core (native FFI,
+/// WASM, dart2js) — the symbol dispatches to the same `monty_type_check`
+/// Rust ABI.
 ///
 /// Run:
-///   dart run bin/type_check_demo.dart
+///   dart run example/type_check_demo.dart
 library;
 
 import 'package:dart_monty/dart_monty.dart';

--- a/example/web/bin/repl_demo.dart
+++ b/example/web/bin/repl_demo.dart
@@ -1,5 +1,9 @@
 // Standalone JS-compiled demo, not a package:test file.
 // ignore_for_file: avoid_print, lines_longer_than_80_chars, avoid_catches_without_on_clauses, cast_nullable_to_non_nullable, invalid_null_aware_operator
+// ignore_for_file: prefer-async-await
+// .then-chains in the JSFunction map below are the established JS-interop
+// idiom across web demos (cf. agent_demo.dart). Rewriting to async/await
+// would diverge from the project pattern.
 /// Interactive REPL Session Demo — MontyRuntime + real plugins in the browser.
 ///
 /// Compiled to JS, exposes window.ReplSessionDemo to HTML.
@@ -34,7 +38,11 @@ external void _jsOnToolCall(JSString jsonPayload);
 // State
 // ---------------------------------------------------------------------------
 
-late MontyRuntime _session;
+MontyRuntime _session = _newSession();
+
+MontyRuntime _newSession() => MontyRuntime(
+  extensions: [JinjaTemplateExtension(), MessageBusExtension()],
+);
 
 // ---------------------------------------------------------------------------
 // API
@@ -44,6 +52,7 @@ late MontyRuntime _session;
 Future<String> _apiRun(String code) async {
   try {
     final result = await _session.execute(code).result;
+
     return jsonEncode(_resultToJson(result));
   } catch (e) {
     return jsonEncode({'ok': false, 'error': e.toString()});
@@ -97,6 +106,7 @@ Future<String> _apiReset() async {
   try {
     await _session.dispose();
     _createSession();
+
     return jsonEncode({'ok': true});
   } catch (e) {
     return jsonEncode({'ok': false, 'error': e.toString()});
@@ -107,14 +117,9 @@ Future<String> _apiReset() async {
 // Session factory
 // ---------------------------------------------------------------------------
 
+// SandboxExtension is FFI-only and cannot be used in a web build.
 void _createSession() {
-  final tmpl = JinjaTemplateExtension();
-  final msgBus = MessageBusExtension();
-
-  // SandboxExtension is FFI-only and cannot be used in a web build.
-  _session = MontyRuntime(
-    extensions: [tmpl, msgBus],
-  );
+  _session = _newSession();
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +135,7 @@ Map<String, dynamic> _resultToJson(MontyResult result) {
       'print_output': result.printOutput,
     };
   }
+
   return {
     'ok': true,
     'value': result.value?.dartValue,
@@ -170,6 +176,7 @@ Map<String, dynamic>? _eventToJson(BridgeEvent event) {
           : event.result,
     };
   }
+
   return null;
 }
 
@@ -177,10 +184,8 @@ Map<String, dynamic>? _eventToJson(BridgeEvent event) {
 // Main
 // ---------------------------------------------------------------------------
 
-Future<void> main() async {
+void main() {
   print('[ReplSessionDemo] Starting...');
-
-  _createSession();
 
   // Expose API to window
   final api = <String, JSFunction>{

--- a/example/web/bin/repl_demo.dart
+++ b/example/web/bin/repl_demo.dart
@@ -122,11 +122,11 @@ void _createSession() {
 // ---------------------------------------------------------------------------
 
 Map<String, dynamic> _resultToJson(MontyResult result) {
-  if (result.isError) {
+  if (!result.ok) {
     return {
       'ok': false,
       'error': result.error?.message ?? 'Unknown error',
-      'excType': result.error?.excType,
+      'excType': result.excType,
       'print_output': result.printOutput,
     };
   }

--- a/lib/dart_monty.dart
+++ b/lib/dart_monty.dart
@@ -4,8 +4,7 @@
 /// import 'package:dart_monty/dart_monty.dart';
 /// import 'package:dart_monty_core/dart_monty_core.dart';
 ///
-/// final monty = Monty();
-/// final result = await monty.exec('2 + 2');
+/// final result = await Monty.exec('2 + 2');
 /// print(result.value); // MontyInt(4)
 /// ```
 library;

--- a/lib/src/bridge/bridge.dart
+++ b/lib/src/bridge/bridge.dart
@@ -14,7 +14,7 @@ import 'package:dart_monty_core/dart_monty_core.dart';
 /// calls to registered [HostFunction] handlers, and emits [BridgeEvent]s.
 ///
 /// ```dart
-/// final bridge = MontyBridge(platform: MontyFfi());
+/// final bridge = MontyBridge(platform: createPlatformMonty());
 /// bridge.registerOs(defaultSandboxOsHandler());
 /// bridge.register(myHostFunction);
 /// final events = bridge.execute('result = my_function()');

--- a/test/integration/monty_reference_behavior_test.dart
+++ b/test/integration/monty_reference_behavior_test.dart
@@ -24,34 +24,31 @@ void main() {
   // ---------------------------------------------------------------------------
 
   group('2a — print output', () {
-    test('raw MontySession captures print() in result.printOutput', () async {
-      // Run print("hello") via dart_monty_core's MontySession directly —
-      // no bridge preamble, no __console_write__ injection, no overriding
-      // print. If MontyResult.printOutput is populated here, Monty captures
-      // prints natively and the bridge's print preamble is adding unnecessary
-      // overhead (and injecting 5 extra lines that distort line numbers).
-      final session = MontySession();
+    test('raw MontyRepl captures print() in result.printOutput', () async {
+      // Confirms Monty captures print() output natively into
+      // MontyResult.printOutput — the dart_monty bridge does not inject any
+      // preamble or override print(); it just surfaces core's printOutput.
+      final session = MontyRepl();
       try {
-        final result = await session.run('print("hello from monty")');
-        // Document what we observe:
+        final result = await session.feedRun('print("hello from monty")');
         expect(
           result.printOutput,
           isNotNull,
           reason:
               'Monty captures print() output natively in '
-              'MontyResult.printOutput without any bridge preamble.',
+              'MontyResult.printOutput.',
         );
         expect(result.printOutput, contains('hello from monty'));
       } finally {
-        session.dispose();
+        await session.dispose();
       }
     });
 
     test(
-      'PlatformBridge also captures print() — consistent with raw session',
+      'MontyRuntime also captures print() — consistent with raw session',
       () async {
-        // If the raw session test above passes, this confirms the bridge
-        // is not introducing a duplicate or conflicting capture path.
+        // The bridge passes printOutput through unchanged; this verifies
+        // it does not lose or duplicate the captured stdout.
         final session = MontyRuntime();
         try {
           final result = await session
@@ -66,26 +63,24 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
-  // 2c. Exception line numbers with bridge preamble
+  // 2c. Exception line numbers
   // ---------------------------------------------------------------------------
 
   group('2c — exception line numbers', () {
     test('NameError on line 1 of user code reports line 1', () async {
-      // PlatformBridge injects a print-override preamble (~5 lines)
-      // before user code, then subtracts _preambleLineCount from exception
-      // line numbers. This test verifies the adjustment is correct.
+      // The bridge injects no preamble; line numbers from core should
+      // come through unchanged.
       final session = MontyRuntime();
       try {
         final result = await session.execute('undefined_variable_xyz').result;
         expect(result.error, isNotNull);
         expect(result.error!.excType, 'NameError');
-        // Line 1 of user code should report as line 1, not line 6
         expect(
           result.error!.lineNumber,
           1,
           reason:
-              'The bridge preamble line count adjustment must correctly map '
-              'exception lines back to user code lines.',
+              'Line 1 of user code must surface as line 1 — the bridge '
+              'must not perturb core line numbers.',
         );
       } finally {
         await session.dispose();
@@ -112,15 +107,15 @@ void main() {
 
   group('2d — last expression capture', () {
     test(
-      'raw MontySession: expression result without captureLastExpression',
+      'raw MontyRepl: expression result without captureLastExpression',
       () async {
         // dart_monty_core's captureLastExpression wraps the last expression as
         // `__r = (expr); __r`. This test checks whether that wrapper is needed,
         // or whether Monty returns the last expression natively.
-        final session = MontySession();
+        final session = MontyRepl();
         try {
           // Run bare expression with NO captureLastExpression wrapping
-          final result = await session.run('1 + 1');
+          final result = await session.feedRun('1 + 1');
           // Document the result:
           expect(
             result.value,
@@ -131,23 +126,23 @@ void main() {
           );
           expect((result.value as MontyInt).value, 2);
         } finally {
-          session.dispose();
+          await session.dispose();
         }
       },
     );
 
-    test('raw MontySession: assignment statement returns MontyNone', () async {
+    test('raw MontyRepl: assignment statement returns MontyNone', () async {
       // Assignments are statements, not expressions — they should return None.
-      final session = MontySession();
+      final session = MontyRepl();
       try {
-        final result = await session.run('x = 42');
+        final result = await session.feedRun('x = 42');
         expect(
           result.value,
           isA<MontyNone>(),
           reason: 'Assignment statement has no return value — MontyNone.',
         );
       } finally {
-        session.dispose();
+        await session.dispose();
       }
     });
   });

--- a/test/integration/monty_reference_behavior_test.dart
+++ b/test/integration/monty_reference_behavior_test.dart
@@ -74,7 +74,7 @@ void main() {
       try {
         final result = await session.execute('undefined_variable_xyz').result;
         expect(result.error, isNotNull);
-        expect(result.error!.excType, 'NameError');
+        expect(result.excType, 'NameError');
         expect(
           result.error!.lineNumber,
           1,

--- a/test/integration/monty_type_check_test.dart
+++ b/test/integration/monty_type_check_test.dart
@@ -1,0 +1,72 @@
+// Integration test for Monty.typeCheck via the FFI backend.
+//
+// Run: dart test --run-skipped --tags=integration -p vm \
+//        test/integration/monty_type_check_test.dart
+//
+// WASM coverage for Monty.typeCheck lives in dart_monty_core's own test
+// suite (the JS bridge + worker round-trip). dart_monty re-exports the
+// symbol unchanged, so we only need to confirm it dispatches correctly
+// through the FFI path.
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Monty.typeCheck', () {
+    test('returns no diagnostics for clean code', () async {
+      final errors = await Monty.typeCheck('x: int = 1\ny: str = "hello"');
+      expect(errors, isEmpty);
+    });
+
+    test('flags type-incompatible assignment', () async {
+      final errors = await Monty.typeCheck('x: int = "not an int"');
+      expect(errors, isNotEmpty);
+      final first = errors.first;
+      expect(first.line, 1);
+      expect(first.code, isNotEmpty);
+      expect(first.message, isNotEmpty);
+    });
+
+    test('prefixCode declarations are visible to the checker', () async {
+      const stub = 'def fetch(url: str) -> str: return ""';
+
+      // Without prefixCode, fetch is unresolved and surfaces a diagnostic.
+      final without = await Monty.typeCheck(
+        'result: str = fetch("https://example.com")',
+      );
+      expect(without, isNotEmpty);
+
+      // With prefixCode, the snippet type-checks cleanly.
+      final withStub = await Monty.typeCheck(
+        'result: str = fetch("https://example.com")',
+        prefixCode: stub,
+      );
+      expect(withStub, isEmpty);
+    });
+
+    test('real type errors surface even when prefixCode is supplied',
+        () async {
+      const stub = 'def fetch(url: str) -> str: return ""';
+      final errors = await Monty.typeCheck(
+        'result: int = fetch("https://example.com")',
+        prefixCode: stub,
+      );
+      expect(errors, isNotEmpty);
+      // Line 2 because prefixCode shifts user code down by one line worth
+      // of the stub — but the diagnostic tracks the user-code position;
+      // confirm the column reflects the assignment, not the stub line.
+      expect(errors.any((e) => e.code.contains('assignment')), isTrue);
+    });
+
+    test('scriptName surfaces in diagnostic path', () async {
+      final errors = await Monty.typeCheck(
+        'x: int = "oops"',
+        scriptName: 'agent.py',
+      );
+      expect(errors, isNotEmpty);
+      expect(errors.first.path, contains('agent.py'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Slims `dart_monty` against the recent `dart_monty_core` API changes
(PRs #55–57, #70, #71). Net of 7 commits, all gates green.

- Migrate the two files that broke against the new core API
  (`Monty(code)` constructor, `MontyRepl.feedRun`, removal of
  `MontySession`).
- Sweep every stale code snippet across docs, tutorials, README, and
  source docstrings so users copy-pasting them get working code.
- Surface `Monty.typeCheck` (#70) via a platform-agnostic demo and an
  FFI integration test — no new dart_monty surface; consumers reach
  the symbol through the existing `dart_monty_core` re-export.
- Adopt `MontyResult.ok` / `MontyResult.excType` (#71) wherever they
  read more naturally (drops a non-null assertion).
- Clear pre-existing dcm warnings in files this branch touched.

## Phase-by-phase

| # | Commit | What |
|---|---|---|
| 1 | `2a377d4` | Migrate `example/example.dart` and the reference-behavior test to the new API. Drop stale comments about a bridge-side print preamble that dart_monty no longer has. |
| 2 | `0fdda82` | Doc snippet sweep: 13 files (`docs/`, `README.md`, `AGENTS.md`, two source docstrings). Replaces `repl.feed` → `feedRun`, `Monty()` → `createPlatformMonty()`, `session.run(...)` → `session.execute(...).result`. Drops the obsolete "Comparison with MontySession" section in `docs/user/repl.md`. |
| 3 | `6c00f02` + `db3cb45` | `Monty.typeCheck` demo at top-level `example/type_check_demo.dart` (four-part: clean, type error, prefixCode worked example, prefixCode mismatch) + FFI integration test. The demo is platform-agnostic — `Monty.typeCheck` dispatches to the same `monty_type_check` Rust ABI on FFI, WASM, and dart2js. WASM coverage for the symbol is owned by `dart_monty_core`'s own test suite; dart_monty re-exports it unchanged. |
| 4 | `b55691d` | dcm cleanups in files touched by Phase 1+3 (non-null assertion + newline-before-return). |
| 5 | `afd0f02` | Adopt `MontyResult.ok` and `MontyResult.excType` (core #71) where they read more naturally. |
| 6 | `219398f` | Pre-existing dcm cleanup in `repl_demo.dart` (touched in Phase 5): replace `late` with a top-level initializer + factory, blank lines before return, drop redundant `async` on a fully-sync `main()`. |

## Slim-down decisions

- **No `MontyRuntime.typeCheck` passthrough.** Users call
  `Monty.typeCheck` directly via the existing `dart_monty_core`
  re-export. Fewer surfaces in dart_monty.
- **No web typeCheck demo.** The top-level demo is platform-agnostic;
  core already exercises the WASM path in its own test suite.
- **No duplicated WASM integration test.** Trust core's coverage of
  the JS bridge + worker round-trip.
- **No backwards-compatibility shims.** Clean break, per project
  policy.

## Deferred — `vfs_demo.dart` MountDir adoption

Phase 4 was scoped to migrate `example/web/bin/vfs_demo.dart` from
dart_monty's `fsHandler(MemoryFileSystem())` to core's
`memoryMountedOsHandler` + `MountDir`. The migration is **blocked**:
the canned Python examples in `example/web/web/vfs.html` (the very
first sample, "hello") call `Path('/sandbox/data').mkdir(parents=True)`,
and core's `memoryMountedOsHandler` does not implement `mkdir`,
`rmdir`, or `rename`. Migrating today would make the demo fail on
the first example a user opens.

Filed upstream: runyaga/dart_monty_core#76. Once those three ops
land in core, vfs_demo can migrate cleanly and dart_monty's
`lib/src/os_call/fs_handlers.dart` becomes a deletion candidate.

## Test plan

- [x] `dart analyze` — 0 issues
- [x] `dart test` — 463 / 463 unit tests pass
- [x] `dart test --run-skipped --tags=integration -p vm test/integration/monty_type_check_test.dart` — 5 / 5 pass
- [x] `dart test --run-skipped --tags=integration -p vm test/integration/monty_reference_behavior_test.dart` — passes locally (FFI lib resolved via pub cache)
- [x] `dcm analyze .` — clean on every file this branch touches; repo-wide totals improve from 36 + 40 → 33 + 33
- [x] `dart compile js --packages=.dart_tool/package_config.json example/web/bin/repl_demo.dart` — compiles cleanly (JS interop intact after Phase 6 edits)
- [x] `dart run example/type_check_demo.dart` — produces expected diagnostics
- [ ] Full `bash tool/gate.sh` — not yet run on a clean checkout
- [ ] WASM gate (`bash tool/test_wasm.sh`) — repo's WASM tooling targets `test/wasm/` which doesn't exist; not exercised here