### PR TITLE
fix(mkdocs): add required 'sections' config to llmstxt plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,40 @@ plugins:
         catch subset violations as typed errors before runtime — the
         supported development loop.
       full_output: llms-full.txt
+      sections:
+        Overview:
+          - index.md
+          - landing.md
+        User Guide:
+          - user/install.md
+          - user/deployment.md
+          - user/repl.md
+          - user/extensions.md
+          - user/api-reference.md
+        Tutorials:
+          - tutorials/host-functions-intro.md
+          - tutorials/host-functions-beginner.md
+          - tutorials/host-functions-intermediate.md
+          - tutorials/host-functions-advanced.md
+          - tutorials/bridge-middleware.md
+          - tutorials/llm-prompt-rules.md
+        Deep Dives:
+          - architecture/overview.md
+          - deep-dives/sandbox-architecture.md
+          - deep-dives/oscall-vfs.md
+          - deep-dives/error-hierarchy.md
+          - deep-dives/extension-system.md
+          - deep-dives/bridge-concurrency.md
+        Technical Reference:
+          - reference/native-crate.md
+          - reference/monty-rust-api.md
+          - reference/ffi-handle-lifecycle.md
+          - reference/bridge-integration.md
+          - reference/internals.md
+          - reference/api-coverage-plan.md
+        Contributing:
+          - contributor/setup.md
+          - contributor/testing.md
 
 nav:
   - Overview: index.md


### PR DESCRIPTION
## Summary

Pages CI broke after #395 with:

\`\`\`
ERROR - Config value 'plugins': Plugin 'llmstxt' option 'sections':
Required configuration not provided.
\`\`\`

[Failing run](https://github.com/runyaga/dart_monty/actions/runs/25148918057/job/73714706548)

`mkdocs-llmstxt` requires a `sections:` mapping under the plugin config. Adds one mirroring the site's `nav:` structure (Overview / User Guide / Tutorials / Deep Dives / Technical Reference / Contributing).

## Test plan

- [ ] CI Pages build passes with the plugin enabled
- [ ] After merge: `https://runyaga.github.io/dart_monty/llms.txt` and `/llms-full.txt` are reachable