### PR TITLE
docs: humanize broken-looking link text in architecture/overview.md

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -159,4 +159,4 @@ The `MontyRuntime` and `PlatformBridge` serve two audiences simultaneously:
 This dual-audience pattern means you register a tool once and get both a
 callable Python function and an LLM-compatible tool definition.
 
-For the `OsCallHandler` layer, see [../deep-dives/oscall-vfs.md](../deep-dives/oscall-vfs.md).
+For the `OsCallHandler` layer, see [OsCall / VFS Layer](../deep-dives/oscall-vfs.md).


### PR DESCRIPTION
## Summary

`docs/architecture/overview.md:162` had:

\`\`\`markdown
For the \`OsCallHandler\` layer, see [../deep-dives/oscall-vfs.md](../deep-dives/oscall-vfs.md).
\`\`\`

mkdocs auto-transforms the *href* (`.md` → `.html`) but never touches the *visible link text*, so the rendered page showed a literal-looking `../deep-dives/oscall-vfs.md` as clickable text — which the user interpreted as "the link isn't being transformed."

Replace with a readable label.