### PR TITLE
fix(example): mirror dart_monty_core override into example pubspecs

### DIFF
--- a/example/native/pubspec.yaml
+++ b/example/native/pubspec.yaml
@@ -8,3 +8,13 @@ environment:
 dependencies:
   dart_monty:
     path: ../..
+
+# Mirror the override from ../../pubspec.yaml — dependency_overrides do not
+# transit through path: deps, so the example needs its own copy until the
+# next dart_monty_core release ships with #99 (inputsToCode + MontyNone +
+# MontyInternalError exports).
+dependency_overrides:
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main

--- a/example/web/pubspec.yaml
+++ b/example/web/pubspec.yaml
@@ -10,3 +10,13 @@ dependencies:
     path: ../..
   file: ^7.0.0
   web: ^1.1.1
+
+# Mirror the override from ../../pubspec.yaml — dependency_overrides do not
+# transit through path: deps, so the example needs its own copy until the
+# next dart_monty_core release ships with #99 (inputsToCode + MontyNone +
+# MontyInternalError exports).
+dependency_overrides:
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main


### PR DESCRIPTION
## Summary

The github-pages CI job runs `dart compile js bin/vfs_demo.dart` from `example/web/`, which has its own `pubspec.yaml` using `dart_monty` via `path: ../..`. **`dependency_overrides` do not transit through `path:` deps** — the example resolves on its own and pulls `dart_monty_core: ^0.17.0` from pub.dev, which predates #99 (`inputsToCode` + `MontyInternalError` + `MontyNone` exports).

Result on CI:

```
../../lib/src/runtime/runtime.dart:219:14:
Error: The method 'inputsToCode' isn't defined for the type 'MontyRuntime'.
        ? '${inputsToCode(inputs)}\n$code'
             ^^^^^^^^^^^^
```

## Fix

Mirror the same `dart_monty_core: git ref main` override into both:
- `example/web/pubspec.yaml`
- `example/native/pubspec.yaml`

## Test plan

- [x] `dart pub get` in `example/web/` resolves with the override
- [x] `dart compile js bin/vfs_demo.dart` succeeds locally
- [x] Same fix mirrored to `example/native/` pre-emptively (it has the same path-dep shape)

## Follow-up

Drop these overrides + bump `dart_monty_core: ^0.x.y` once the next core release ships with #99. Same trigger as the root `pubspec.yaml` override.