### PR TITLE
docs: round 2 sim-feedback (FFI triples + sandbox table + subset at top-level)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@
 
 Sandboxed Python interpreter for Dart and Flutter. Run Python from native, web, and mobile — one package, every platform.
 
+## Monty is a Python *subset*
+
+Before writing code, know that Monty does **not** support a chunk
+of regular Python. Hitting one of these features at runtime raises
+a typed error — gate your code through `Monty.typeCheck` first.
+
+**Not supported:** `class`, decorators (`@foo`, `@dataclass`),
+generators (`yield`), `match`/`case`, `del`, walrus (`:=`), chained
+assignment; `open()`/`eval()`/`exec()`/`locals()`/`globals()`;
+`os`/`sys`/`subprocess`/`shutil`; `requests`/`urllib`/`http`;
+`threading`/`multiprocessing`/`asyncio`. **Use dicts + module-level
+functions in place of classes.** Curated stdlib: `json`, `math`,
+`re`, `pathlib`, `datetime`, `collections`.
+
+**Pre-flight every script:**
+
+```dart
+final errors = await Monty.typeCheck(userCode);
+if (errors.isNotEmpty) return; // reject before runtime.execute
+final result = await runtime.execute(userCode).result;
+```
+
+See [`docs/tutorials/llm-prompt-rules.md`](docs/tutorials/llm-prompt-rules.md)
+for the full constraint list and rationale.
+
 ## Quick Start
 
 ### Install (from GitHub)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,40 @@
 
 Sandboxed Python interpreter for Dart and Flutter. Run Python from native, web, and mobile — one package, every platform.
 
+## Monty is a Python *subset*
+
+Before you write any code, know that Monty does **not** support a
+chunk of regular Python. Hitting one of these features at runtime
+raises a typed error, but it's much friendlier to gate your code
+through `Monty.typeCheck` first.
+
+**Not supported:**
+
+- `class` keyword (no user-defined classes — use dicts + module-level
+  functions in their place)
+- Decorators (`@foo`) and `@dataclass`
+- Generators (`yield`, `yield from`)
+- `match` / `case`, `del`, walrus (`:=`), chained assignment
+- `open()`, `eval()`, `exec()`, `locals()`, `globals()`
+- `os`, `sys`, `subprocess`, `shutil`, `requests`, `urllib`, `http`
+- `threading`, `multiprocessing`, `asyncio`
+- Arbitrary `import` — stdlib is curated to `json`, `math`, `re`,
+  `pathlib`, `datetime`, `collections`
+
+**Pre-flight every script:**
+
+```dart
+final errors = await Monty.typeCheck(userCode);
+if (errors.isNotEmpty) {
+  // Reject before runtime.execute(...).
+  return errors.map((e) => '${e.path}:${e.line}: ${e.message}').toList();
+}
+final result = await runtime.execute(userCode).result;
+```
+
+See [LLM prompt rules](tutorials/llm-prompt-rules.md) for the full
+constraint list.
+
 ## Quick Start
 
 Install both packages from GitHub (do **not** use `dart pub add` —

--- a/docs/user/extensions.md
+++ b/docs/user/extensions.md
@@ -144,8 +144,27 @@ gets its own `MontyPlatform` and `DefaultMontyBridge`. Children
 can inherit extensions from the parent and even spawn their own
 children (grandchildren).
 
+### What the sandbox actually constrains
+
+| Dimension | Mechanism | Limit / behaviour |
+|---|---|---|
+| **Memory** | `MontyLimits(memoryBytes:)` on parent or per-child | Hard cap; raises `MontyResourceError.MemoryLimitExceeded` on overflow |
+| **CPU / wall-clock** | `MontyLimits(timeoutMs:)` | Raises `MontyResourceError.TimeoutError` on overflow |
+| **Stack depth** | `MontyLimits(stackDepth:)` | Raises a Python `RecursionError` on overflow |
+| **Filesystem** | `OsCallHandler` composition (`memoryFsHandler`, `sandboxedFsHandler`, `readOnlyHandler`, `overlayFsHandler`) | No filesystem access at all unless an `OsCallHandler` is registered for `Path.*` |
+| **Network** | None native — Python stdlib has no `requests`/`urllib`/`http` | Network access is exposed only via host functions you register |
+| **Child concurrency** | `maxChildren:` on `SandboxExtension` | Hard cap on simultaneous live children |
+| **Child depth** | `maxDepth:` on `SandboxExtension` | Cap on grandchild → great-grandchild recursion |
+| **Per-child VFS** | `childVfsStrategy:` (`isolated` default, `shared`, `none`) | Whether children inherit the parent's VFS or get their own |
+
+**Not constrained**: per-call instruction count independent of
+wall-clock time (the interpreter runs on the host thread for native
+backends and a Worker thread for WASM); CPU usage by the host
+process itself; non-Python work the host does in handlers you
+expose (those run on the host with full host privileges).
+
 See [Sandbox Architecture](../deep-dives/sandbox-architecture.md) for the
-full deep dive.
+full deep dive on the parent↔child runtime topology.
 
 ### Sandbox Functions
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -32,6 +32,21 @@ swap `git:` for `path:`.
   (built by `dart_monty_core`'s `hook/build.dart`) is compiled
   automatically when you run `dart pub get` — requires a working
   Rust toolchain (cargo + rustc).
+
+  Supported host triples in v0.17.0:
+
+  | OS / arch | Triple |
+  |---|---|
+  | macOS arm64 | `aarch64-apple-darwin` |
+  | macOS x86_64 | `x86_64-apple-darwin` |
+  | Linux arm64 | `aarch64-unknown-linux-gnu` |
+  | Linux x86_64 | `x86_64-unknown-linux-gnu` |
+  | Windows arm64 | `aarch64-pc-windows-msvc` |
+  | Windows x86_64 | `x86_64-pc-windows-msvc` |
+
+  Other triples (32-bit ARM, musl libc, BSDs, …) are not built by
+  the hook today.
+
 - **iOS/Android:** Not yet supported. Planned once the FFI/WASM
   story stabilises.
 


### PR DESCRIPTION
Three findings from round 2 of the dart_monty UX-simulation harness,
scenario 01 (Evaluator/Installer) against Minimax-M2.7. Each commit
addresses one finding from the persona's `ScenarioReport`; rationale
in the commit messages.

## Findings (3 commits)

| # | Severity | Commit | What | File |
|---|---|---|---|---|
| 1 | medium | `docs(install): enumerate supported FFI host triples` | Adds the 6 supported triples (macOS arm64+x86_64, Linux arm64+x86_64-gnu, Windows arm64+x86_64) inline, so consumers can check their target without bouncing into dart_monty_core's README | `docs/user/install.md` |
| 2 | medium | `docs(extensions): single authoritative sandbox-constraints table` | Persona had to cross-reference 3 deep-dives to answer "what does the sandbox actually constrain?" — now a single table answering that, plus an explicit "not constrained" note | `docs/user/extensions.md` |
| 3 | high | `docs: surface Monty Python subset at top-level` | Subset constraints were buried in `tutorials/llm-prompt-rules.md` (LLM-targeted) + `deep-dives/error-hierarchy.md`. New devs reading `README.md` or `index.md` first don't know about them until runtime failure. Adds an inline subset section + typeCheck pre-flight snippet to BOTH top-level surfaces | `README.md`, `docs/index.md` |

## Sim provenance

Round 2's `ScenarioReport` lives at:

```
~/dev/dart_monty_sim/runs/2026-04-28T20-49-07Z/minimax-MiniMax-M2_7/scenario_01_evaluator.md
```

Each finding above quotes the persona's verbatim suggested edit; my
commit messages explain the friction that motivated it. Round 1
findings landed via PR #386 (install snippet → git: deps).

## Test plan

- [x] `mkdocs build --strict` clean (no broken links).
- [ ] Re-run scenario 01 round 3 against the post-fix docs to verify
      these findings are gone (next round of the sim loop).
- [ ] Run scenario 02 (Integrator) — currently in flight against the
      pre-fix docs; if subset visibility was a friction there too,
      this PR also addresses it.