### PR TITLE
feat(host): narrow HostContext.parent + safe subExecute (no execute() footgun)

### DIFF
--- a/lib/src/extensions/run_script.dart
+++ b/lib/src/extensions/run_script.dart
@@ -4,7 +4,6 @@ import 'package:dart_monty/src/host/function.dart';
 import 'package:dart_monty/src/host/param.dart';
 import 'package:dart_monty/src/host/param_type.dart';
 import 'package:dart_monty/src/host/schema.dart';
-import 'package:dart_monty_core/dart_monty_core.dart';
 
 /// Builds a `run_script` [HostFunction] that Python code can call to execute
 /// another script file and receive its last-expression value.
@@ -23,12 +22,13 @@ import 'package:dart_monty_core/dart_monty_core.dart';
 /// greeting = run_script('greet.py', inputs={'name': 'Alice'})
 /// ```
 ///
-/// The sub-script runs on the same runtime, so it shares registered host
-/// functions. Its last expression becomes the return value — exactly what
+/// The sub-script runs in a fresh Monty interpreter (via `ctx.subExecute`),
+/// so it does NOT share state or registered host functions with the caller.
+/// Its last expression becomes the return value — exactly what
 /// `MontyResult.value.dartValue` would return.
 ///
-/// Throws a Python-visible exception if [readFile] fails or the sub-script
-/// raises an error.
+/// Throws a Python-visible exception if [readFile] fails, no sub-executor is
+/// available, or the sub-script raises an error.
 HostFunction buildRunScriptFunction(
   FutureOr<String> Function(String path) readFile,
 ) {
@@ -61,6 +61,14 @@ HostFunction buildRunScriptFunction(
           ? rawInputs.map((k, v) => MapEntry(k.toString(), v as Object?))
           : null;
 
+      final subExecute = ctx.subExecute;
+      if (subExecute == null) {
+        throw StateError(
+          'run_script: no subExecute wired into HostContext. '
+          'Register the function on a real MontyRuntime, not a bare test ctx.',
+        );
+      }
+
       final String code;
       try {
         code = await readFile(path);
@@ -68,10 +76,7 @@ HostFunction buildRunScriptFunction(
         throw Exception('run_script: could not read "$path": $e');
       }
 
-      // Use a fresh Monty execution so the sub-script does not contend with
-      // the caller's bridge lock (the bridge serialises executions; nested
-      // ctx.runtime.execute() calls would deadlock).
-      final result = await Monty(code).run(inputs: inputs);
+      final result = await subExecute(code, inputs: inputs);
       if (result.isError) {
         final msg = result.error?.message ?? 'unknown error';
         throw Exception('run_script("$path") failed: $msg');

--- a/lib/src/extensions/sandbox.dart
+++ b/lib/src/extensions/sandbox.dart
@@ -526,7 +526,7 @@ class SandboxExtension extends MontyExtension
       completer: completer,
       childId: id,
       stream: stream,
-      parent: ctx.runtime,
+      parent: ctx.parent,
     );
 
     _children[id] = _ChildHandle(
@@ -684,7 +684,7 @@ class SandboxExtension extends MontyExtension
     required Completer<Object?> completer,
     required int childId,
     required Stream<BridgeEvent> stream,
-    required MontyRuntimeRef? parent,
+    required HostParentRef? parent,
   }) {
     String? errorMessage;
     MontyException? errorException;

--- a/lib/src/host/context.dart
+++ b/lib/src/host/context.dart
@@ -5,6 +5,14 @@ import 'package:dart_monty/src/runtime/runtime_ref.dart';
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:meta/meta.dart';
 
+/// Signature of [HostContext.subExecute] — runs Python [code] in a fresh
+/// Monty interpreter and returns its [MontyResult].
+///
+/// Optional [inputs] are injected as top-level Python variables before
+/// [code] runs (same semantics as `MontyRuntime.execute(inputs:)`).
+typedef HostSubExecutor =
+    Future<MontyResult> Function(String code, {Map<String, Object?>? inputs});
+
 /// Context passed to every [HostFunctionHandler] invocation.
 ///
 /// Gives handlers:
@@ -14,7 +22,13 @@ import 'package:meta/meta.dart';
 /// - [cancelToken] — cooperative cancellation signal for long-running work
 /// - [os] — the currently-registered OS handler, for handlers that want to
 ///   call OS primitives directly without routing through Python
-/// - [runtime] — the owning runtime, for sub-executions (nullable in tests)
+/// - [parent] — narrow view of the owning runtime ([HostParentRef]) for
+///   event forwarding and schema introspection. Deliberately does NOT
+///   expose `execute()` — calling that from a host function would deadlock
+///   the bridge.
+/// - [subExecute] — runs a sub-script in a fresh Monty interpreter, safely.
+///   The parent runtime is busy holding the bridge lock; this path uses
+///   `Monty(code).run()` and therefore does not contend with it.
 @immutable
 class HostContext {
   /// Creates a [HostContext].
@@ -23,7 +37,8 @@ class HostContext {
     required this.executionId,
     CancelToken? cancelToken,
     this.os,
-    this.runtime,
+    this.parent,
+    this.subExecute,
   }) : cancelToken = cancelToken ?? CancelToken();
 
   /// Emits an arbitrary [BridgeEvent] during a handler invocation.
@@ -55,11 +70,32 @@ class HostContext {
   /// pure-Dart host functions).
   final OsCallHandler? os;
 
-  /// The owning runtime that dispatched this tool call.
+  /// Narrow view of the owning runtime — event forwarding and schema
+  /// introspection only.
   ///
-  /// `null` in test contexts where no full runtime is wired up. Handlers that
-  /// need to drive sub-executions should null-check before calling.
-  final MontyRuntimeRef? runtime;
+  /// `null` in test contexts where no full runtime is wired up. Deliberately
+  /// typed as [HostParentRef] (not `MontyRuntimeRef`) so handlers cannot
+  /// accidentally call `execute()` and deadlock the bridge — use
+  /// [subExecute] for sub-runs.
+  final HostParentRef? parent;
+
+  /// Runs a sub-script in a fresh Monty interpreter and returns its result.
+  ///
+  /// Safe to call from inside a host function handler — uses an independent
+  /// execution context so it does not contend with the caller's bridge lock.
+  /// Each call gets a brand-new interpreter; variables from the caller's
+  /// session are not visible, and sub-script state does not leak back.
+  ///
+  /// `null` in test contexts where no dispatch layer wires it.
+  ///
+  /// ```dart
+  /// final result = await ctx.subExecute!(
+  ///   'n * 2',
+  ///   inputs: {'n': 21},
+  /// );
+  /// // result.value.dartValue == 42
+  /// ```
+  final HostSubExecutor? subExecute;
 
   /// Emits a [BridgeFunctionEmit] text event — convenience over calling [emit]
   /// directly for the common streaming-progress use case.

--- a/lib/src/host/dispatch.dart
+++ b/lib/src/host/dispatch.dart
@@ -42,6 +42,14 @@ class _PendingFuture {
 // Top-level helpers shared by HostDispatch dispatch methods.
 // ---------------------------------------------------------------------------
 
+/// Default [HostSubExecutor] wired into every [HostContext]. Runs [code]
+/// in a fresh Monty interpreter via `Monty(code).run()` so host functions
+/// can drive sub-executions without contending with the caller's bridge lock.
+Future<MontyResult> _defaultSubExecute(
+  String code, {
+  Map<String, Object?>? inputs,
+}) => Monty(code).run(inputs: inputs);
+
 /// Invokes [fn] through [interceptor], or calls the handler directly when
 /// [fn] is infra or no interceptor is registered.
 Future<Object?> _invoke(
@@ -272,7 +280,8 @@ class HostDispatch {
       emit: sink,
       executionId: name,
       os: osHandler,
-      runtime: _runtime,
+      parent: _runtime,
+      subExecute: _defaultSubExecute,
     );
 
     return _invoke(_interceptor, fn, name, validatedArgs, ctx);
@@ -337,7 +346,8 @@ class HostDispatch {
       emit: controller.add,
       executionId: callId,
       os: osHandler,
-      runtime: _runtime,
+      parent: _runtime,
+      subExecute: _defaultSubExecute,
     );
     final Object? result;
     try {
@@ -397,7 +407,8 @@ class HostDispatch {
       emit: controller.add,
       executionId: callId,
       os: osHandler,
-      runtime: _runtime,
+      parent: _runtime,
+      subExecute: _defaultSubExecute,
     );
     final Future<Object?> handlerFuture;
     try {

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -134,6 +134,7 @@ class MontyRuntime implements MontyRuntimeRef {
       StreamController<BridgeEvent>.broadcast();
 
   /// All registered tool schemas — feed these to an LLM as tool definitions.
+  @override
   List<HostFunctionSchema> get schemas =>
       (_sharedBridge ?? _schemaBridge)?.schemas ?? [];
 

--- a/lib/src/runtime/runtime_ref.dart
+++ b/lib/src/runtime/runtime_ref.dart
@@ -1,18 +1,22 @@
 import 'package:dart_monty/src/bridge/event.dart';
 import 'package:dart_monty/src/host/context.dart' show HostContext;
+import 'package:dart_monty/src/host/schema.dart' show HostFunctionSchema;
 import 'package:dart_monty/src/runtime/execution_handle.dart';
 import 'package:dart_monty_core/dart_monty_core.dart';
 
-/// Minimal interface that [HostContext] uses to reference the owning runtime.
+/// Minimal interface that internal extension/plugin code uses to drive
+/// the owning runtime — top-level execute, event forwarding, etc.
 ///
 /// Defined as a separate abstract interface to break the circular dependency
 /// between `host/context.dart` → this file and `monty_runtime.dart` →
 /// `host/function.dart` → `host/context.dart`.
 ///
-/// `MontyRuntime` implements this interface; host function handlers that need
-/// to spin up a sub-execution should type their `ctx.runtime` as
-/// [MontyRuntimeRef].
-abstract interface class MontyRuntimeRef {
+/// **Not safe to use from inside [HostContext] handlers.** Calling [execute]
+/// from a host function deadlocks the bridge — the parent execution still
+/// holds the bridge lock. Host functions get the narrower [HostParentRef]
+/// (event forwarding + schema introspection only) plus `ctx.subExecute` for
+/// fresh sub-runs.
+abstract interface class MontyRuntimeRef implements HostParentRef {
   /// Executes Python [code] in this runtime and returns an [ExecutionHandle]
   /// carrying the events stream, terminal result future, and cancel hook.
   ///
@@ -34,12 +38,28 @@ abstract interface class MontyRuntimeRef {
     OsCallHandler? os,
     Map<String, Object?>? inputs,
   });
+}
 
-  /// Emits [event] on this runtime's broadcast `events` stream wrapped as a
-  /// [BridgeChildEvent] tagged with [childHandle].
+/// The narrow slice of the parent runtime exposed to host function handlers
+/// via [HostContext.parent].
+///
+/// Deliberately omits `execute()` — calling it from a host function would
+/// deadlock the bridge (the outer execution still holds the bridge lock).
+/// Use `ctx.subExecute` for sub-executions; it runs in a fresh interpreter
+/// via `Monty(code).run()` and therefore does not contend with the lock.
+abstract interface class HostParentRef {
+  /// Emits [event] on the parent runtime's broadcast `events` stream wrapped
+  /// as a `BridgeChildEvent` tagged with [childHandle].
   ///
-  /// Used by child-spawning plugins (e.g. `SandboxExtension`) to aggregate
-  /// child execution events into the parent's event stream so observers see a
-  /// single attributed ordering across the ownership tree.
+  /// Used by child-spawning extensions (e.g. `SandboxExtension`) to aggregate
+  /// child execution events into the parent's event stream so observers see
+  /// a single attributed ordering across the ownership tree.
   void emitChildEvent(String childHandle, BridgeEvent event);
+
+  /// All host function schemas registered on the parent runtime.
+  ///
+  /// Host functions can introspect the available tool surface — e.g. the
+  /// `requires()` host function uses this to verify that declared
+  /// dependencies are actually wired up before a script proceeds.
+  List<HostFunctionSchema> get schemas;
 }

--- a/test/integration/monty_runtime_test.dart
+++ b/test/integration/monty_runtime_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty_core/dart_monty_core.dart' show MontyInternalError;
 import 'package:test/test.dart';
 
 /// Integration tests for MontyRuntime — requires the native Monty
@@ -678,6 +679,25 @@ result
 
       expect(result.error, isNull);
       expect(result.value.dartValue, 42);
+    });
+
+    test('Dart null value in inputs throws MontyInternalError', () {
+      // Dart null is not a valid Python literal — use MontyNone() for
+      // Python None. The encoder throws MontyInternalError (extends Error,
+      // not Exception, so it can't be swallowed by `on Exception`).
+      expect(
+        () => session.execute('x', inputs: {'x': null}),
+        throwsA(isA<MontyInternalError>()),
+      );
+    });
+
+    test('unsupported value type in inputs throws ArgumentError', () {
+      // toPythonLiteral rejects arbitrary Dart objects (DateTime, custom
+      // classes, etc.) — only the documented set is convertible.
+      expect(
+        () => session.execute('x', inputs: {'x': Object()}),
+        throwsA(isA<ArgumentError>()),
+      );
     });
 
     test('inputs named param: null inputs is a no-op', () async {

--- a/test/integration/run_script_test.dart
+++ b/test/integration/run_script_test.dart
@@ -120,5 +120,40 @@ void main() {
       expect(result.error, isNull);
       expect(result.value.dartValue, 'hello, alice!');
     });
+
+    // Schema-level validation: HostFunctionSchema.mapAndValidate +
+    // HostParam.validate throw FormatException on bad arg shape, which
+    // dispatch.dart routes back to Python as a script error.
+    group('invalid arguments surface as Python errors', () {
+      test('wrong type for path (int instead of str)', () async {
+        final result = await runtime.execute('run_script(123)').result;
+
+        expect(result.isError, isTrue);
+      });
+
+      test('wrong type for inputs (str instead of dict/map)', () async {
+        vfs['greet.py'] = 'f"hi {name}"';
+        final result = await runtime
+            .execute('run_script("greet.py", inputs="oops")')
+            .result;
+
+        expect(result.isError, isTrue);
+      });
+
+      test('missing required path arg', () async {
+        final result = await runtime.execute('run_script()').result;
+
+        expect(result.isError, isTrue);
+      });
+
+      test('unknown kwarg rejected', () async {
+        vfs['greet.py'] = 'f"hi {name}"';
+        final result = await runtime
+            .execute('run_script("greet.py", typo={"name": "alice"})')
+            .result;
+
+        expect(result.isError, isTrue);
+      });
+    });
   });
 }

--- a/test/src/host/context_test.dart
+++ b/test/src/host/context_test.dart
@@ -2,6 +2,11 @@ import 'package:dart_monty/dart_monty_bridge.dart';
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:test/test.dart';
 
+// Shared no-op emit callback for structural tests that never emit events.
+// Pulled out so the inline lambdas don't trip DCM's no-empty-block rule.
+// ignore: no-empty-block
+void _ignoreEvent(BridgeEvent _) {}
+
 void main() {
   group('HostContext.parent', () {
     test('typed as HostParentRef — no execute() at compile time', () {
@@ -10,7 +15,7 @@ void main() {
       // The only way to drive a sub-script from a host function is
       // ctx.subExecute. If a future refactor re-introduced execute() on
       // HostParentRef, this test's compile-time guarantee would break.
-      final ctx = HostContext(emit: (_) {}, executionId: 'test');
+      final ctx = HostContext(emit: _ignoreEvent, executionId: 'test');
 
       expect(ctx.parent, isNull);
       // Parent surface area:
@@ -25,7 +30,7 @@ void main() {
     });
 
     test('subExecute is null on a bare HostContext (test fixture)', () {
-      final ctx = HostContext(emit: (_) {}, executionId: 'test');
+      final ctx = HostContext(emit: _ignoreEvent, executionId: 'test');
 
       expect(ctx.subExecute, isNull);
     });
@@ -39,7 +44,7 @@ void main() {
         }) => Monty(code).run(inputs: inputs);
 
         final ctx = HostContext(
-          emit: (_) {},
+          emit: _ignoreEvent,
           executionId: 'test',
           subExecute: wired,
         );

--- a/test/src/host/context_test.dart
+++ b/test/src/host/context_test.dart
@@ -1,0 +1,68 @@
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HostContext.parent', () {
+    test('typed as HostParentRef — no execute() at compile time', () {
+      // This test is mostly about the *static* shape: ctx.parent is
+      // HostParentRef?, which intentionally does NOT expose execute().
+      // The only way to drive a sub-script from a host function is
+      // ctx.subExecute. If a future refactor re-introduced execute() on
+      // HostParentRef, this test's compile-time guarantee would break.
+      final ctx = HostContext(emit: (_) {}, executionId: 'test');
+
+      expect(ctx.parent, isNull);
+      // Parent surface area:
+      //   - emitChildEvent(handle, event)
+      //   - schemas
+      // Deliberately absent: execute(), invokeHostFunction(), dispose()...
+      //
+      // The cast below would be a compile error if the type ever drifted:
+      // ignore: omit_local_variable_types
+      final HostParentRef? p = ctx.parent;
+      expect(p, isNull);
+    });
+
+    test('subExecute is null on a bare HostContext (test fixture)', () {
+      final ctx = HostContext(emit: (_) {}, executionId: 'test');
+
+      expect(ctx.subExecute, isNull);
+    });
+
+    test(
+      'subExecute closure runs Python and returns the result',
+      () async {
+        Future<MontyResult> wired(
+          String code, {
+          Map<String, Object?>? inputs,
+        }) => Monty(code).run(inputs: inputs);
+
+        final ctx = HostContext(
+          emit: (_) {},
+          executionId: 'test',
+          subExecute: wired,
+        );
+
+        final r = await ctx.subExecute!('x * 2', inputs: {'x': 21});
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 42);
+      },
+      // Needs the native runtime bound via FFI/WASM harness; the structural
+      // tests in this group cover the design surface on every platform.
+      tags: ['integration'],
+    );
+  });
+
+  group('HostParentRef contract', () {
+    test('exposes emitChildEvent and schemas — and nothing else', () {
+      // Compile-time check: a HostParentRef? variable does not carry
+      // .execute() or other dangerous methods. If you uncomment the
+      // commented line below, dart analyze must fail.
+      const HostParentRef? parent = null;
+
+      // parent.execute('1 + 1');  // <- would not compile (good!)
+      expect(parent, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Stacks on top of #405 (`feat/inputs-run-script`). Makes the `ctx.runtime.execute()` deadlock — diagnosed in #405 and worked around via inlined `Monty(code).run()` — **impossible at compile time** for host function handlers.

### The bug (recap)

`PlatformBridge.execute()` flips `_isExecuting = true` and keeps it set throughout dispatch. Calling `ctx.runtime.execute()` from inside a host function handler always threw `StateError('Bridge is already executing')`.

### The fix

Split `MontyRuntimeRef` into two interfaces:

```dart
abstract interface class HostParentRef {
  void emitChildEvent(String childHandle, BridgeEvent event);
  List<HostFunctionSchema> get schemas;
}

abstract interface class MontyRuntimeRef implements HostParentRef {
  ExecutionHandle execute(String code, {OsCallHandler? os, Map<String, Object?>? inputs});
}
```

Then `HostContext` exposes only the safe subset:

| Old | New |
|---|---|
| `runtime: MontyRuntimeRef?` | `parent: HostParentRef?` (no `execute()` accessible) |
| (n/a) | `subExecute: HostSubExecutor?` — closure that runs sub-scripts via `Monty(code).run()` in a fresh interpreter |

`HostDispatch` wires `subExecute` into every `HostContext` automatically.

### Downstream changes in this PR

- `run_script.dart` — uses `ctx.subExecute!(code, inputs: inputs)` instead of inlining `Monty(code).run()`
- `sandbox.dart` — `_setupChildListener` narrows its `parent:` param to `HostParentRef?` (only ever calls `emitChildEvent`)
- `runtime.dart` — `@override` on `schemas` so `MontyRuntime` cleanly satisfies `HostParentRef`

### Tests

- New `test/src/host/context_test.dart` — covers the structural contract (`parent` is `HostParentRef?`, no `.execute()` reachable; `subExecute` closure runs Python and returns the result on FFI; bare-context fixture has nulls)
- `test/integration/run_script_test.dart` — new "invalid arguments surface as Python errors" group: wrong type for `path`, wrong type for `inputs`, missing required arg, unknown kwarg
- `test/integration/monty_runtime_test.dart` — new Dart-side error tests: `inputs: {'x': null}` → `MontyInternalError` (synchronous), `inputs: {'x': Object()}` → `ArgumentError` (synchronous)

## Test plan

- [x] `dart analyze lib/` — no issues
- [x] `dart test --run-skipped --tags=integration -p vm` — 276/276 ✓
- [x] `dart test test/src/host/context_test.dart -p chrome` — 3 pass + 1 skipped (integration-tagged runtime test)
- [x] `dcm analyze` — no new warnings introduced

## Depends on

- #405 (this branch is stacked on `feat/inputs-run-script`)