### PR TITLE
fix: preserve typed MontyValue through bridge + dataclass demo + bug triage docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,100 @@ Run these checks after every code change:
 3. `dart test` — must pass all tests
 4. Maintain 90%+ line coverage (enforced by CI and pre-push hooks)
 
+## Bug Triage
+
+Before filing a bug against `dart_monty`, walk it down the stack to
+locate the layer where it actually lives. Filing at the wrong layer
+costs time and obscures real upstream issues.
+
+### The stack
+
+```
+dart_monty (this repo)               <- bridge, runtime, extensions, host fns
+    |
+dart_monty_core (Dart wrapper)       <- Monty / MontyRepl / MontyResult, JSON
+    |                                   value envelopes (__type: dataclass, …)
+dart_monty_core (Rust shim)          <- native/src/convert.rs etc. — JSON ↔
+    |                                   typed MontyObject conversion
+pydantic/monty (Rust upstream)       <- the interpreter itself, MontyObject
+                                        enum, externals, REPL
+```
+
+A bug surfaces in `dart_monty`. Walk **down**, layer by layer, until
+the bug stops reproducing. The lowest layer where it still reproduces
+is where to file.
+
+### Triage workflow
+
+1. **Slim the reproducer.** Strip the failing case to the smallest
+   self-contained Dart program that uses only `package:dart_monty`. No
+   plugins, no extensions, no HTTP, no HostContext gymnastics — just
+   the suspect code path. Save it as `/tmp/reproducer.dart`.
+
+2. **Reproduce against `dart_monty_core` directly.** Skip
+   `dart_monty`'s bridge by replacing `MontyRuntime`/`HostFunction`
+   with `Monty(code).run(externalFunctions: ...)` or `MontyRepl`. Add
+   only `package:dart_monty_core/dart_monty_core.dart` to the
+   reproducer:
+
+   ```dart
+   import 'package:dart_monty_core/dart_monty_core.dart';
+
+   Future<void> main() async {
+     // … the same logic, but through Monty/MontyRepl, not MontyRuntime
+   }
+   ```
+
+   - **Reproduces here too** → bug is at the `dart_monty_core` Dart
+     layer or below. Continue to step 3.
+   - **Does not reproduce** → bug is in `dart_monty`'s bridge / runtime
+     / extensions. File on **this** repo with the slim reproducer.
+
+3. **Reproduce against the Rust shim directly (`dart_monty_core` Rust
+   side).** If the bug involves JSON envelope handling
+   (`__type: dataclass`, `__type: bytes`, etc.), inspect the symmetric
+   pair in `dart_monty_core/native/src/convert.rs` —
+   `monty_object_to_json` and `json_to_monty_object`. Diff the two: if
+   one path normalises a field the other path doesn't, you've found
+   the asymmetry. A failing fixture at the shim layer is enough; you
+   don't have to write Rust to triage.
+
+   - **Reproduces with symmetric envelopes** → continue to step 4.
+   - **Asymmetry in `convert.rs`** → file on **`dart_monty_core`**
+     against the Rust shim.
+
+4. **Reproduce against `pydantic/monty` upstream.** This is the highest
+   bar; do it when steps 1–3 didn't localise the bug. A small
+   Rust binary that pulls in `monty = { git = ..., tag = "v0.0.17" }`
+   and exercises the typed `MontyObject` API directly tells you
+   whether upstream is the source. If the bug only shows when a JSON
+   envelope is involved, it's almost never an upstream-Rust bug —
+   pydantic/monty doesn't see the JSON, only the typed `MontyObject`
+   variants.
+
+   - **Reproduces against pydantic/monty** → file upstream at
+     <https://github.com/pydantic/monty>.
+   - **Does not reproduce** → the bug is in `dart_monty_core`'s shim
+     or wrapper. File on `dart_monty_core` with the layered evidence.
+
+### What goes in the bug report
+
+Whichever layer you file at:
+
+- the slim reproducer (one file, no external services, deterministic);
+- the layers you tried and which ones reproduced or didn't (show your
+  work — saves the next person 30 minutes);
+- the file:line trace of the relevant code path on each layer
+  (`grep -n` output is fine).
+
+### Why this matters
+
+Filing a "dart_monty bug" that's actually a `dart_monty_core` Rust
+shim asymmetry routes the wrong people to the wrong code. Filing a
+"dart_monty_core bug" that's actually upstream pydantic/monty
+behaviour wastes a wrap-side fix attempt that won't hold. The triage
+walk costs 5–15 minutes; misrouting costs hours per side.
+
 ## CI
 
 GitHub Actions run on every push and PR to `main`. Docs-only changes

--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ Future<void> main() async {
 }
 ```
 
+## Examples
+
+Runnable end-to-end demos, all platform-agnostic (FFI on the VM, WASM
+in Chrome — `Monty` dispatches to the same Rust ABI on every backend):
+
+| File | What it shows |
+|---|---|
+| [`example/example.dart`](example/example.dart) | Minimal `Monty.exec` one-shots, including error handling. |
+| [`example/type_check_demo.dart`](example/type_check_demo.dart) | `Monty.typeCheck` for static type analysis — clean code, type errors, `prefixCode` for declaring external function shapes. |
+| [`example/dataclass_demo.dart`](example/dataclass_demo.dart) | Round-trip Python `@dataclass` values into typed Dart objects via `MontyDataclass.hydrate(factory)` and a caller-side registry. |
+
+Run any of them with `dart run example/<file>.dart` from the repo root.
+For the native and web runners (with built Rust library and a COOP/COEP
+server), see `example/native/run.sh` and `example/web/run.sh`.
+
 ## Documentation
 
 - [**Installation**](docs/user/install.md) — Add to your project

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ in Chrome — `Monty` dispatches to the same Rust ABI on every backend):
 |---|---|
 | [`example/example.dart`](example/example.dart) | Minimal `Monty.exec` one-shots, including error handling. |
 | [`example/type_check_demo.dart`](example/type_check_demo.dart) | `Monty.typeCheck` for static type analysis — clean code, type errors, `prefixCode` for declaring external function shapes. |
-| [`example/dataclass_demo.dart`](example/dataclass_demo.dart) | Round-trip Python `@dataclass` values into typed Dart objects via `MontyDataclass.hydrate(factory)` and a caller-side registry. |
+| [`example/dataclass_demo.dart`](example/dataclass_demo.dart) | Stateful dataclass round-trip across `MontyRuntime.execute` calls — produce, attribute-access, return, and re-bind a `@dataclass`, hydrating into a typed Dart `User` on the way back. |
 
 Run any of them with `dart run example/<file>.dart` from the repo root.
 For the native and web runners (with built Rust library and a COOP/COEP

--- a/example/dataclass_demo.dart
+++ b/example/dataclass_demo.dart
@@ -1,0 +1,156 @@
+// Printing to stdout is expected in an example.
+// ignore_for_file: avoid_print
+// User/Order classes appear first for readability; the MontyCallback
+// signature is `Future<Object?>` per the typedef, so the lambdas can't
+// be sync.
+// ignore_for_file: prefer-match-file-name, avoid-unnecessary-futures
+/// Dataclass hydration — Python `@dataclass` values returned through
+/// dart_monty round-trip into typed Dart objects via
+/// `MontyDataclass.hydrate(factory)`.
+///
+/// Works on every backend dart_monty_core ships (native FFI, WASM,
+/// dart2js) — the dataclass envelope is platform-agnostic.
+///
+/// This demo uses `Monty.exec` with `externalFunctions:` because the
+/// `MontyRuntime` + `HostFunction` bridge path currently coerces the
+/// dataclass envelope to `MontyDict` on the way back (see issue
+/// referenced in the README). When that lands, this demo will be
+/// expanded with a bridge-side variant.
+///
+/// Run:
+///   dart run example/dataclass_demo.dart
+library;
+
+import 'package:dart_monty/dart_monty.dart';
+
+// ── User-defined Dart classes the demo hydrates into. ───────────────────────
+
+class User {
+  const User({required this.name, required this.age});
+
+  factory User.fromAttrs(Map<String, Object?> a) =>
+      User(name: a['name']! as String, age: a['age']! as int);
+
+  final String name;
+  final int age;
+
+  @override
+  String toString() => 'User(name=$name, age=$age)';
+}
+
+class Order {
+  const Order({required this.id, required this.total});
+
+  factory Order.fromAttrs(Map<String, Object?> a) =>
+      Order(id: a['id']! as int, total: (a['total']! as num).toDouble());
+
+  final int id;
+  final double total;
+
+  @override
+  String toString() => 'Order(id=$id, total=$total)';
+}
+
+// ── Helper: build the dataclass envelope returned from a Dart callback. ─────
+
+Map<String, Object?> _dataclass({
+  required String name,
+  required int typeId,
+  required Map<String, Object?> attrs,
+}) => {
+  '__type': 'dataclass',
+  'name': name,
+  'type_id': typeId,
+  'field_names': attrs.keys.toList(),
+  'attrs': attrs,
+  'frozen': false,
+};
+
+Future<void> main() async {
+  await _readingFields();
+  await _hydrateOne();
+  await _hydrateRegistry();
+}
+
+// ── 1. Read fields directly off MontyDataclass. ─────────────────────────────
+Future<void> _readingFields() async {
+  print('── reading fields ──');
+
+  final r = await Monty.exec(
+    'make_user("alice", 30)',
+    externalFunctions: {
+      'make_user': (args) async => _dataclass(
+        name: 'User',
+        typeId: 1,
+        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
+      ),
+    },
+  );
+
+  final dc = r.value as MontyDataclass;
+  print('  name:      ${dc.name}');                // User
+  print('  fields:    ${dc.fieldNames}');          // [name, age]
+  print('  frozen:    ${dc.frozen}');              // false
+  print('  dartAttrs: ${dc.dartAttrs}');           // {name: alice, age: 30}
+}
+
+// ── 2. Hydrate into a user-supplied Dart class via a factory. ───────────────
+Future<void> _hydrateOne() async {
+  print('\n── hydrate (one type) ──');
+
+  final r = await Monty.exec(
+    'make_user("bob", 42)',
+    externalFunctions: {
+      'make_user': (args) async => _dataclass(
+        name: 'User',
+        typeId: 1,
+        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
+      ),
+    },
+  );
+
+  final user = (r.value as MontyDataclass).hydrate(User.fromAttrs);
+  print('  $user');                                // User(name=bob, age=42)
+}
+
+// ── 3. Caller-side registry dispatching multiple dataclass types. ───────────
+Future<void> _hydrateRegistry() async {
+  print('\n── hydrate (registry) ──');
+
+  final factories = <String, Object Function(Map<String, Object?>)>{
+    'User': User.fromAttrs,
+    'Order': Order.fromAttrs,
+  };
+
+  Object? hydrate(MontyValue value) {
+    if (value is! MontyDataclass) return value;
+    final factory = factories[value.name];
+
+    return factory == null ? value : factory(value.dartAttrs);
+  }
+
+  final externalFunctions = <String, MontyCallback>{
+    'make_user': (_) async => _dataclass(
+      name: 'User',
+      typeId: 1,
+      attrs: {'name': 'carol', 'age': 7},
+    ),
+    'make_order': (_) async => _dataclass(
+      name: 'Order',
+      typeId: 2,
+      attrs: {'id': 99, 'total': 12.5},
+    ),
+  };
+
+  final ru = await Monty.exec(
+    'make_user()',
+    externalFunctions: externalFunctions,
+  );
+  final ro = await Monty.exec(
+    'make_order()',
+    externalFunctions: externalFunctions,
+  );
+
+  print('  ${hydrate(ru.value)}'); // User(name=carol, age=7)
+  print('  ${hydrate(ro.value)}'); // Order(id=99, total=12.5)
+}

--- a/example/dataclass_demo.dart
+++ b/example/dataclass_demo.dart
@@ -1,27 +1,22 @@
 // Printing to stdout is expected in an example.
 // ignore_for_file: avoid_print
-// User/Order classes appear first for readability; the MontyCallback
-// signature is `Future<Object?>` per the typedef, so the lambdas can't
+// User/Order classes lead the file for readability; MontyCallback's
+// signature is `Future<Object?>` per the typedef so the lambdas can't
 // be sync.
 // ignore_for_file: prefer-match-file-name, avoid-unnecessary-futures
-/// Dataclass hydration — Python `@dataclass` values returned through
-/// dart_monty round-trip into typed Dart objects via
-/// `MontyDataclass.hydrate(factory)`.
+/// Dataclass hydration through `MontyRuntime` — Python `@dataclass`
+/// values returned from a registered `HostFunction` round-trip into
+/// typed Dart objects via `MontyDataclass.hydrate(factory)`.
 ///
 /// Works on every backend dart_monty_core ships (native FFI, WASM,
-/// dart2js) — the dataclass envelope is platform-agnostic.
-///
-/// This demo uses `Monty.exec` with `externalFunctions:` because the
-/// `MontyRuntime` + `HostFunction` bridge path currently coerces the
-/// dataclass envelope to `MontyDict` on the way back (see issue
-/// referenced in the README). When that lands, this demo will be
-/// expanded with a bridge-side variant.
+/// dart2js) — the bridge surface is platform-agnostic.
 ///
 /// Run:
 ///   dart run example/dataclass_demo.dart
 library;
 
 import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
 
 // ── User-defined Dart classes the demo hydrates into. ───────────────────────
 
@@ -51,7 +46,7 @@ class Order {
   String toString() => 'Order(id=$id, total=$total)';
 }
 
-// ── Helper: build the dataclass envelope returned from a Dart callback. ─────
+// ── Helper: build the dataclass envelope returned from a HostFunction. ──────
 
 Map<String, Object?> _dataclass({
   required String name,
@@ -67,55 +62,52 @@ Map<String, Object?> _dataclass({
 };
 
 Future<void> main() async {
-  await _readingFields();
-  await _hydrateOne();
+  await _bridgeRoundTrip();
   await _hydrateRegistry();
 }
 
-// ── 1. Read fields directly off MontyDataclass. ─────────────────────────────
-Future<void> _readingFields() async {
-  print('── reading fields ──');
+// ── 1. HostFunction returns a dataclass envelope; MontyRuntime preserves
+//      the typed MontyDataclass through to MontyResult.value.
+Future<void> _bridgeRoundTrip() async {
+  print('── bridge round-trip ──');
 
-  final r = await Monty.exec(
-    'make_user("alice", 30)',
-    externalFunctions: {
-      'make_user': (args) async => _dataclass(
-        name: 'User',
-        typeId: 1,
-        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
+  final runtime = MontyRuntime()
+    ..register(
+      HostFunction(
+        schema: const HostFunctionSchema(
+          name: 'make_user',
+          description: 'Construct a User dataclass.',
+          params: [
+            HostParam(name: 'name', type: HostParamType.string),
+            HostParam(name: 'age', type: HostParamType.integer),
+          ],
+        ),
+        handler: (args, _) async => _dataclass(
+          name: 'User',
+          typeId: 1,
+          attrs: {'name': args['name'], 'age': args['age']},
+        ),
       ),
-    },
-  );
+    );
 
-  final dc = r.value as MontyDataclass;
-  print('  name:      ${dc.name}');                // User
-  print('  fields:    ${dc.fieldNames}');          // [name, age]
-  print('  frozen:    ${dc.frozen}');              // false
-  print('  dartAttrs: ${dc.dartAttrs}');           // {name: alice, age: 30}
+  final result = await runtime.execute(
+    'make_user(name="alice", age=30)',
+  ).result;
+  final dc = result.value as MontyDataclass;
+
+  print('  type:     ${dc.name}');                  // User
+  print('  fields:   ${dc.fieldNames}');            // [name, age]
+  print('  attrs:    ${dc.dartAttrs}');             // {name: alice, age: 30}
+
+  final user = dc.hydrate(User.fromAttrs);
+  print('  hydrated: $user');                       // User(name=alice, age=30)
+
+  await runtime.dispose();
 }
 
-// ── 2. Hydrate into a user-supplied Dart class via a factory. ───────────────
-Future<void> _hydrateOne() async {
-  print('\n── hydrate (one type) ──');
-
-  final r = await Monty.exec(
-    'make_user("bob", 42)',
-    externalFunctions: {
-      'make_user': (args) async => _dataclass(
-        name: 'User',
-        typeId: 1,
-        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
-      ),
-    },
-  );
-
-  final user = (r.value as MontyDataclass).hydrate(User.fromAttrs);
-  print('  $user');                                // User(name=bob, age=42)
-}
-
-// ── 3. Caller-side registry dispatching multiple dataclass types. ───────────
+// ── 2. Registry pattern dispatching multiple dataclass types by name. ───────
 Future<void> _hydrateRegistry() async {
-  print('\n── hydrate (registry) ──');
+  print('\n── registry dispatch ──');
 
   final factories = <String, Object Function(Map<String, Object?>)>{
     'User': User.fromAttrs,
@@ -129,28 +121,39 @@ Future<void> _hydrateRegistry() async {
     return factory == null ? value : factory(value.dartAttrs);
   }
 
-  final externalFunctions = <String, MontyCallback>{
-    'make_user': (_) async => _dataclass(
-      name: 'User',
-      typeId: 1,
-      attrs: {'name': 'carol', 'age': 7},
-    ),
-    'make_order': (_) async => _dataclass(
-      name: 'Order',
-      typeId: 2,
-      attrs: {'id': 99, 'total': 12.5},
-    ),
-  };
+  final runtime = MontyRuntime()
+    ..register(
+      HostFunction(
+        schema: const HostFunctionSchema(
+          name: 'make_user',
+          description: 'Construct a User.',
+        ),
+        handler: (_, _) async => _dataclass(
+          name: 'User',
+          typeId: 1,
+          attrs: {'name': 'carol', 'age': 7},
+        ),
+      ),
+    )
+    ..register(
+      HostFunction(
+        schema: const HostFunctionSchema(
+          name: 'make_order',
+          description: 'Construct an Order.',
+        ),
+        handler: (_, _) async => _dataclass(
+          name: 'Order',
+          typeId: 2,
+          attrs: {'id': 99, 'total': 12.5},
+        ),
+      ),
+    );
 
-  final ru = await Monty.exec(
-    'make_user()',
-    externalFunctions: externalFunctions,
-  );
-  final ro = await Monty.exec(
-    'make_order()',
-    externalFunctions: externalFunctions,
-  );
+  final ru = await runtime.execute('make_user()').result;
+  final ro = await runtime.execute('make_order()').result;
 
   print('  ${hydrate(ru.value)}'); // User(name=carol, age=7)
   print('  ${hydrate(ro.value)}'); // Order(id=99, total=12.5)
+
+  await runtime.dispose();
 }

--- a/example/dataclass_demo.dart
+++ b/example/dataclass_demo.dart
@@ -1,15 +1,22 @@
 // Printing to stdout is expected in an example.
 // ignore_for_file: avoid_print
-// User/Order classes lead the file for readability; MontyCallback's
-// signature is `Future<Object?>` per the typedef so the lambdas can't
-// be sync.
+// User leads the file for readability; MontyCallback's signature is
+// `Future<Object?>` per the typedef so the lambda can't be sync.
 // ignore_for_file: prefer-match-file-name, avoid-unnecessary-futures
-/// Dataclass hydration through `MontyRuntime` — Python `@dataclass`
-/// values returned from a registered `HostFunction` round-trip into
-/// typed Dart objects via `MontyDataclass.hydrate(factory)`.
+/// Stateful dataclass round-trip through `MontyRuntime`.
+///
+/// `MontyRuntime` keeps Python state across `execute()` calls, so a
+/// dataclass produced by one call remains a live Python object on the
+/// next call. The bridge round-trip preserves the typed
+/// `MontyDataclass` so the Dart side can hydrate it into a user class.
+///
+/// Core's `dart_monty_core/example/10_dataclasses.dart` covers the
+/// per-call hydration mechanics with `Monty(code).run`. This demo
+/// shows the part `MontyRuntime` adds: durable state across calls,
+/// observable through ordinary Python attribute access in user code.
 ///
 /// Works on every backend dart_monty_core ships (native FFI, WASM,
-/// dart2js) — the bridge surface is platform-agnostic.
+/// dart2js).
 ///
 /// Run:
 ///   dart run example/dataclass_demo.dart
@@ -17,8 +24,6 @@ library;
 
 import 'package:dart_monty/dart_monty.dart';
 import 'package:dart_monty/dart_monty_bridge.dart';
-
-// ── User-defined Dart classes the demo hydrates into. ───────────────────────
 
 class User {
   const User({required this.name, required this.age});
@@ -33,44 +38,17 @@ class User {
   String toString() => 'User(name=$name, age=$age)';
 }
 
-class Order {
-  const Order({required this.id, required this.total});
-
-  factory Order.fromAttrs(Map<String, Object?> a) =>
-      Order(id: a['id']! as int, total: (a['total']! as num).toDouble());
-
-  final int id;
-  final double total;
-
-  @override
-  String toString() => 'Order(id=$id, total=$total)';
-}
-
-// ── Helper: build the dataclass envelope returned from a HostFunction. ──────
-
-Map<String, Object?> _dataclass({
-  required String name,
-  required int typeId,
-  required Map<String, Object?> attrs,
-}) => {
-  '__type': 'dataclass',
-  'name': name,
-  'type_id': typeId,
-  'field_names': attrs.keys.toList(),
-  'attrs': attrs,
-  'frozen': false,
-};
+Map<String, Object?> _userEnvelope({required String name, required int age}) =>
+    {
+      '__type': 'dataclass',
+      'name': 'User',
+      'type_id': 1,
+      'field_names': ['name', 'age'],
+      'attrs': {'name': name, 'age': age},
+      'frozen': false,
+    };
 
 Future<void> main() async {
-  await _bridgeRoundTrip();
-  await _hydrateRegistry();
-}
-
-// ── 1. HostFunction returns a dataclass envelope; MontyRuntime preserves
-//      the typed MontyDataclass through to MontyResult.value.
-Future<void> _bridgeRoundTrip() async {
-  print('── bridge round-trip ──');
-
   final runtime = MontyRuntime()
     ..register(
       HostFunction(
@@ -82,78 +60,41 @@ Future<void> _bridgeRoundTrip() async {
             HostParam(name: 'age', type: HostParamType.integer),
           ],
         ),
-        handler: (args, _) async => _dataclass(
-          name: 'User',
-          typeId: 1,
-          attrs: {'name': args['name'], 'age': args['age']},
+        handler: (args, _) async => _userEnvelope(
+          name: args['name']! as String,
+          age: args['age']! as int,
         ),
       ),
     );
 
-  final result = await runtime.execute(
-    'make_user(name="alice", age=30)',
-  ).result;
-  final dc = result.value as MontyDataclass;
+  // 1. Construct and bind the dataclass in Python state. The assignment
+  //    has no return value, but `user` now lives in the runtime's heap.
+  await runtime.execute('user = make_user(name="alice", age=30)').result;
+  print('── 1. user = make_user(...) ──');
 
-  print('  type:     ${dc.name}');                  // User
-  print('  fields:   ${dc.fieldNames}');            // [name, age]
-  print('  attrs:    ${dc.dartAttrs}');             // {name: alice, age: 30}
+  // 2. Access an attribute on a *later* execute call. This only works
+  //    because `user` survived as a real Python object — not a serialized
+  //    envelope rebuilt from JSON each call.
+  final nameResult = await runtime.execute('user.name').result;
+  print('── 2. user.name ──');
+  print('   value: ${nameResult.value.dartValue}'); // alice
 
-  final user = dc.hydrate(User.fromAttrs);
-  print('  hydrated: $user');                       // User(name=alice, age=30)
+  // 3. Return the whole dataclass. The bridge preserves the typed
+  //    MontyDataclass through to the result so the host can hydrate.
+  final fullResult = await runtime.execute('user').result;
+  final dc = fullResult.value as MontyDataclass;
+  print('── 3. user ──');
+  // Expected: typed = MontyDataclass, hydrated = User(name=alice, age=30)
+  print('   typed:    ${dc.runtimeType}');
+  print('   hydrated: ${dc.hydrate(User.fromAttrs)}');
 
-  await runtime.dispose();
-}
-
-// ── 2. Registry pattern dispatching multiple dataclass types by name. ───────
-Future<void> _hydrateRegistry() async {
-  print('\n── registry dispatch ──');
-
-  final factories = <String, Object Function(Map<String, Object?>)>{
-    'User': User.fromAttrs,
-    'Order': Order.fromAttrs,
-  };
-
-  Object? hydrate(MontyValue value) {
-    if (value is! MontyDataclass) return value;
-    final factory = factories[value.name];
-
-    return factory == null ? value : factory(value.dartAttrs);
-  }
-
-  final runtime = MontyRuntime()
-    ..register(
-      HostFunction(
-        schema: const HostFunctionSchema(
-          name: 'make_user',
-          description: 'Construct a User.',
-        ),
-        handler: (_, _) async => _dataclass(
-          name: 'User',
-          typeId: 1,
-          attrs: {'name': 'carol', 'age': 7},
-        ),
-      ),
-    )
-    ..register(
-      HostFunction(
-        schema: const HostFunctionSchema(
-          name: 'make_order',
-          description: 'Construct an Order.',
-        ),
-        handler: (_, _) async => _dataclass(
-          name: 'Order',
-          typeId: 2,
-          attrs: {'id': 99, 'total': 12.5},
-        ),
-      ),
-    );
-
-  final ru = await runtime.execute('make_user()').result;
-  final ro = await runtime.execute('make_order()').result;
-
-  print('  ${hydrate(ru.value)}'); // User(name=carol, age=7)
-  print('  ${hydrate(ro.value)}'); // Order(id=99, total=12.5)
+  // 4. Replace the binding and confirm subsequent reads see the new one.
+  await runtime.execute('user = make_user(name="bob", age=42)').result;
+  final replaced = await runtime.execute('user').result;
+  final replacedDc = replaced.value as MontyDataclass;
+  print('── 4. after re-binding ──');
+  // Expected: User(name=bob, age=42)
+  print('   hydrated: ${replacedDc.hydrate(User.fromAttrs)}');
 
   await runtime.dispose();
 }

--- a/lib/src/bridge/event.dart
+++ b/lib/src/bridge/event.dart
@@ -31,6 +31,7 @@ class BridgeRunFinished extends BridgeEvent {
     required this.threadId,
     required this.runId,
     this.value,
+    this.montyValue,
     this.printOutput,
   });
 
@@ -40,8 +41,17 @@ class BridgeRunFinished extends BridgeEvent {
   /// Run identifier.
   final String runId;
 
-  /// The Python return value (when execution completed successfully).
+  /// The Python return value as a plain Dart value (collections
+  /// recursively unwrapped). Loses `__type` envelopes — a Python
+  /// dataclass returns as a `Map<String, Object?>` here. Suitable for
+  /// telemetry and UI display.
   final Object? value;
+
+  /// The Python return value as a typed [MontyValue], preserving
+  /// `__type` envelopes (e.g. `MontyDataclass`, `MontyNamedTuple`).
+  /// Use this when downstream code needs to distinguish typed values
+  /// from plain dicts.
+  final MontyValue? montyValue;
 
   /// Captured print output (when available).
   final String? printOutput;

--- a/lib/src/bridge/platform.dart
+++ b/lib/src/bridge/platform.dart
@@ -57,6 +57,7 @@ void _emitComplete(
         threadId: threadId,
         runId: runId,
         value: complete.result.value.dartValue,
+        montyValue: complete.result.value,
         printOutput: complete.result.printOutput,
       ),
     );

--- a/lib/src/runtime/runtime_state.dart
+++ b/lib/src/runtime/runtime_state.dart
@@ -54,8 +54,11 @@ MontyResult extractBridgeResult(
 ) {
   for (final event in events.reversed) {
     if (event is BridgeRunFinished) {
+      // Prefer the typed MontyValue when the bridge attached one — falling
+      // back to fromDart loses __type envelopes (dataclass, namedtuple, …)
+      // because event.value is the dartValue, a plain Dart shape.
       return MontyResult(
-        value: MontyValue.fromDart(event.value),
+        value: event.montyValue ?? MontyValue.fromDart(event.value),
         usage: _zeroUsage,
         printOutput: event.printOutput,
       );

--- a/test/src/bridge/monty_runtime_state_test.dart
+++ b/test/src/bridge/monty_runtime_state_test.dart
@@ -127,6 +127,47 @@ void main() {
       expect(result.value.dartValue, 99);
     });
 
+    test('preserves typed MontyValue (regression for #384)', () {
+      // event.value is the dartValue (a Map for MontyDataclass) which
+      // would normally re-parse as MontyDict via fromDart. The
+      // montyValue field carries the typed value through losslessly.
+      const dataclass = MontyDataclass(
+        name: 'User',
+        typeId: 1,
+        fieldNames: ['name', 'age'],
+        attrs: {
+          'name': MontyString('alice'),
+          'age': MontyInt(30),
+        },
+      );
+      final events = <BridgeEvent>[
+        BridgeRunFinished(
+          threadId: 't',
+          runId: 'r',
+          value: dataclass.dartValue,
+          montyValue: dataclass,
+        ),
+      ];
+      final result = extractBridgeResult(events, 0);
+      expect(result.value, isA<MontyDataclass>());
+      expect((result.value as MontyDataclass).name, 'User');
+    });
+
+    test('falls back to fromDart when montyValue absent', () {
+      // External bridge implementations that don't set montyValue
+      // still get a MontyDict from a Map event.value — backwards
+      // compatible behaviour.
+      final events = <BridgeEvent>[
+        const BridgeRunFinished(
+          threadId: 't',
+          runId: 'r',
+          value: {'k': 1},
+        ),
+      ];
+      final result = extractBridgeResult(events, 0);
+      expect(result.value, isA<MontyDict>());
+    });
+
     test('preserves printOutput from BridgeRunFinished', () {
       final events = <BridgeEvent>[
         const BridgeRunFinished(


### PR DESCRIPTION
Closes #384.

## Summary

Three intertwined additions, all motivated by the dataclass slim-down
investigation:

1. **Fix #384** — `MontyRuntime` no longer coerces typed `MontyValue`
   subclasses (`MontyDataclass`, `MontyNamedTuple`, `MontyBytes`, …) to
   `MontyDict` on the way back. Adds `montyValue: MontyValue?` to
   `BridgeRunFinished`; `extractBridgeResult` prefers it.
2. **`example/dataclass_demo.dart`** — focused on state persistence
   across `MontyRuntime.execute` calls (the part `Monty.run` cannot do).
   Deliberately distinct from `dart_monty_core/example/10_dataclasses.dart`,
   which already covers per-call hydration mechanics.
3. **`CONTRIBUTING.md`** — Bug Triage section codifying the layered
   triage discipline (`dart_monty` → `dart_monty_core` Dart → Rust shim
   → upstream `pydantic/monty`).

## Why the demo isn't a clone of core's

`dart_monty_core/example/10_dataclasses.dart` already shows
read-fields / hydrate-one / registry-dispatch via
`Monty(code).run(externalFunctions: ...)`. A second demo with the same
shape but a different import would be redundant.

The dart_monty demo runs four sequential `execute()` calls on **one**
runtime to show what `MontyRuntime` adds — durable state across calls
that user code can observe through ordinary Python attribute access:

```text
1. user = make_user(name="alice", age=30)   # bind
2. user.name                                # attribute access — survives
3. user                                     # return whole dataclass; hydrate
4. user = make_user(name="bob", age=42)     # re-bind
```

Step 2 specifically demonstrates `user` survived as a real Python
object, not a JSON envelope rebuilt per call. Step 3 demonstrates the
bridge round-trip preserving the typed `MontyDataclass` — the part
fixed in commit 2 of this PR.

## The bug (commit 2)

Before this PR:

```dart
// Monty.run + externalFunctions: returns MontyDataclass ✅
// MontyRuntime + HostFunction: returns MontyDict   ❌
```

`runtime_state.dart:58` re-wrapped `event.value` (the lossy `dartValue`,
a plain `Map` for typed values) via `MontyValue.fromDart`, which doesn't
honour `__type` envelopes. The typed value held by core's `MontyResult`
was discarded mid-stream.

`BridgeRunFinished` gains a typed `montyValue: MontyValue?` field
alongside the existing `value: Object?`. `_emitComplete` populates
both; `extractBridgeResult` prefers `montyValue`, falling back to
`MontyValue.fromDart(value)` for backwards compat.

`event.value` (the dartValue) is **unchanged**. Sandbox children, web
demo consumers, and integration tests asserting
`finished.value isA<String>` keep working.

## Why CONTRIBUTING is in this PR

The triage section was written after-the-fact. The bug should have
been walked down the stack (dart_monty → dart_monty_core Dart → Rust
shim → pydantic/monty) before filing. Codifying the discipline closes
the meta-gap.

## Tests

- New unit test covering the dataclass round-trip via a synthetic
  `BridgeRunFinished` event with typed `montyValue` returns
  `MontyDataclass`.
- New unit test covering the `fromDart` fallback when `montyValue` is
  absent (backwards-compat regression).
- Demo runs end-to-end through the bridge; output verified.

## README

`## Examples` section between Quick Start and Documentation lists the
three top-level demos:

| File | What it shows |
|---|---|
| `example/example.dart` | Minimal `Monty.exec` one-shots |
| `example/type_check_demo.dart` | `Monty.typeCheck` static analysis |
| `example/dataclass_demo.dart` | Stateful dataclass round-trip across `MontyRuntime.execute` calls |

## Test plan

- [x] `dart analyze` — 0 issues
- [x] `dart test` — 465 / 465 (2 new regression tests)
- [x] `dcm analyze .` — clean on every touched file; repo baseline 33+33 unchanged
- [x] `dart run example/dataclass_demo.dart` — produces expected output
- [x] Direct probe: both `Monty(code).run` and `MontyRuntime.execute` return `MontyDataclass`