### PR TITLE
docs: landing page + llmstxt plugin + drop broken native-build nav entry

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -74,7 +74,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install MkDocs dependencies
-        run: pip install mkdocs-material
+        run: pip install -r requirements-docs.txt
       - name: Build documentation
         run: mkdocs build
       # ── Assemble site ────────────────────────────────────────────────

--- a/docs/landing.md
+++ b/docs/landing.md
@@ -1,0 +1,73 @@
+# Documentation
+
+<p align="center">
+  <img src="assets/dart_monty.jpg" alt="dart_monty" width="200">
+</p>
+
+Sandboxed Python interpreter for Dart and Flutter. Run Python from native,
+web, and mobile — one package, every platform.
+
+> Looking for a quick taste? Try the [live REPL](repl.html) or the
+> [agent demo](agent.html). For the API at a glance, see
+> [User Guide → API Reference](user/api-reference.html).
+
+## User Guide
+
+Practical, task-oriented docs for adding `dart_monty` to a project.
+
+- [Installation](user/install.html) — Add to your `pubspec.yaml`
+- [Deployment](user/deployment.html) — Native and web deployment notes
+- [REPL](user/repl.html) — Stateful interactive execution
+- [Extensions](user/extensions.html) — Template, MessageBus, Sandbox
+- [API Reference](user/api-reference.html) — Method-by-method summary
+
+## Tutorials
+
+Walkthroughs that build something real, step by step.
+
+- [Host Functions Intro](tutorials/host-functions-intro.html)
+- [Host Functions Beginner](tutorials/host-functions-beginner.html)
+- [Host Functions Intermediate](tutorials/host-functions-intermediate.html)
+- [Host Functions Advanced](tutorials/host-functions-advanced.html)
+- [Bridge Middleware](tutorials/bridge-middleware.html)
+- [LLM Prompt Rules](tutorials/llm-prompt-rules.html)
+
+## Deep Dives
+
+How the package works under the hood.
+
+- [Architecture Overview](architecture/overview.html)
+- [Sandbox Architecture](deep-dives/sandbox-architecture.html)
+- [OsCall / VFS Layer](deep-dives/oscall-vfs.html)
+- [Error Hierarchy](deep-dives/error-hierarchy.html)
+- [Extension System](deep-dives/extension-system.html)
+- [Bridge Concurrency](deep-dives/bridge-concurrency.html)
+
+## Technical Reference
+
+Source-of-truth references for the internal contract surface.
+
+- [Native Crate (Rust)](reference/native-crate.html)
+- [Monty Rust API](reference/monty-rust-api.html)
+- [FFI Handle Lifecycle](reference/ffi-handle-lifecycle.html)
+- [Bridge Integration](reference/bridge-integration.html)
+- [Internals](reference/internals.html)
+- [API Coverage Plan](reference/api-coverage-plan.html)
+
+## Contributing
+
+- [Development Setup](contributor/setup.html)
+- [Testing](contributor/testing.html)
+
+## For LLMs
+
+A machine-readable index of this site is available at
+[`/llms.txt`](llms.txt) — see [llmstxt.org](https://llmstxt.org) for the
+spec.
+
+## Source
+
+Source lives at [github.com/runyaga/dart_monty](https://github.com/runyaga/dart_monty).
+The companion package
+[`dart_monty_core`](https://github.com/runyaga/dart_monty_core)
+ships the low-level FFI/WASM bindings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,28 @@ markdown_extensions:
 extra_css:
   - extra.css
 
+# Generates llms.txt + llms-full.txt at site root from the nav/sections
+# below. Install: pip install -r requirements-docs.txt
+plugins:
+  - search
+  - llmstxt:
+      markdown_description: |
+        High-level Dart/Flutter bindings for sandboxed Python scripting.
+        Builds on dart_monty_core (the low-level FFI/WASM glue) with a
+        runtime, extension API (Jinja, MessageBus, Sandbox), Flutter web
+        bridge auto-loading, OS-call composition, and host-function
+        dispatch with typed schemas.
+
+        IMPORTANT: Monty does NOT support `class`, decorators (`@foo`),
+        generators (`yield`), `match`/`case`, `del`, or arbitrary
+        imports. Use dicts + module-level functions in place of classes.
+        Stdlib: `math`, `re`, `json`, `datetime`, `pathlib`.
+
+        Run `Monty.typeCheck(code)` before `runtime.execute(code)` to
+        catch subset violations as typed errors before runtime — the
+        supported development loop.
+      full_output: llms-full.txt
+
 nav:
   - Overview: index.md
   - User Guide:
@@ -63,5 +85,4 @@ nav:
   - Contributing:
       - Development Setup: contributor/setup.md
       - Testing: contributor/testing.md
-      - Native Build: contributor/native-build.md
 

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocs-llmstxt>=0.2
+pymdown-extensions>=10.7


### PR DESCRIPTION
## Summary

Three related doc-site fixes:

1. **`docs/landing.md`** — new lightweight TOC hub linking to the major doc sections (User Guide, Tutorials, Deep Dives, Reference, Contributing) plus a pointer to `/llms.txt`. Intended as the canonical Documentation landing target for README links.
2. **`mkdocs-llmstxt` plugin** — generates `/llms.txt` and `/llms-full.txt` at the site root automatically from the nav structure (mirrors dart_monty_core's setup). Without this the link in landing.md 404s.
3. **Drop broken nav entry** — `Native Build: contributor/native-build.md` referenced a file that doesn't exist. Cargo/Rust setup is already covered in `contributor/setup.md` and `contributor/testing.md`.
4. **CI: install via `requirements-docs.txt`** — `pages.yaml` was installing only `mkdocs-material`; bumped to use `pip install -r requirements-docs.txt` so the llmstxt plugin resolves.

## Out of scope (separate follow-ups)

The user has identified additional doc-site bugs that need their own fixes:

- Mermaid diagram contrast issue: white-on-light-purple `PlatformBridge` text on `deep-dives/sandbox-architecture.html`
- Mermaid diagram not rendering on `deep-dives/oscall-vfs.html` ("handler diagram")
- Relative `.md` link in `architecture/overview.html` not being transformed to `.html`

These are unrelated to the landing-page / llmstxt scope and warrant separate PRs.

## Test plan

- [x] Local audit: `grep` of all `.md` references in `mkdocs.yml` against the docs/ folder shows all entries resolve except the now-removed `contributor/native-build.md`
- [ ] Local mkdocs build (deferred — couldn't install `mkdocs-llmstxt` locally without a venv; CI will validate)
- [ ] After merge: confirm `/llms.txt` and `/llms-full.txt` are reachable on the deployed site
- [ ] After merge: link the README's Documentation entry at `/landing.html` (separate PR — PR #394 currently points it at the GitHub `docs/` folder; lands either before or after this depending on order)