### PR TITLE
docs: repoint broken Documentation link to GitHub docs/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Pages](https://github.com/runyaga/dart_monty/actions/workflows/pages.yaml/badge.svg)](https://runyaga.github.io/dart_monty/)
 [![codecov](https://codecov.io/gh/runyaga/dart_monty/graph/badge.svg)](https://codecov.io/gh/runyaga/dart_monty)
 
-[Live Demo](https://runyaga.github.io/dart_monty/) | [Documentation](https://runyaga.github.io/dart_monty/help.html) | [GitHub](https://github.com/runyaga/dart_monty)
+[Live Demo](https://runyaga.github.io/dart_monty/) | [Documentation](https://github.com/runyaga/dart_monty/tree/main/docs) | [GitHub](https://github.com/runyaga/dart_monty)
 
 Sandboxed Python interpreter for Dart and Flutter. Run Python from native, web, and mobile — one package, every platform.
 


### PR DESCRIPTION
## Summary

The README nav line had `[Documentation](https://runyaga.github.io/dart_monty/help.html)` which 404s. The github.io pages site is currently unreliable, so this repoints to the repo's `docs/` folder which renders natively on GitHub:

```diff
-[Live Demo](https://runyaga.github.io/dart_monty/) | [Documentation](https://runyaga.github.io/dart_monty/help.html) | [GitHub](https://github.com/runyaga/dart_monty)
+[Live Demo](https://runyaga.github.io/dart_monty/) | [Documentation](https://github.com/runyaga/dart_monty/tree/main/docs) | [GitHub](https://github.com/runyaga/dart_monty)
```

## Caveat

Same as the previous docs PRs — pub.dev pins the README per published version, so dart_monty 0.17.0's listing keeps the broken link. The fix lands on the next release.