### PR TITLE
docs: fix PlatformBridge contrast in sandbox-architecture mermaid

### DIFF
--- a/docs/deep-dives/sandbox-architecture.md
+++ b/docs/deep-dives/sandbox-architecture.md
@@ -34,7 +34,8 @@ graph TD
     F --> G
     G --> H
 
-    style F fill:#ccf,stroke:#333,stroke-width:2px,color:#000
+    classDef bridge fill:#ccf,stroke:#333,stroke-width:2px,color:#000
+    class C,F bridge
 ```
 
 ### Cross-platform Support


### PR DESCRIPTION
## Summary

On https://runyaga.github.io/dart_monty/deep-dives/sandbox-architecture.html the `PlatformBridge` text rendered white-on-light-purple in dark mode. Root cause: only node `F` (the *child*-session PlatformBridge) had explicit styling with `color:#000`. Node `C` (the *parent*-session PlatformBridge) had no styling, so mkdocs-material's dark-mode mermaid theme overrode the text colour to white while leaving the default light fill.

Replace the per-node `style F` with a `classDef bridge` applied to both `C` and `F` so they're styled consistently.