### PR TITLE
docs: fix unrendered handler diagram in oscall-vfs.md

### DIFF
--- a/docs/deep-dives/oscall-vfs.md
+++ b/docs/deep-dives/oscall-vfs.md
@@ -14,8 +14,8 @@ The functional API uses composable handlers instead of a class hierarchy.
 graph TD
     subgraph "Python Code"
         direction LR
-        A("Path('/file.txt').read_text()") --> B{OsCall};
-        C("Path('/new.txt').write_text(...)") --> B;
+        A["Path('/file.txt').read_text()"] --> B{OsCall};
+        C["Path('/new.txt').write_text(...)"] --> B;
     end
 
     subgraph "OsCallHandler"
@@ -25,12 +25,12 @@ graph TD
 
     subgraph Filesystems
         direction TB
-        D -- "Write" --> E[Scratch (MemoryFS)];
-        D -- "Read" --> F[Base (ReadOnly)];
+        D -- "Write" --> E["Scratch (MemoryFS)"];
+        D -- "Read" --> F["Base (ReadOnly)"];
         F --> G[Real FS];
     end
 
-    style E fill:#ccf,stroke:#333,stroke-width:2px;
+    style E fill:#ccf,stroke:#333,stroke-width:2px,color:#000;
 ```
 
 ### Core Handlers


### PR DESCRIPTION
## Summary

The handler diagram on https://runyaga.github.io/dart_monty/deep-dives/oscall-vfs.html silently failed to render. Root cause: mermaid's parser can't handle parentheses inside square-bracket node labels (e.g. `[Scratch (MemoryFS)]`) — it sees the inner `(` as the start of another shape and bails on the whole diagram.

## Changes

\`\`\`diff
- E[Scratch (MemoryFS)]
+ E["Scratch (MemoryFS)"]
- F[Base (ReadOnly)]
+ F["Base (ReadOnly)"]
\`\`\`

Also switch the rounded-shape Python-code nodes `A` and `C` from `A("Path(...)")` to `A["Path(...)"]` — the original form nests parens two-deep and is unreliable across mermaid versions.

Added `color:#000` to the `style E` line so the styled node stays readable against the light-purple fill in dark theme (same root cause as the sandbox-architecture fix).