### PR TITLE
docs: absolute image URL + refreshed pubspec description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # dart_monty
 
 <p align="center">
-  <img src="docs/assets/dart_monty.jpg" alt="dart_monty" width="280">
+  <img src="https://raw.githubusercontent.com/runyaga/dart_monty/main/docs/assets/dart_monty.jpg" alt="dart_monty" width="280">
 </p>
 
 [![CI](https://github.com/runyaga/dart_monty/actions/workflows/ci.yaml/badge.svg)](https://github.com/runyaga/dart_monty/actions/workflows/ci.yaml)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_monty
-description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust. Run Python from Dart and Flutter on desktop, web, and mobile.
+description: Script your Dart/Flutter app with sandboxed Python — runtime extensions, Flutter glue, and FFI/WASM asset loading on top of dart_monty_core.
 version: 0.17.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty


### PR DESCRIPTION
## Summary

Two small post-release doc fixes for the next dart_monty release:

1. **README image rendered blank on pub.dev's `0.17.0` listing.** pub.dev's markdown sanitizer strips `<img>` tags with relative `src` (only absolute URLs survive — same reason the CI/Pages/codecov badges already worked). Switching to `https://raw.githubusercontent.com/runyaga/dart_monty/main/docs/assets/dart_monty.jpg` makes the image render.
2. **pubspec `description` rewritten** to a one-liner that says what the package is at a glance and complements `dart_monty_core`'s description rather than duplicating it.

## Caveat

pub.dev pins the README and pubspec description per published version. `dart_monty 0.17.0`'s listing won't update from these changes — they'll surface only when the next version ships.