### PR TITLE
feat: inputs injection and buildRunScriptFunction

### DIFF
--- a/example/web/bin/agent_demo.dart
+++ b/example/web/bin/agent_demo.dart
@@ -283,10 +283,10 @@ Future<String> _execute(String code) async {
 Map<String, dynamic> _eventToMap(BridgeEvent event) {
   return switch (event) {
     BridgeRunStarted(:final threadId, :final runId) => {
-      'type': 'RunStarted',
-      'threadId': threadId,
-      'runId': runId,
-    },
+        'type': 'RunStarted',
+        'threadId': threadId,
+        'runId': runId,
+      },
     BridgeRunFinished(
       :final threadId,
       :final runId,
@@ -301,37 +301,37 @@ Map<String, dynamic> _eventToMap(BridgeEvent event) {
         if (printOutput != null) 'printOutput': printOutput,
       },
     BridgeRunError(:final message, :final printOutput) => {
-      'type': 'RunError',
-      'message': message,
-      if (printOutput != null) 'printOutput': printOutput,
-    },
+        'type': 'RunError',
+        'message': message,
+        if (printOutput != null) 'printOutput': printOutput,
+      },
     BridgeCallStarted(:final callId) => {
-      'type': 'CallStarted',
-      'callId': callId,
-    },
+        'type': 'CallStarted',
+        'callId': callId,
+      },
     BridgeCallFinished(:final callId) => {
-      'type': 'CallFinished',
-      'callId': callId,
-    },
+        'type': 'CallFinished',
+        'callId': callId,
+      },
     BridgeFunctionCallStart(:final callId, :final name) => {
-      'type': 'FunctionCallStart',
-      'callId': callId,
-      'name': name,
-    },
+        'type': 'FunctionCallStart',
+        'callId': callId,
+        'name': name,
+      },
     BridgeFunctionCallArgs(:final callId, :final delta) => {
-      'type': 'FunctionCallArgs',
-      'callId': callId,
-      'delta': delta,
-    },
+        'type': 'FunctionCallArgs',
+        'callId': callId,
+        'delta': delta,
+      },
     BridgeFunctionCallEnd(:final callId) => {
-      'type': 'FunctionCallEnd',
-      'callId': callId,
-    },
+        'type': 'FunctionCallEnd',
+        'callId': callId,
+      },
     BridgeFunctionCallResult(:final callId, :final result) => {
-      'type': 'FunctionCallResult',
-      'callId': callId,
-      'result': result,
-    },
+        'type': 'FunctionCallResult',
+        'callId': callId,
+        'result': result,
+      },
     BridgeOsCallStart(
       :final callId,
       :final operationName,
@@ -344,21 +344,21 @@ Map<String, dynamic> _eventToMap(BridgeEvent event) {
         if (argumentSummary != null) 'argumentSummary': argumentSummary,
       },
     BridgeOsCallResult(:final callId, :final result, :final durationMs) => {
-      'type': 'OsCallResult',
-      'callId': callId,
-      'result': result,
-      if (durationMs != null) 'durationMs': durationMs,
-    },
+        'type': 'OsCallResult',
+        'callId': callId,
+        'result': result,
+        if (durationMs != null) 'durationMs': durationMs,
+      },
     BridgeFunctionEmit(:final callId, :final text) => {
-      'type': 'FunctionEmit',
-      'callId': callId,
-      'text': text,
-    },
+        'type': 'FunctionEmit',
+        'callId': callId,
+        'text': text,
+      },
     BridgeChildEvent(:final childHandle, :final inner) => {
-      'type': 'ChildEvent',
-      'childHandle': childHandle,
-      'inner': _eventToMap(inner),
-    },
+        'type': 'ChildEvent',
+        'childHandle': childHandle,
+        'inner': _eventToMap(inner),
+      },
   };
 }
 
@@ -456,8 +456,8 @@ Future<void> main() async {
   final api = <String, JSFunction>{
     'init': (() => _init().then((ok) => ok.toJS).toJS).toJS,
     'execute': ((JSString code) => _execute(
-      code.toDart,
-    ).then((r) => r.toJS).toJS).toJS,
+          code.toDart,
+        ).then((r) => r.toJS).toJS).toJS,
     'getState': (() => _getState().toJS).toJS,
     'getSchemas': (() => _getSchemas().toJS).toJS,
     'clearState': _clearState.toJS,

--- a/example/web/bin/ladder_showcase.dart
+++ b/example/web/bin/ladder_showcase.dart
@@ -326,8 +326,7 @@ Future<Map<String, dynamic>> _runExpectError(
 
   return {
     'status': 'warn',
-    'detail':
-        'Expected error but got value: ${result['value']}'
+    'detail': 'Expected error but got value: ${result['value']}'
         ' — WASM Monty may handle this differently than CPython',
   };
 }
@@ -478,7 +477,8 @@ Future<Map<String, dynamic>> _runAsync(Map<String, dynamic> fixture) async {
     (await _montyResolveFutures(
       jsonEncode(results).toJS,
       jsonEncode(errors).toJS,
-    ).toDart).toDart,
+    ).toDart)
+        .toDart,
   );
 
   if (result['ok'] != true) {
@@ -520,8 +520,7 @@ Map<String, dynamic> _compareResult(
 
     return {
       'status': 'warn',
-      'detail':
-          'Value: $str'
+      'detail': 'Value: $str'
           ' — expected to contain "$expectedContains"'
           ' (WASM Monty behavioral difference)',
     };
@@ -536,8 +535,7 @@ Map<String, dynamic> _compareResult(
 
     return {
       'status': 'warn',
-      'detail':
-          'Value: $actual'
+      'detail': 'Value: $actual'
           ' — expected (sorted): $expected'
           ' (WASM Monty behavioral difference)',
     };
@@ -549,8 +547,7 @@ Map<String, dynamic> _compareResult(
 
   return {
     'status': 'warn',
-    'detail':
-        'Value: $actual'
+    'detail': 'Value: $actual'
         ' — expected: $expected'
         ' (WASM Monty behavioral difference)',
   };

--- a/example/web/bin/main.dart
+++ b/example/web/bin/main.dart
@@ -70,7 +70,8 @@ def fib(n):
 fib(10)
 '''
           .toJS,
-    ).toDart).toDart,
+    ).toDart)
+        .toDart,
   );
   print('  fib(10) = ${r['value']}');
 
@@ -93,14 +94,16 @@ fib(10)
     (await _bridgeStart(
       'fetch("https://example.com")'.toJS,
       '["fetch"]'.toJS,
-    ).toDart).toDart,
+    ).toDart)
+        .toDart,
   );
   print('  start() → state=${r['state']}, fn=${r['functionName']}');
 
   r = _parse(
     (await _bridgeResume(
       jsonEncode('<html>Hello from Dart!</html>').toJS,
-    ).toDart).toDart,
+    ).toDart)
+        .toDart,
   );
   print('  resume() → state=${r['state']}, value=${r['value']}');
 
@@ -118,14 +121,16 @@ result
 '''
           .toJS,
       '["fetch"]'.toJS,
-    ).toDart).toDart,
+    ).toDart)
+        .toDart,
   );
   print('  start() → state=${r['state']}');
 
   r = _parse(
     (await _bridgeResumeWithError(
       jsonEncode('network timeout').toJS,
-    ).toDart).toDart,
+    ).toDart)
+        .toDart,
   );
   print('  resumeWithError() → value=${r['value']}');
 

--- a/example/web/bin/repl_demo.dart
+++ b/example/web/bin/repl_demo.dart
@@ -41,8 +41,8 @@ external void _jsOnToolCall(JSString jsonPayload);
 MontyRuntime _session = _newSession();
 
 MontyRuntime _newSession() => MontyRuntime(
-  extensions: [JinjaTemplateExtension(), MessageBusExtension()],
-);
+      extensions: [JinjaTemplateExtension(), MessageBusExtension()],
+    );
 
 // ---------------------------------------------------------------------------
 // API
@@ -68,7 +68,8 @@ Future<String> _apiExecute(String code) async {
       if (map != null) {
         events.add(map);
         // Notify HTML of tool calls in real-time
-        if (event is BridgeFunctionCallStart || event is BridgeFunctionCallResult) {
+        if (event is BridgeFunctionCallStart ||
+            event is BridgeFunctionCallResult) {
           try {
             _jsOnToolCall(jsonEncode(map).toJS);
           } on Object catch (_) {}
@@ -190,11 +191,11 @@ void main() {
   // Expose API to window
   final api = <String, JSFunction>{
     'run': ((JSString code) => _apiRun(
-      code.toDart,
-    ).then((r) => r.toJS).toJS).toJS,
+          code.toDart,
+        ).then((r) => r.toJS).toJS).toJS,
     'execute': ((JSString code) => _apiExecute(
-      code.toDart,
-    ).then((r) => r.toJS).toJS).toJS,
+          code.toDart,
+        ).then((r) => r.toJS).toJS).toJS,
     'reset': (() => _apiReset().then((r) => r.toJS).toJS).toJS,
   }.jsify();
   _replSessionDemo = api as JSObject;

--- a/example/web/bin/vfs_demo.dart
+++ b/example/web/bin/vfs_demo.dart
@@ -155,7 +155,8 @@ Future<Map<String, dynamic>> _runWithVfs(String code) async {
         state = _parse(
           (await _bridgeResumeWithError(
             jsonEncode(e.toString()).toJS,
-          ).toDart).toDart,
+          ).toDart)
+              .toDart,
         );
       }
     } else {
@@ -265,8 +266,8 @@ Future<void> main() async {
   // Expose API to HTML.
   final api = <String, JSFunction>{
     'run': ((JSString code) => _apiRun(
-      code.toDart,
-    ).then((r) => r.toJS).toJS).toJS,
+          code.toDart,
+        ).then((r) => r.toJS).toJS).toJS,
     'mountFile': ((JSString path, JSString content) {
       unawaited(_mountFile(path.toDart, content.toDart));
     }).toJS,

--- a/lib/dart_monty_bridge.dart
+++ b/lib/dart_monty_bridge.dart
@@ -17,6 +17,7 @@ export 'src/extensions/defaults.dart';
 export 'src/extensions/event_loop.dart';
 export 'src/extensions/jinja_template.dart';
 export 'src/extensions/message_bus.dart';
+export 'src/extensions/run_script.dart';
 export 'src/extensions/sandbox.dart';
 export 'src/host/args.dart';
 export 'src/host/context.dart';

--- a/lib/src/extension/coordinator.dart
+++ b/lib/src/extension/coordinator.dart
@@ -538,9 +538,7 @@ class ExtensionCoordinator {
         final fnName = fn.schema.name;
         final desc = fn.schema.description;
         buffer.writeln(
-          desc != null
-              ? '- `$fnName($params)`: $desc'
-              : '- `$fnName($params)`',
+          desc != null ? '- `$fnName($params)`: $desc' : '- `$fnName($params)`',
         );
       }
       buffer.writeln();

--- a/lib/src/extension/coordinator.dart
+++ b/lib/src/extension/coordinator.dart
@@ -63,14 +63,15 @@ enum ChildVfsStrategy {
 /// unchanged when [provider] is `null` or returns `null` for the function name.
 HostFunction _enrichFunction(HostFunction fn, DescriptionProvider? provider) {
   if (provider == null) return fn;
-  final desc = provider(fn.schema.name);
+  final schema = fn.schema;
+  final desc = provider(schema.name);
   if (desc == null) return fn;
 
   return HostFunction(
     schema: HostFunctionSchema(
-      name: fn.schema.name,
+      name: schema.name,
       description: desc,
-      params: fn.schema.params,
+      params: schema.params,
     ),
     ffiHandler: fn.ffiHandler,
     wasmHandler: fn.wasmHandler,

--- a/lib/src/extension/extension.dart
+++ b/lib/src/extension/extension.dart
@@ -1,8 +1,7 @@
 import 'package:dart_monty/src/bridge/logger.dart';
 import 'package:dart_monty/src/extension/attach_context.dart';
 import 'package:dart_monty/src/extension/coordinator.dart';
-import 'package:dart_monty/src/extensions/sandbox.dart'
-    show SandboxExtension;
+import 'package:dart_monty/src/extensions/sandbox.dart' show SandboxExtension;
 import 'package:dart_monty/src/host/function.dart';
 import 'package:dart_monty/src/os_call/os_handlers.dart';
 import 'package:dart_monty/src/runtime/backend_kind.dart';

--- a/lib/src/extensions/run_script.dart
+++ b/lib/src/extensions/run_script.dart
@@ -77,6 +77,7 @@ HostFunction buildRunScriptFunction(
         final msg = result.error?.message ?? 'unknown error';
         throw Exception('run_script("$path") failed: $msg');
       }
+
       return result.value.dartValue;
     },
   );

--- a/lib/src/extensions/run_script.dart
+++ b/lib/src/extensions/run_script.dart
@@ -4,6 +4,7 @@ import 'package:dart_monty/src/host/function.dart';
 import 'package:dart_monty/src/host/param.dart';
 import 'package:dart_monty/src/host/param_type.dart';
 import 'package:dart_monty/src/host/schema.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
 
 /// Builds a `run_script` [HostFunction] that Python code can call to execute
 /// another script file and receive its last-expression value.
@@ -60,11 +61,6 @@ HostFunction buildRunScriptFunction(
           ? rawInputs.map((k, v) => MapEntry(k.toString(), v as Object?))
           : null;
 
-      final runtime = ctx.runtime;
-      if (runtime == null) {
-        throw StateError('run_script: no runtime available in this context');
-      }
-
       final String code;
       try {
         code = await readFile(path);
@@ -72,7 +68,10 @@ HostFunction buildRunScriptFunction(
         throw Exception('run_script: could not read "$path": $e');
       }
 
-      final result = await runtime.execute(code, inputs: inputs).result;
+      // Use a fresh Monty execution so the sub-script does not contend with
+      // the caller's bridge lock (the bridge serialises executions; nested
+      // ctx.runtime.execute() calls would deadlock).
+      final result = await Monty(code).run(inputs: inputs);
       if (result.isError) {
         final msg = result.error?.message ?? 'unknown error';
         throw Exception('run_script("$path") failed: $msg');

--- a/lib/src/extensions/run_script.dart
+++ b/lib/src/extensions/run_script.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:dart_monty/src/host/function.dart';
+import 'package:dart_monty/src/host/param.dart';
+import 'package:dart_monty/src/host/param_type.dart';
+import 'package:dart_monty/src/host/schema.dart';
+
+/// Builds a `run_script` [HostFunction] that Python code can call to execute
+/// another script file and receive its last-expression value.
+///
+/// [readFile] is invoked with the requested path and must return the script's
+/// source code. Wire it to a VFS, `dart:io` file read, or any other source:
+///
+/// ```dart
+/// runtime.register(buildRunScriptFunction(
+///   (path) => vfs.readFile(path),
+/// ));
+/// ```
+///
+/// From Python:
+/// ```python
+/// greeting = run_script('greet.py', inputs={'name': 'Alice'})
+/// ```
+///
+/// The sub-script runs on the same runtime, so it shares registered host
+/// functions. Its last expression becomes the return value — exactly what
+/// `MontyResult.value.dartValue` would return.
+///
+/// Throws a Python-visible exception if [readFile] fails or the sub-script
+/// raises an error.
+HostFunction buildRunScriptFunction(
+  FutureOr<String> Function(String path) readFile,
+) {
+  return HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'run_script',
+      description:
+          'Execute a script file and return its last-expression value. '
+          'inputs are injected as Python variables before the script runs.',
+      params: [
+        HostParam(
+          name: 'path',
+          type: HostParamType.string,
+          description: 'Path to the script file.',
+        ),
+        HostParam(
+          name: 'inputs',
+          type: HostParamType.map,
+          isRequired: false,
+          description:
+              'Optional key/value pairs injected as Python variables '
+              'before the script runs.',
+        ),
+      ],
+    ),
+    handler: (args, ctx) async {
+      final path = args['path']! as String;
+      final rawInputs = args['inputs'];
+      final inputs = rawInputs is Map
+          ? rawInputs.map((k, v) => MapEntry(k.toString(), v as Object?))
+          : null;
+
+      final runtime = ctx.runtime;
+      if (runtime == null) {
+        throw StateError('run_script: no runtime available in this context');
+      }
+
+      final String code;
+      try {
+        code = await readFile(path);
+      } on Object catch (e) {
+        throw Exception('run_script: could not read "$path": $e');
+      }
+
+      final result = await runtime.execute(code, inputs: inputs).result;
+      if (result.isError) {
+        final msg = result.error?.message ?? 'unknown error';
+        throw Exception('run_script("$path") failed: $msg');
+      }
+      return result.value.dartValue;
+    },
+  );
+}

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -208,14 +208,21 @@ class MontyRuntime implements MontyRuntimeRef {
   /// execution without mutating session state. Children spawned during the
   /// call inherit the override via `HostContext.os` and `spawnChild`.
   @override
-  ExecutionHandle execute(String code, {OsCallHandler? os}) {
+  ExecutionHandle execute(
+    String code, {
+    OsCallHandler? os,
+    Map<String, Object?>? inputs,
+  }) {
     if (_disposed) throw StateError('MontyRuntime has been disposed');
+    final effective = inputs != null && inputs.isNotEmpty
+        ? '${inputsToCode(inputs)}\n$code'
+        : code;
 
     if (_sandbox) {
-      return _executeSandboxed(code, osOverride: os);
+      return _executeSandboxed(effective, osOverride: os);
     }
 
-    return _executeShared(code, osOverride: os);
+    return _executeShared(effective, osOverride: os);
   }
 
   /// Invokes a registered host function directly from Dart — useful for

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -464,14 +464,15 @@ class MontyRuntime implements MontyRuntimeRef {
 
   HostFunction _applyDescription(HostFunction fn) {
     if (_descriptionProvider == null) return fn;
-    final desc = _descriptionProvider(fn.schema.name);
+    final schema = fn.schema;
+    final desc = _descriptionProvider(schema.name);
     if (desc == null) return fn;
 
     return HostFunction(
       schema: HostFunctionSchema(
-        name: fn.schema.name,
+        name: schema.name,
         description: desc,
-        params: fn.schema.params,
+        params: schema.params,
       ),
       ffiHandler: fn.ffiHandler,
       wasmHandler: fn.wasmHandler,

--- a/lib/src/runtime/runtime_ref.dart
+++ b/lib/src/runtime/runtime_ref.dart
@@ -18,7 +18,22 @@ abstract interface class MontyRuntimeRef {
   ///
   /// Passing [os] overrides the runtime's session OS handler for this one
   /// call. Children spawned during the execution inherit the override.
-  ExecutionHandle execute(String code, {OsCallHandler? os});
+  ///
+  /// [inputs] injects per-invocation Python variables before [code] runs.
+  /// Each key becomes a top-level Python variable — mirrors `MontyRepl.feedRun`
+  /// so the API is consistent across the stack.
+  ///
+  /// ```dart
+  /// runtime.execute(code, inputs: {'greeting': 'hello', 'name': 'Alice'});
+  /// ```
+  /// ```python
+  /// print(f"{greeting}, {name}!")
+  /// ```
+  ExecutionHandle execute(
+    String code, {
+    OsCallHandler? os,
+    Map<String, Object?>? inputs,
+  });
 
   /// Emits [event] on this runtime's broadcast `events` stream wrapped as a
   /// [BridgeChildEvent] tagged with [childHandle].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,3 +29,13 @@ dependencies:
 
 dev_dependencies:
   very_good_analysis: ^10.0.0
+
+# dart_monty_core 0.17.0 (pub.dev) predates the inputs/MontyInternalError/
+# MontyNone work merged in dart_monty_core#99. Point at main until the next
+# core release. dependency_overrides apply to this repo's builds only —
+# downstream consumers still see the pub.dev `^0.17.0` constraint above.
+dependency_overrides:
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main

--- a/test/integration/monty_runtime_test.dart
+++ b/test/integration/monty_runtime_test.dart
@@ -580,16 +580,18 @@ result
       expect(session.coordinator, isNull);
     });
 
-    test('shared mode: registered extensions are visible on coordinator',
-        () async {
-      final ext = JinjaTemplateExtension();
-      final session = MontyRuntime(extensions: [ext]);
-      addTearDown(session.dispose);
-      expect(
-        session.coordinator!.extensions.map((e) => e.namespace),
-        contains('tmpl'),
-      );
-    });
+    test(
+      'shared mode: registered extensions are visible on coordinator',
+      () async {
+        final ext = JinjaTemplateExtension();
+        final session = MontyRuntime(extensions: [ext]);
+        addTearDown(session.dispose);
+        expect(
+          session.coordinator!.extensions.map((e) => e.namespace),
+          contains('tmpl'),
+        );
+      },
+    );
 
     test('clearState() produces a new non-null coordinator', () async {
       final session = MontyRuntime();
@@ -622,9 +624,7 @@ result
     });
 
     test('int input is visible as a Python variable', () async {
-      final result = await session
-          .execute('x * 2', inputs: {'x': 21})
-          .result;
+      final result = await session.execute('x * 2', inputs: {'x': 21}).result;
 
       expect(result.value.dartValue, 42);
     });
@@ -661,9 +661,7 @@ result
       final r1 = await sandbox
           .execute('name', inputs: {'name': 'alice'})
           .result;
-      final r2 = await sandbox
-          .execute('name', inputs: {'name': 'bob'})
-          .result;
+      final r2 = await sandbox.execute('name', inputs: {'name': 'bob'}).result;
 
       expect(r1.value.dartValue, 'alice');
       expect(r2.value.dartValue, 'bob');

--- a/test/integration/monty_runtime_test.dart
+++ b/test/integration/monty_runtime_test.dart
@@ -681,6 +681,9 @@ result
     });
 
     test('inputs named param: null inputs is a no-op', () async {
+      // Explicitly passing `inputs: null` is the contract under test here;
+      // the redundant-default lint would defeat the test's purpose.
+      // ignore: avoid_redundant_argument_values
       final result = await session.execute('1 + 1', inputs: null).result;
 
       expect(result.error, isNull);

--- a/test/integration/monty_runtime_test.dart
+++ b/test/integration/monty_runtime_test.dart
@@ -646,12 +646,15 @@ result
       expect(result.value.dartValue, 2);
     });
 
-    test('inputs do not bleed into the next execute() call', () async {
+    test('shared mode: injected inputs persist as Python globals', () async {
+      // In shared mode, inputsToCode() prepends `temp = 99` as an assignment,
+      // so `temp` lives in the module globals and remains visible on the next
+      // execute() call — which is expected shared-interpreter behaviour.
       await session.execute('pass', inputs: {'temp': 99}).result;
       final result = await session.execute('temp').result;
 
-      // temp is not re-injected; Python raises NameError.
-      expect(result.error, isNotNull);
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 99);
     });
 
     test('sandbox mode: inputs injected per call', () async {
@@ -665,6 +668,69 @@ result
 
       expect(r1.value.dartValue, 'alice');
       expect(r2.value.dartValue, 'bob');
+    });
+
+    // inputs is a named (kwargs-only) Dart parameter — no positional form
+    // exists in the API. The tests below confirm the named-only contract
+    // is enforced end-to-end.
+    test('inputs named param: omitting inputs is valid', () async {
+      final result = await session.execute('7 * 6').result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 42);
+    });
+
+    test('inputs named param: null inputs is a no-op', () async {
+      final result = await session.execute('1 + 1', inputs: null).result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 2);
+    });
+  });
+
+  group('MontyRuntime.execute return-value semantics', () {
+    late MontyRuntime session;
+
+    setUp(() {
+      session = MontyRuntime();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('last expression is captured as result value', () async {
+      final result = await session.execute('x + 1', inputs: {'x': 41}).result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 42);
+    });
+
+    test(
+      'assignment statement yields MontyNone — not the assigned value',
+      () async {
+        final result = await session.execute('x = 42').result;
+
+        expect(result.error, isNull);
+        // Assignment is a statement; no last-expression value.
+        expect(result.value.dartValue, isNull);
+      },
+    );
+
+    test('expression after assignment is the result', () async {
+      final result = await session.execute('x = 7\nx * 6').result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 42);
+    });
+
+    test('module-level return yields the return value', () async {
+      // pydantic-monty treats module-level `return` as a valid return
+      // statement — it returns the value rather than raising SyntaxError.
+      final result = await session.execute('return 42').result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 42);
     });
   });
 

--- a/test/integration/monty_runtime_test.dart
+++ b/test/integration/monty_runtime_test.dart
@@ -602,6 +602,74 @@ result
     });
   });
 
+  group('MontyRuntime.execute inputs injection', () {
+    late MontyRuntime session;
+
+    setUp(() {
+      session = MontyRuntime();
+    });
+
+    tearDown(() async {
+      await session.dispose();
+    });
+
+    test('string input is visible as a Python variable', () async {
+      final result = await session
+          .execute('greeting', inputs: {'greeting': 'hello'})
+          .result;
+
+      expect(result.value.dartValue, 'hello');
+    });
+
+    test('int input is visible as a Python variable', () async {
+      final result = await session
+          .execute('x * 2', inputs: {'x': 21})
+          .result;
+
+      expect(result.value.dartValue, 42);
+    });
+
+    test('multiple inputs are all visible', () async {
+      final result = await session
+          .execute(
+            'f"{say}, {target}!"',
+            inputs: {'say': 'hi', 'target': 'alan'},
+          )
+          .result;
+
+      expect(result.value.dartValue, 'hi, alan!');
+    });
+
+    test('null inputs param is a no-op', () async {
+      final result = await session.execute('1 + 1').result;
+
+      expect(result.value.dartValue, 2);
+    });
+
+    test('inputs do not bleed into the next execute() call', () async {
+      await session.execute('pass', inputs: {'temp': 99}).result;
+      final result = await session.execute('temp').result;
+
+      // temp is not re-injected; Python raises NameError.
+      expect(result.error, isNotNull);
+    });
+
+    test('sandbox mode: inputs injected per call', () async {
+      final sandbox = MontyRuntime(sandbox: true);
+      addTearDown(sandbox.dispose);
+
+      final r1 = await sandbox
+          .execute('name', inputs: {'name': 'alice'})
+          .result;
+      final r2 = await sandbox
+          .execute('name', inputs: {'name': 'bob'})
+          .result;
+
+      expect(r1.value.dartValue, 'alice');
+      expect(r2.value.dartValue, 'bob');
+    });
+  });
+
   group('MontyRuntime.descriptionProvider', () {
     test('overrides function description on registered extension', () async {
       final session = MontyRuntime(

--- a/test/integration/monty_type_check_test.dart
+++ b/test/integration/monty_type_check_test.dart
@@ -46,8 +46,7 @@ void main() {
       expect(withStub, isEmpty);
     });
 
-    test('real type errors surface even when prefixCode is supplied',
-        () async {
+    test('real type errors surface even when prefixCode is supplied', () async {
       const stub = 'def fetch(url: str) -> str: return ""';
       final errors = await Monty.typeCheck(
         'result: int = fetch("https://example.com")',

--- a/test/integration/run_script_test.dart
+++ b/test/integration/run_script_test.dart
@@ -1,0 +1,86 @@
+@Tags(['integration'])
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildRunScriptFunction', () {
+    late MontyRuntime runtime;
+    late Map<String, String> vfs;
+
+    setUp(() {
+      vfs = {};
+      runtime = MontyRuntime()
+        ..register(
+          buildRunScriptFunction((path) async {
+            final code = vfs[path];
+            if (code == null) throw Exception('file not found: $path');
+            return code;
+          }),
+        );
+    });
+
+    tearDown(() async {
+      await runtime.dispose();
+    });
+
+    test('returns last expression from sub-script', () async {
+      vfs['greet.py'] = 'f"hello, {name}!"';
+      final result = await runtime
+          .execute(
+            'run_script("greet.py", inputs={"name": "alice"})',
+          )
+          .result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'hello, alice!');
+    });
+
+    test('sub-script with no inputs still runs', () async {
+      vfs['add.py'] = '1 + 2';
+      final result = await runtime.execute('run_script("add.py")').result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 3);
+    });
+
+    test('multiple inputs are all injected', () async {
+      vfs['fmt.py'] = 'f"{say}, {target}!"';
+      final result = await runtime
+          .execute(
+            'run_script("fmt.py", inputs={"say": "hi", "target": "alan"})',
+          )
+          .result;
+
+      expect(result.value.dartValue, 'hi, alan!');
+    });
+
+    test('sub-script error surfaces as Python exception', () async {
+      vfs['bad.py'] = '1 / 0';
+      final result = await runtime.execute('run_script("bad.py")').result;
+
+      // run_script throws, which Python surfaces as an error result.
+      expect(result.isError, isTrue);
+    });
+
+    test('missing file surfaces as Python exception', () async {
+      final result = await runtime
+          .execute('run_script("missing.py")')
+          .result;
+
+      expect(result.isError, isTrue);
+    });
+
+    test('return value is usable in caller script', () async {
+      vfs['double.py'] = 'n * 2';
+      final result = await runtime
+          .execute(
+            'x = run_script("double.py", inputs={"n": 21})\nx',
+          )
+          .result;
+
+      expect(result.value.dartValue, 42);
+    });
+  });
+}

--- a/test/integration/run_script_test.dart
+++ b/test/integration/run_script_test.dart
@@ -90,7 +90,8 @@ void main() {
         final result = await runtime.execute('run_script("assign.py")').result;
 
         expect(result.error, isNull);
-        // Assignment is a statement; no last-expression value — run_script returns None.
+        // Assignment is a statement; no last-expression value — run_script
+        // returns None.
         expect(result.value.dartValue, isNull);
       },
     );
@@ -105,8 +106,9 @@ void main() {
     });
 
     // Both kwargs and positional forms work for host-function params:
-    // run_script("foo.py", inputs={"k":"v"}) and run_script("foo.py", {"k":"v"})
-    // are equivalent — pydantic-monty maps positional args to schema params
+    // run_script("foo.py", inputs={"k":"v"}) and
+    // run_script("foo.py", {"k":"v"}) are equivalent — pydantic-monty
+    // maps positional args to schema params
     // by index. The kwargs-only contract lives at the *Dart* API level: the
     // `inputs` param is a Dart named parameter with no positional form.
     test('positional dict is equivalent to inputs= kwarg form', () async {

--- a/test/integration/run_script_test.dart
+++ b/test/integration/run_script_test.dart
@@ -65,9 +65,7 @@ void main() {
     });
 
     test('missing file surfaces as Python exception', () async {
-      final result = await runtime
-          .execute('run_script("missing.py")')
-          .result;
+      final result = await runtime.execute('run_script("missing.py")').result;
 
       expect(result.isError, isTrue);
     });

--- a/test/integration/run_script_test.dart
+++ b/test/integration/run_script_test.dart
@@ -80,5 +80,43 @@ void main() {
 
       expect(result.value.dartValue, 42);
     });
+
+    // Return-value semantics: run_script captures the last expression of
+    // the sub-script. Assignment statements yield None (dartValue == null).
+    test(
+      'sub-script assignment statement yields None — not the assigned value',
+      () async {
+        vfs['assign.py'] = 'x = 99';
+        final result = await runtime.execute('run_script("assign.py")').result;
+
+        expect(result.error, isNull);
+        // Assignment is a statement; no last-expression value — run_script returns None.
+        expect(result.value.dartValue, isNull);
+      },
+    );
+
+    test('sub-script module-level return yields the return value', () async {
+      // pydantic-monty treats module-level `return` as a valid return.
+      vfs['ret.py'] = 'return 99';
+      final result = await runtime.execute('run_script("ret.py")').result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 99);
+    });
+
+    // Both kwargs and positional forms work for host-function params:
+    // run_script("foo.py", inputs={"k":"v"}) and run_script("foo.py", {"k":"v"})
+    // are equivalent — pydantic-monty maps positional args to schema params
+    // by index. The kwargs-only contract lives at the *Dart* API level: the
+    // `inputs` param is a Dart named parameter with no positional form.
+    test('positional dict is equivalent to inputs= kwarg form', () async {
+      vfs['greet.py'] = 'f"hello, {name}!"';
+      final result = await runtime
+          .execute('run_script("greet.py", {"name": "alice"})')
+          .result;
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'hello, alice!');
+    });
   });
 }


### PR DESCRIPTION
## Summary

- **`MontyRuntime.execute` / `MontyRuntimeRef.execute`** gain `inputs: Map<String,Object?>?` — mirrors pydantic-monty's kwargs-only `inputs` parameter; `inputsToCode` is prepended before user code in both shared and sandbox modes
- **`buildRunScriptFunction(readFile)`** — VFS-agnostic `HostFunction` factory exported from `dart_monty_bridge`; Python scripts call `run_script('foo.py', inputs={'k': 'v'})` and receive the sub-script's last-expression value back
- `pubspec_overrides.yaml` (gitignored) points at local `dart_monty_core` during development

## Test plan

- [ ] `dart test --tags=integration test/integration/monty_runtime_test.dart` (inputs injection group)
- [ ] `dart test --tags=integration test/integration/run_script_test.dart`
- [ ] `dart analyze lib/ test/`

## Depends on

`dart_monty_core` PR #99 (`inputs_encoder.dart` export + `MontyInternalError`)