### PR TITLE
docs(install): direct users to GitHub git: install (sim feedback round 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,24 +14,45 @@ Sandboxed Python interpreter for Dart and Flutter. Run Python from native, web, 
 
 ## Quick Start
 
-Add `dart_monty` to your `pubspec.yaml`. Flutter Web consumers add
-`dart_monty_core` as a peer dep so the asset bundler can locate the
-WASM/JS files:
+### Install (from GitHub)
+
+Both packages install from GitHub via `git:` deps. **Do not use
+`dart pub add dart_monty`** — pub.dev's `dart_monty` is the legacy
+0.11.0 with a different API; the current code (with `Monty.exec`,
+`MontyRuntime`, etc.) lives only on GitHub for now.
+
+You must list **both** packages explicitly under `git:` — without
+the explicit `dart_monty_core` entry, pub will resolve it from
+pub.dev and the APIs won't match:
 
 ```yaml
 # pubspec.yaml
 dependencies:
-  dart_monty: ^<version>
-  # Flutter Web only — Flutter's asset resolver needs this listed
-  # directly; it does not chase transitive references. Not redundant.
-  dart_monty_core: ^<version>
+  dart_monty:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main
 
-# Only needed by Flutter's build hook — instructs the asset bundler
-# to include dart_monty_core's WASM/JS bridge files. Plain-Dart
-# consumers ignore this stanza.
+# Flutter only — instructs the asset bundler to include
+# dart_monty_core's WASM/JS bridge files. Plain-Dart consumers
+# ignore this stanza.
 flutter:
   assets:
     - package: dart_monty_core
+```
+
+For local development against a worktree, swap `git:` for `path:`:
+
+```yaml
+dependencies:
+  dart_monty:
+    path: /path/to/dart_monty
+  dart_monty_core:
+    path: /path/to/dart_monty_core
 ```
 
 Then import the package:

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,8 +14,20 @@ Sandboxed Python interpreter for Dart and Flutter. Run Python from native, web, 
 
 ## Quick Start
 
-```bash
-dart pub add dart_monty
+Install both packages from GitHub (do **not** use `dart pub add` —
+pub.dev has a legacy `dart_monty` 0.11.0 with a different API):
+
+```yaml
+# pubspec.yaml
+dependencies:
+  dart_monty:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main
 ```
 
 **One-shot execution**

--- a/docs/user/deployment.md
+++ b/docs/user/deployment.md
@@ -14,9 +14,20 @@ and native applications.
 ## Flutter Web
 
 ```yaml
-# pubspec.yaml
+# pubspec.yaml — install both packages from GitHub
 dependencies:
-  dart_monty: ^<version>
+  dart_monty:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main
+
+flutter:
+  assets:
+    - package: dart_monty_core
 ```
 
 ```dart

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -1,10 +1,28 @@
 # Installation
 
-Add `dart_monty` to your project:
+Both `dart_monty` and `dart_monty_core` install from GitHub via
+`git:` deps. **Do not run `dart pub add dart_monty`** — pub.dev's
+`dart_monty` is the legacy 0.11.0 with a different API (no
+`Monty.exec`, no `MontyRuntime`); the current code lives only on
+GitHub for now.
 
-```bash
-dart pub add dart_monty
+```yaml
+# pubspec.yaml
+dependencies:
+  dart_monty:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main
 ```
+
+Both packages must be listed under `git:` — without an explicit
+`dart_monty_core` entry, pub will resolve the transitive dep from
+pub.dev and the APIs won't match. For local worktree development
+swap `git:` for `path:`.
 
 ## Platform Requirements
 
@@ -28,14 +46,20 @@ package that owns the files.
 ```yaml
 # pubspec.yaml
 dependencies:
-  dart_monty: ^<version>
+  dart_monty:
+    git:
+      url: https://github.com/runyaga/dart_monty.git
+      ref: main
   # Required — Flutter's asset bundler needs this listed directly.
   # Do not remove; it is not redundant with dart_monty.
-  dart_monty_core: ^<version>
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main
 
-# Only needed by Flutter's build hook — instructs the asset bundler
-# to include dart_monty_core's WASM/JS bridge files. Plain-Dart
-# consumers ignore this stanza.
+# Flutter only — instructs the asset bundler to include
+# dart_monty_core's WASM/JS bridge files. Plain-Dart consumers
+# ignore this stanza.
 flutter:
   assets:
     - package: dart_monty_core
@@ -72,8 +96,9 @@ Without Flutter's asset bundler, copy the three asset files from the
 `<script>` tag:
 
 ```bash
-# Locate dart_monty_core's assets in the pub cache
-CORE_ASSETS=$(dart pub cache dir)/hosted/pub.dev/dart_monty_core-*/assets
+# dart_monty_core is git-installed, so its assets live under the
+# git pub cache (not the pub.dev hosted cache).
+CORE_ASSETS=$(dart pub cache dir)/git/dart_monty_core-*/lib/assets
 cp $CORE_ASSETS/dart_monty_core_bridge.js web/
 cp $CORE_ASSETS/dart_monty_core_worker.js web/
 cp $CORE_ASSETS/dart_monty_core_native.wasm web/


### PR DESCRIPTION
## Summary

Replaces the pub.dev install pin in README's Quick Start with an
explicit two-package `git: ref: main` block. Adds a `path:` variant
for local development.

## Why

First high-leverage finding from the dart_monty UX-simulation
harness, scenario 01 (Evaluator/Installer), against Minimax-M2.7.
The persona produced three high-severity frictions on the same
axis:

1. **"The install docs say `dart pub add dart_monty` but the
   critical context says pub.dev has legacy 0.11.0 and to use git
   deps — these conflict, which is the real install path?"**
2. **"Confirmed: `dart pub add dart_monty` installs the legacy
   0.11.0 (NOT 0.17.0)."** — verified empirically by running the
   command.
3. **"The git: dependency for dart_monty_core worked (0.0.2 from
   git), but dart_monty resolved to hosted (0.11.0) which has a
   different API — no Monty.exec(). Need to use both packages from
   git."** — the persona discovered the transitive-resolution trap.

Finding #3 is the subtle one: even if a user knows to install
`dart_monty_core` from git, the README's `dart_monty: ^<version>`
example will still pull `dart_monty` from pub.dev (where it's
legacy 0.11.0 with no `Monty.exec`/`MontyRuntime`).

## Change

Replaces the install YAML in README.md Quick Start. New copy
explicitly says "do not use `dart pub add dart_monty`" and lists
both packages under `git:`. Adds a `path:` worktree variant.

## Test plan

- [x] README renders cleanly.
- [ ] Re-run scenario 01 against the post-fix README to confirm the
      three frictions are gone (next round of the sim loop).

## Related

- Sim harness: `~/dev/dart_monty_sim/`
- Mirror fix to dart_monty_core: runyaga/dart_monty_core PR #88
  (commit `a11989f`).
- Round 1 frictions log:
  `~/dev/dart_monty_sim/runs/2026-04-28T20-44-49Z/minimax-MiniMax-M2_7/frictions_01_evaluator.jsonl`