### PR TITLE
chore: rename ToolCall* event-type strings to FunctionCall*

### DIFF
--- a/docs/tutorials/host-functions-beginner.md
+++ b/docs/tutorials/host-functions-beginner.md
@@ -118,7 +118,7 @@ HostFunction(
 
 If Python calls `divide(10, 0)`, it gets a Python exception with the
 message `"Division by zero"`. The bridge logs the error with stack trace
-via `struct_log` and emits a `BridgeToolCallResult` with the error
+via `struct_log` and emits a `BridgeFunctionCallResult` with the error
 message.
 
 You do not need to catch exceptions yourself for error propagation --
@@ -143,21 +143,21 @@ Each host function call emits a sequence of tool call events:
 
 ```text
 BridgeStepStarted(stepId: "greet")
-BridgeToolCallStart(callId: "0", name: "greet")
-BridgeToolCallArgs(callId: "0", delta: '{"name":"World"}')
-BridgeToolCallEnd(callId: "0")
+BridgeFunctionCallStart(callId: "0", name: "greet")
+BridgeFunctionCallArgs(callId: "0", delta: '{"name":"World"}')
+BridgeFunctionCallEnd(callId: "0")
   -- handler runs --
-BridgeToolCallResult(callId: "0", result: "Hello, World!")
+BridgeFunctionCallResult(callId: "0", result: "Hello, World!")
 BridgeStepFinished(stepId: "greet")
 ```
 
 | Event | Description |
 |-------|-------------|
 | `BridgeStepStarted` | A host function call step begins |
-| `BridgeToolCallStart` | Function name identified |
-| `BridgeToolCallArgs` | Arguments as JSON delta |
-| `BridgeToolCallEnd` | Arguments complete |
-| `BridgeToolCallResult` | Handler result (or error message) |
+| `BridgeFunctionCallStart` | Function name identified |
+| `BridgeFunctionCallArgs` | Arguments as JSON delta |
+| `BridgeFunctionCallEnd` | Arguments complete |
+| `BridgeFunctionCallResult` | Handler result (or error message) |
 | `BridgeStepFinished` | Step complete |
 
 ### Text Events (Print Capture)
@@ -185,9 +185,9 @@ await for (final event in bridge.execute(code)) {
   switch (event) {
     case BridgeRunStarted(:final threadId, :final runId):
       print('Started: thread=$threadId run=$runId');
-    case BridgeToolCallStart(:final callId, :final name):
+    case BridgeFunctionCallStart(:final callId, :final name):
       print('Calling: $name (call $callId)');
-    case BridgeToolCallResult(:final callId, :final result):
+    case BridgeFunctionCallResult(:final callId, :final result):
       print('Result: $result (call $callId)');
     case BridgeTextContent(:final delta):
       print('Output: $delta');

--- a/docs/user/repl.md
+++ b/docs/user/repl.md
@@ -80,7 +80,7 @@ print(r2.value); // MontyInt(43)
 // Event stream for real-time visibility
 final events = session.execute('tmpl_render(...)');
 await for (final event in events) {
-  // BridgeToolCallStart, BridgeToolCallResult, etc.
+  // BridgeFunctionCallStart, BridgeFunctionCallResult, etc.
 }
 
 await session.dispose();

--- a/example/web/bin/agent_demo.dart
+++ b/example/web/bin/agent_demo.dart
@@ -308,21 +308,21 @@ Map<String, dynamic> _eventToMap(BridgeEvent event) {
       'callId': callId,
     },
     BridgeFunctionCallStart(:final callId, :final name) => {
-      'type': 'ToolCallStart',
+      'type': 'FunctionCallStart',
       'callId': callId,
       'name': name,
     },
     BridgeFunctionCallArgs(:final callId, :final delta) => {
-      'type': 'ToolCallArgs',
+      'type': 'FunctionCallArgs',
       'callId': callId,
       'delta': delta,
     },
     BridgeFunctionCallEnd(:final callId) => {
-      'type': 'ToolCallEnd',
+      'type': 'FunctionCallEnd',
       'callId': callId,
     },
     BridgeFunctionCallResult(:final callId, :final result) => {
-      'type': 'ToolCallResult',
+      'type': 'FunctionCallResult',
       'callId': callId,
       'result': result,
     },

--- a/example/web/web/agent.html
+++ b/example/web/web/agent.html
@@ -501,10 +501,10 @@ x</textarea>
       // Visual indicator: Python blocked on msg_recv / unblocked
       const pushBtn = document.getElementById('dartPushBtn');
       const waitingBanner = document.getElementById('waitingBanner');
-      if (event.type === 'ToolCallStart' && event.name === 'msg_recv') {
+      if (event.type === 'FunctionCallStart' && event.name === 'msg_recv') {
         if (waitingBanner) { waitingBanner.style.display = 'flex'; }
         if (pushBtn) { pushBtn.disabled = false; pushBtn.style.opacity = '1'; pushBtn.style.animation = 'pulse 1s infinite'; }
-      } else if (event.type === 'ToolCallResult' || event.type === 'RunFinished' || event.type === 'RunError') {
+      } else if (event.type === 'FunctionCallResult' || event.type === 'RunFinished' || event.type === 'RunError') {
         if (waitingBanner) { waitingBanner.style.display = 'none'; }
         if (pushBtn) { pushBtn.disabled = true; pushBtn.style.opacity = '0.4'; pushBtn.style.animation = ''; }
       }
@@ -532,7 +532,7 @@ x</textarea>
     function getEventTypeClass(type) {
       if (type === 'RunError') return 'event-type-error';
       if (type.startsWith('Run')) return 'event-type-run';
-      if (type.startsWith('Tool')) return 'event-type-tool';
+      if (type.startsWith('FunctionCall')) return 'event-type-tool';
       if (type.startsWith('OsCall')) return 'event-type-os';
       if (type.startsWith('Text')) return 'event-type-text';
       if (type.startsWith('Step')) return 'event-type-step';
@@ -547,9 +547,9 @@ x</textarea>
         case 'RunStarted': return 'thread=' + event.threadId;
         case 'RunFinished': return event.value ? 'value=' + event.value : 'done';
         case 'RunError': return event.message;
-        case 'ToolCallStart': return event.name + '()';
-        case 'ToolCallArgs': return event.delta;
-        case 'ToolCallResult': return event.result;
+        case 'FunctionCallStart': return event.name + '()';
+        case 'FunctionCallArgs': return event.delta;
+        case 'FunctionCallResult': return event.result;
         case 'OsCallStart': return event.operationName + (event.argumentSummary ? ' ' + event.argumentSummary : '');
         case 'OsCallResult': return event.result + (event.durationMs != null ? ' [' + event.durationMs + 'ms]' : '');
         case 'TextContent': return event.delta;

--- a/test/experiments/tool_chain_experiment_test.dart
+++ b/test/experiments/tool_chain_experiment_test.dart
@@ -277,7 +277,7 @@ send_message(msg=msg)
     tearDown(() => h.dispose());
 
     test(
-      'runWithEvents captures BridgeToolCallStart for each tool call',
+      'runWithEvents captures BridgeFunctionCallStart for each tool call',
       () async {
         final (:result, :events) = await h.runWithEvents('probe()');
 


### PR DESCRIPTION
## Summary

The `Bridge*Call` event classes were already renamed from `BridgeToolCall*` to `BridgeFunctionCall*` in `lib/`, but stale references survived in docs, the agent demo, and the demo's JS consumer. The producer-side Dart classes moved on, but the **JSON event-type strings stayed on the old name** — visible in the web demo UI as `ToolCallStart`, `ToolCallResult`, etc.

## Changes

| File | What |
|---|---|
| `example/web/bin/agent_demo.dart` | JSON `'type'` strings: `'ToolCall*'` → `'FunctionCall*'` (Dart producer) |
| `example/web/web/agent.html` | JS string matches updated in lockstep (consumer) — including a `startsWith('Tool')` branch that would have become dead |
| `docs/user/repl.md` | Stale class-name comment |
| `docs/tutorials/host-functions-beginner.md` | 9 references in narrative + table + code snippets |
| `test/experiments/tool_chain_experiment_test.dart` | Test description string |

## Intentionally **not** changed

- `lib/src/host/dispatch.dart` — internal helpers `_validateToolCallArgs`, `dispatchToolCall` are private and unrelated to the public event surface. Renaming them is optional churn.

## Test plan

- [x] `dart analyze --fatal-infos` clean
- [x] `dart test` — 465 passing, 23 skipped, 0 failed
- [x] `grep -rn "ToolCallStart\|ToolCallResult\|ToolCallArgs\|ToolCallEnd\|BridgeToolCall"` returns only the deliberately-skipped private helpers
- [ ] Manual smoke: run `example/web/run.sh`, open the agent demo, verify the UI renders `FunctionCall*` event types correctly (no events shown as raw JSON-on-default fallthrough)

## Caveat

`'FunctionCallEnd'` (inner: arg streaming complete) and `'CallFinished'` (outer: whole call wrapper done) are **different** events — easy to confuse by name. The JS consumer in `agent.html` keeps them distinct.