### PR TITLE
docs: cover inputs:, run_script, and HostContext.parent/subExecute

### DIFF
--- a/docs/tutorials/host-functions-intermediate.md
+++ b/docs/tutorials/host-functions-intermediate.md
@@ -144,7 +144,27 @@ session.execute(script);
 ext.dispatch({'action': 'quit'});
 ```
 
+## What's on `ctx`
+
+Every handler signature is `(args, ctx) async`. `ctx` is a `HostContext`
+exposing the platform plumbing your handler may need:
+
+| Field | Purpose |
+|-------|---------|
+| `emit(BridgeEvent)` / `emitText(String)` | Push events into the execution stream — progress, intermediate results, custom events |
+| `executionId` | Unique ID for this tool call; correlate with `BridgeFunctionEmit` and other per-call events |
+| `cancelToken` | Cooperative cancellation signal — race long-running work against `cancelToken.future` to bail when `ExecutionHandle.cancel()` fires |
+| `os` | Currently-registered `OsCallHandler`, for handlers that want to invoke OS primitives directly without routing through Python |
+| `parent` | Narrow `HostParentRef?` view of the owning runtime — `emitChildEvent` for child-spawning extensions, `schemas` for tool introspection. Deliberately **does not** expose `execute()` (that would deadlock the bridge). |
+| `subExecute` | Closure that runs a sub-script in a fresh Monty interpreter. Use when you need to drive another Python execution from inside your handler — see [Inputs, run_script, and Sub-Execution](inputs-and-sub-scripts.md). |
+
+The `parent` / `subExecute` split is intentional: nested
+`execute()` on the same bridge would always deadlock (`_isExecuting`
+stays true through dispatch), so the API offers `subExecute` for the
+safe path and a narrower `HostParentRef` for everything else.
+
 ## Next Steps
 
 The [Advanced guide](host-functions-advanced.md) covers deep-dives into
-`SandboxExtension` and complex production patterns.
+`SandboxExtension` and complex production patterns. For sub-scripting,
+see [Inputs, `run_script`, and Sub-Execution](inputs-and-sub-scripts.md).

--- a/docs/tutorials/inputs-and-sub-scripts.md
+++ b/docs/tutorials/inputs-and-sub-scripts.md
@@ -33,8 +33,8 @@ final r = await runtime
 // r.value.dartValue == 'hello, Alice!'
 ```
 
-The same parameter is on `Hhg.run(code, inputs: …)` and on
-`buildRunScriptFunction`'s sub-script invocation.
+The same parameter rides through `buildRunScriptFunction`'s sub-script
+invocation and through `HostContext.subExecute`.
 
 ### Convertible types
 

--- a/docs/tutorials/inputs-and-sub-scripts.md
+++ b/docs/tutorials/inputs-and-sub-scripts.md
@@ -1,0 +1,253 @@
+# Inputs, `run_script`, and Sub-Execution
+
+This guide covers three closely-related features:
+
+1. **`inputs:`** — inject per-call Python variables before code runs.
+2. **`run_script`** — call another script from Python and receive its
+   last-expression value.
+3. **`HostContext.subExecute`** — drive sub-executions from your own
+   host functions, safely.
+
+All three were introduced together because they solve the same problem
+from different angles: how to compose multiple Monty executions when
+the bridge serialises one run at a time.
+
+**Prerequisites:** [Host Functions — Intermediate](host-functions-intermediate.md).
+
+---
+
+## `inputs:` — per-call variable injection
+
+`MontyRuntime.execute` takes an optional `Map<String, Object?> inputs`.
+Each entry is converted to a Python literal and prepended to the code
+as an assignment statement, so the value lands as a top-level Python
+name *before* user code runs:
+
+```dart
+final r = await runtime
+    .execute('f"{greeting}, {name}!"', inputs: {
+      'greeting': 'hello',
+      'name': 'Alice',
+    })
+    .result;
+// r.value.dartValue == 'hello, Alice!'
+```
+
+The same parameter is on `Hhg.run(code, inputs: …)` and on
+`buildRunScriptFunction`'s sub-script invocation.
+
+### Convertible types
+
+`bool`, `int`, `double` (incl. `nan` / `inf`), `String`, `List`, `Map`,
+and `MontyNone()`. Lists and maps are converted recursively.
+
+### Two distinct error mechanisms
+
+Both are **synchronous** — the script never starts when the encoder
+rejects an input.
+
+| Bad input | Throws | Why |
+|---|---|---|
+| Dart `null` value | `MontyInternalError` | Use `MontyNone()` for Python `None`. `MontyInternalError` extends `Error` (not `Exception`), so it can't be silently swallowed by `on Exception` handlers. |
+| Unsupported type (`DateTime`, custom class, etc.) | `ArgumentError` | Convert to a supported type first. |
+
+```dart
+runtime.execute('x', inputs: {'x': null});           // → MontyInternalError
+runtime.execute('x', inputs: {'x': DateTime.now()}); // → ArgumentError
+runtime.execute('x is None', inputs: {'x': const MontyNone()}); // OK
+```
+
+### Shared mode persistence
+
+In shared mode (the default), injected names land in the Python
+interpreter's globals — so they persist into subsequent calls on the
+same runtime. Sandbox mode (`MontyRuntime(sandbox: true)`) starts each
+call from a fresh interpreter, so injected names disappear after the
+call returns.
+
+---
+
+## `run_script` — call another script from Python
+
+`buildRunScriptFunction(readFile)` builds a `HostFunction` that lets
+Python execute another script file by path:
+
+```dart
+final vfs = <String, String>{
+  'greet.py': 'f"hello, {name}!"',
+  'double.py': 'n * 2',
+};
+
+final runtime = MontyRuntime()
+  ..register(buildRunScriptFunction((path) async {
+    final code = vfs[path];
+    if (code == null) throw Exception('file not found: $path');
+    return code;
+  }));
+```
+
+From Python:
+
+```python
+greeting = run_script('greet.py', inputs={'name': 'Alice'})
+# 'hello, Alice!'
+
+doubled = run_script('double.py', inputs={'n': 21})
+# 42
+```
+
+The `readFile` callback is your wiring — point it at a `dart:io` read,
+a VFS, an HTTP fetch, or whatever script source you have. It runs
+synchronously from Python's perspective; awaitable Dart work in
+`readFile` is fine.
+
+### Return-value semantics
+
+`run_script` returns whatever the sub-script's last expression
+evaluates to:
+
+| Sub-script content | `run_script(...)` returns |
+|---|---|
+| `n * 2` (last-expression) | the value (`42`) |
+| `x = 99` (statement only) | `None` |
+| `x = 7\nx * 6` (statement, then expression) | the expression value (`42`) |
+| `return 42` at module level | the return value (`42`) — pydantic-monty allows it |
+| Sub-script raises | the host function raises in Python; `result.isError == true` |
+
+### Argument shape
+
+`run_script` itself is just a host function with two params:
+
+| Param | Type | Required |
+|---|---|---|
+| `path` | `string` | yes |
+| `inputs` | `map` | no |
+
+Both kwargs and positional forms work — `run_script('foo.py', inputs={'k':'v'})`
+and `run_script('foo.py', {'k':'v'})` are equivalent because pydantic-monty
+maps positional args to schema params by index.
+
+Invalid arguments surface as Python errors (`result.isError == true`):
+
+| Misuse | Surfaces as |
+|---|---|
+| `run_script(123)` (wrong type) | Python error |
+| `run_script("f.py", inputs="oops")` (wrong type for `inputs`) | Python error |
+| `run_script()` (missing required `path`) | Python error |
+| `run_script("f.py", typo={…})` (unknown kwarg) | Python error |
+
+---
+
+## `HostContext.subExecute` — sub-execution from your own host function
+
+Every host function handler receives a `HostContext`. Two of its fields
+are the wiring for sub-execution:
+
+```dart
+class HostContext {
+  // … emit, executionId, cancelToken, os …
+
+  /// Narrow view of the owning runtime — event forwarding + schema
+  /// introspection only. Deliberately does NOT expose `execute()`.
+  final HostParentRef? parent;
+
+  /// Runs a sub-script in a fresh Monty interpreter. Safe to call from
+  /// inside a handler — uses an independent execution context, so it
+  /// doesn't contend with the caller's bridge lock.
+  final HostSubExecutor? subExecute;
+}
+```
+
+### Why two fields?
+
+The bridge serialises executions: while a script is running,
+`_isExecuting` stays true through every host function dispatch.
+Calling `runtime.execute()` from inside a handler would always throw
+`StateError('Bridge is already executing')`.
+
+So `HostContext` exposes only the safe surface:
+
+- **`parent: HostParentRef?`** — `emitChildEvent` (for
+  child-spawning extensions like `SandboxExtension` to forward events
+  to the parent's stream) and `schemas` (for tool introspection like
+  the `requires()` host function). Crucially, **no `execute()`** —
+  the misuse is impossible at compile time.
+- **`subExecute`** — runs sub-scripts via `Monty(code).run()` in a
+  fresh interpreter. No shared state with the caller, no bridge
+  contention, returns a `MontyResult`.
+
+### Building your own `run_script`-style function
+
+```dart
+HostFunction myEvalFn() {
+  return HostFunction(
+    schema: const HostFunctionSchema(
+      name: 'evaluate',
+      description: 'Run a snippet and return its last expression.',
+      params: [
+        HostParam(name: 'code', type: HostParamType.string),
+        HostParam(
+          name: 'inputs',
+          type: HostParamType.map,
+          isRequired: false,
+        ),
+      ],
+    ),
+    handler: (args, ctx) async {
+      final subExecute = ctx.subExecute;
+      if (subExecute == null) {
+        throw StateError('evaluate: no subExecute wired into HostContext');
+      }
+      final code = args['code']! as String;
+      final rawInputs = args['inputs'];
+      final inputs = rawInputs is Map
+          ? rawInputs.map((k, v) => MapEntry(k.toString(), v as Object?))
+          : null;
+
+      final result = await subExecute(code, inputs: inputs);
+      if (result.isError) {
+        throw Exception('evaluate failed: ${result.error?.message}');
+      }
+      return result.value.dartValue;
+    },
+  );
+}
+```
+
+### What you trade for safety
+
+`subExecute` runs in a **fresh interpreter** — variables, functions,
+imports from the caller are not visible to the sub-script. If you need
+the sub-script to see the caller's state, you have to inject it
+explicitly via `inputs:` (or accept that the sub-script can only call
+the same host functions, since those are wired through every Monty
+execution).
+
+This is by design: nested execution on the same Python interpreter is
+the deadlock scenario, so the API doesn't offer it.
+
+---
+
+## Putting it together
+
+A typical pattern: the LLM generates a small helper script that
+needs to call back into a curated set of Dart functions. The IDE wires
+that pattern with three pieces:
+
+```dart
+final runtime = MontyRuntime()
+  // 1. Register the helpers — visible in both the main script and any
+  //    script run via run_script.
+  ..register(myEvalFn())
+  ..register(buildRunScriptFunction((path) => vfs.readFile(path)));
+
+// 2. Inject context into the main script before it runs.
+final r = await runtime
+    .execute(mainScript, inputs: {'session_id': sessionId})
+    .result;
+```
+
+Inside `mainScript`, Python can call `run_script('helper.py', inputs={…})`
+to dispatch into a separate file, with the helper's own injected
+inputs. Each helper runs in its own fresh interpreter via `subExecute`
+— no deadlock, no leakage, no surprises.

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -77,8 +77,8 @@ final errors = await Monty.typeCheck(
 
 ## Per-call inputs
 
-`MontyRuntime.execute(code, inputs: {…})` and `Hhg.run(code, inputs: {…})`
-inject Python variables before user code runs:
+`MontyRuntime.execute(code, inputs: {…})` injects Python variables
+before user code runs:
 
 ```dart
 await runtime

--- a/docs/user/api-reference.md
+++ b/docs/user/api-reference.md
@@ -75,6 +75,25 @@ final errors = await Monty.typeCheck(
 );
 ```
 
+## Per-call inputs
+
+`MontyRuntime.execute(code, inputs: {…})` and `Hhg.run(code, inputs: {…})`
+inject Python variables before user code runs:
+
+```dart
+await runtime
+    .execute('f"{greeting}, {name}!"', inputs: {
+      'greeting': 'hello',
+      'name': 'Alice',
+    })
+    .result;
+```
+
+Convertible types: `bool`, `int`, `double`, `String`, `List`, `Map`,
+and `MontyNone()`. Dart `null` throws `MontyInternalError` (use
+`MontyNone()` for Python `None`); unsupported types throw
+`ArgumentError`. Both are synchronous — the script never starts.
+
 ## Host Functions
 
 Expose Dart code to Python:
@@ -89,6 +108,32 @@ HostFunction(
   handler: (args, ctx) async => http.read(Uri.parse(args.str('url'))),
 )
 ```
+
+`ctx` (`HostContext`) exposes:
+
+| Field | Purpose |
+|-------|---------|
+| `emit` / `emitText` | Push `BridgeEvent`s mid-call (progress, custom events) |
+| `executionId` | Per-call ID for event correlation |
+| `cancelToken` | Cooperative cancellation for long-running work |
+| `os` | Active `OsCallHandler`, for direct OS-primitive calls |
+| `parent: HostParentRef?` | Narrow view of the owning runtime — `emitChildEvent`, `schemas`. **No `execute()`** (would deadlock). |
+| `subExecute` | Run a sub-script in a fresh interpreter. See `buildRunScriptFunction` and the [tutorial](../tutorials/inputs-and-sub-scripts.md). |
+
+### `buildRunScriptFunction`
+
+Convenience builder for a `run_script` host function — Python calls
+`run_script('foo.py', inputs={…})` and gets back the sub-script's
+last-expression value:
+
+```dart
+runtime.register(buildRunScriptFunction((path) async {
+  return await File(path).readAsString();
+}));
+```
+
+See the [Inputs, `run_script`, and Sub-Execution tutorial](../tutorials/inputs-and-sub-scripts.md)
+for the full story.
 
 ## Extensions
 


### PR DESCRIPTION
## Summary

Documents what #405 + #406 introduced. New tutorial + updates to two existing docs.

## Changes

### New tutorial — `docs/tutorials/inputs-and-sub-scripts.md`

Cohesive walkthrough of three closely-related features:

1. **`inputs:`** — per-call variable injection, the convertible-type list, the two synchronous error paths (`MontyInternalError` for Dart `null`, `ArgumentError` for unsupported types), and shared-mode persistence behaviour.
2. **`buildRunScriptFunction`** — wiring, return-value semantics (last-expr / assignment / `return` / multi-line), and Python-side argument-shape rules (positional vs kwargs equivalence, validation surfaces as `result.isError`).
3. **`HostContext.subExecute`** — the safe sub-execution path. Explains why `HostContext.parent` is narrow (`HostParentRef`, no `execute()`): the bridge serialises executions, so nested `execute()` would always deadlock — the API offers `subExecute` for the safe path instead.

Closes with a "putting it together" example showing all three composed.

### `docs/tutorials/host-functions-intermediate.md`

New "What's on `ctx`" section — full table of `HostContext` fields (`emit` / `executionId` / `cancelToken` / `os` / `parent` / `subExecute`) with the rationale for the parent/subExecute split.

### `docs/user/api-reference.md`

- New "Per-call inputs" section with the type rules and error mechanisms.
- Host Functions section gets a `ctx` field table next to the example.
- New "`buildRunScriptFunction`" subsection pointing at the tutorial.

## What's intentionally *not* included

- No `Hhg.run` references — Hhg lives in `dart_monty_labs`, not in this package. The `inputs:` story is told at the `MontyRuntime.execute` level (the surface that ships in dart_monty).
- No documentation for awaitable Dart externals — that surface depends on `dart_monty_core`'s unmerged `feat/repl-future-capable` work; it'll get its own doc when the REPL futures path lands.

## Test plan

- [x] `dart analyze lib/ test/` — clean
- [x] No `Hhg` references in `docs/`
- [x] Cross-links resolve (`host-functions-intermediate.md` ↔ `inputs-and-sub-scripts.md` ↔ `api-reference.md`)