### PR TITLE
fix(mkdocs): set site_url required by llmstxt plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,6 @@
 site_name: dart_monty
 site_description: Pure Dart bindings for Monty, a restricted sandboxed Python interpreter built in Rust.
+site_url: https://runyaga.github.io/dart_monty/
 theme:
   name: material
   palette:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,40 @@ plugins:
         catch subset violations as typed errors before runtime — the
         supported development loop.
       full_output: llms-full.txt
+      sections:
+        Overview:
+          - index.md
+          - landing.md
+        User Guide:
+          - user/install.md
+          - user/deployment.md
+          - user/repl.md
+          - user/extensions.md
+          - user/api-reference.md
+        Tutorials:
+          - tutorials/host-functions-intro.md
+          - tutorials/host-functions-beginner.md
+          - tutorials/host-functions-intermediate.md
+          - tutorials/host-functions-advanced.md
+          - tutorials/bridge-middleware.md
+          - tutorials/llm-prompt-rules.md
+        Deep Dives:
+          - architecture/overview.md
+          - deep-dives/sandbox-architecture.md
+          - deep-dives/oscall-vfs.md
+          - deep-dives/error-hierarchy.md
+          - deep-dives/extension-system.md
+          - deep-dives/bridge-concurrency.md
+        Technical Reference:
+          - reference/native-crate.md
+          - reference/monty-rust-api.md
+          - reference/ffi-handle-lifecycle.md
+          - reference/bridge-integration.md
+          - reference/internals.md
+          - reference/api-coverage-plan.md
+        Contributing:
+          - contributor/setup.md
+          - contributor/testing.md
 
 nav:
   - Overview: index.md


### PR DESCRIPTION
## Summary

Pages build still failing after #399 with a *new* error:

\`\`\`
ValueError: 'site_url' must be set in the MkDocs configuration
to be used with the 'llmstxt' plugin
\`\`\`

The plugin uses `site_url` to compose absolute URLs in the generated `llms.txt`. Mirror dart_monty_core's value: `https://runyaga.github.io/dart_monty/`.

## Test plan

- [ ] CI Pages build green
- [ ] After merge: `https://runyaga.github.io/dart_monty/llms.txt` and `/llms-full.txt` reachable
- [ ] After merge: `https://runyaga.github.io/dart_monty/landing.html` reachable