### PR TITLE
feat(runtime): MontyRuntime(useFutures: …) — Layer 4 of the async/sync matrix

### DIFF
--- a/docs/tutorials/host-functions-advanced.md
+++ b/docs/tutorials/host-functions-advanced.md
@@ -446,30 +446,82 @@ await registry1.disposeAll();
 Each extension instance maintains its own state. Two `StorageExtension`
 instances do not share data.
 
-## Futures Batching
+## Futures Batching (`MontyRuntime(useFutures: true)`)
 
-When `useFutures: true` (the default) and the platform implements
-`MontyFutureCapable`, the bridge dispatches host function calls as
-futures. This enables concurrent handler execution within a single
-Python execution:
+By default `MontyRuntime` dispatches host functions **serially**: each
+call awaits its handler before resuming Python. Set `useFutures: true`
+on the constructor to flip the bridge into the futures-batching path —
+host calls dispatch concurrently within a single Python execution, and
+Python's `await ext()` against a Dart-registered handler returns the
+resolved value instead of raising `TypeError`.
 
-1. Python calls a host function.
-2. Instead of blocking until the handler completes, the bridge calls
-   `resumeAsFuture()` to tell the platform "this call is pending."
-3. Python continues executing. If it calls more host functions before
-   using the return value, those are also dispatched as futures.
-4. When Python actually **reads** a return value from a host function
-   call (e.g., assigns it to a variable, passes it to another function,
-   or uses it in an expression), the Monty runtime needs the concrete
-   result. At that point the platform emits `MontyResolveFutures` with
-   the list of pending call IDs.
-5. The bridge awaits all pending handler futures and feeds the results
-   back in a batch.
+```dart
+final runtime = MontyRuntime(useFutures: true)
+  ..register(slowHostFn);
 
-This is transparent to the Python code and the handler implementations.
-It only affects execution ordering: handlers may run concurrently if
-the platform supports futures.
+await runtime.execute('''
+import asyncio
+results = await asyncio.gather(slow(1), slow(2), slow(3))
+''').result;
+// All three host calls dispatch concurrently; total wall time ≈ one delay,
+// not three.
+```
 
-If a handler throws synchronously (before returning a `Future`), the
-bridge catches it immediately and feeds the error back via
-`resumeWithError()` to avoid deadlocking the platform.
+What changes when `useFutures: true`:
+
+1. Python calls a host function. The bridge dispatches it via
+   `dispatchToolCallAsFuture` — the handler is launched as an unawaited
+   `Future` and registered in `_pendingFutures`. The platform is
+   resumed via `resumeAsFuture()` so Python keeps running.
+2. If Python calls more host functions before suspending, those are
+   also dispatched as futures, in parallel with earlier ones.
+3. When Python's interpreter actually needs the concrete result of a
+   host call (any `await fn()` or implicit await inside `asyncio.gather`),
+   the platform emits `MontyResolveFutures` with the list of pending
+   call IDs.
+4. The bridge awaits each registered future, collects values into
+   `results` and per-call exceptions into `errors`, then feeds the
+   batch back via `(_platform as MontyFutureCapable).resolveFutures(
+   results, errors: errors)`.
+
+This is transparent to handler implementations — they're written the
+same way regardless of the flag. The only difference is execution
+ordering.
+
+### When to leave the flag off (the default)
+
+- Your handlers don't benefit from concurrency (sync values, fast pure
+  computations).
+- Your handlers mutate shared state and you need the legacy serial-
+  dispatch guarantee. Concurrent dispatch lets handlers race against
+  each other; serialising at the dispatch boundary is the simplest way
+  to avoid that.
+- You want bit-for-bit back-compat with pre-flag behaviour.
+
+### When to flip it on
+
+- Your script uses Python `await ext()` against a Dart-registered host
+  function (the only way to express "this call is async" inside
+  Python). Without `useFutures: true`, that line raises
+  `TypeError: 'str' object can't be awaited` because the eager dispatch
+  path returns a plain value.
+- Your handlers do real I/O (HTTP, file, sub-process) and you want
+  `asyncio.gather` to actually parallelise — sequential dispatch costs
+  you the sum of all handler latencies.
+
+### Error handling
+
+`useFutures: true` collects per-call errors into the `errors` map and
+hands them to `resolveFutures`. The pydantic-monty engine surfaces a
+failed future as a script termination (`MontyScriptError`) with the
+error message verbatim — Python's own `try / except RuntimeError`
+around `await fn()` does **not** catch it today. If you want recovery
+semantics, do the catching Dart-side inside the handler and return a
+sentinel value.
+
+For the cell-by-cell contract across every (Dart × Python × API layer
+× backend) combination, see
+[dart_monty_core's async-matrix deep dive][async-matrix] and the
+matrix tests in `test/integration/_runtime_async_matrix_body.dart`.
+
+[async-matrix]: https://github.com/runyaga/dart_monty_core/blob/main/docs/deep-dives/async-matrix.md

--- a/docs/tutorials/inputs-and-sub-scripts.md
+++ b/docs/tutorials/inputs-and-sub-scripts.md
@@ -251,3 +251,46 @@ Inside `mainScript`, Python can call `run_script('helper.py', inputs={…})`
 to dispatch into a separate file, with the helper's own injected
 inputs. Each helper runs in its own fresh interpreter via `subExecute`
 — no deadlock, no leakage, no surprises.
+
+## Sync vs async handlers
+
+A `HostFunctionHandler` always returns `Future<Object?>`, but how the
+bridge dispatches it depends on `MontyRuntime(useFutures: …)`:
+
+- **`MontyRuntime()` (default, `useFutures: false`)** — handlers are
+  awaited inline before the bridge resumes Python. Python sees the
+  resolved value as a plain object. This is the simplest mental model:
+  one host call → one round-trip → one Python `resume`. **Limitation:**
+  Python `await ext()` against the host function raises
+  `TypeError: 'str' object can't be awaited` — by the time Python
+  evaluates `await`, the value is already a plain `str`/`int`, not a
+  future.
+
+- **`MontyRuntime(useFutures: true)`** — handlers are launched as
+  unawaited futures and the bridge replies with `resumeAsFuture()`.
+  Python keeps running, can fire more host calls in parallel
+  (`asyncio.gather` parallelises across externals), and the bridge
+  batch-resolves them when Python actually suspends on a value.
+  Concurrent dispatch is the whole point. **Trade-off:** handlers can
+  race over shared state, so be deliberate about flipping the flag for
+  any runtime whose handlers are stateful.
+
+```dart
+// Default (serial, simple): bare calls only — `await fetch(x)` would fail.
+await MontyRuntime().execute('result = fetch(7)\nresult').result;
+
+// Futures mode: Python `await fetch(x)` works, gather parallelises.
+await MontyRuntime(useFutures: true).execute('''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''').result;
+```
+
+For the cell-by-cell contract — every combination of (Dart sync vs
+async) × (Python bare call vs `await`) × API layer × backend — see
+[dart_monty_core's async-matrix deep dive][async-matrix] and the
+matrix test bodies (Layer 4 lives at
+`test/integration/_runtime_async_matrix_body.dart` in this repo).
+
+[async-matrix]: https://github.com/runyaga/dart_monty_core/blob/main/docs/deep-dives/async-matrix.md

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -73,6 +73,7 @@ class MontyRuntime implements MontyRuntimeRef {
     BridgeLogger? logger,
     MontyInterceptor? interceptor,
     bool sandbox = false,
+    bool useFutures = false,
     DescriptionProvider? descriptionProvider,
   }) : assert(
          os == null || osHandlers == null,
@@ -83,6 +84,7 @@ class MontyRuntime implements MontyRuntimeRef {
        _logger = logger,
        _interceptor = interceptor,
        _sandbox = sandbox,
+       _useFutures = useFutures,
        _descriptionProvider = descriptionProvider {
     if (!sandbox) {
       // Shared mode: create persistent REPL-backed interpreter.
@@ -92,7 +94,7 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
       _sharedBridge = PlatformBridge(
         platform: _sharedPlatform!,
-        useFutures: false,
+        useFutures: _useFutures,
         logger: logger,
         interceptor: interceptor,
         runtime: this,
@@ -115,6 +117,7 @@ class MontyRuntime implements MontyRuntimeRef {
   final BridgeLogger? _logger;
   final MontyInterceptor? _interceptor;
   final bool _sandbox;
+  final bool _useFutures;
   final DescriptionProvider? _descriptionProvider;
 
   // Shared mode state.
@@ -290,7 +293,7 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
       _sharedBridge = PlatformBridge(
         platform: _sharedPlatform!,
-        useFutures: false,
+        useFutures: _useFutures,
         logger: _logger,
         runtime: this,
       );
@@ -449,7 +452,7 @@ class MontyRuntime implements MontyRuntimeRef {
   PlatformBridge _buildBridge({MontyPlatform? platform}) {
     final b = PlatformBridge(
       platform: platform ?? ReplPlatform(repl: MontyRepl()),
-      useFutures: false,
+      useFutures: _useFutures,
       logger: _logger,
       interceptor: _interceptor,
       runtime: this,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,12 +30,17 @@ dependencies:
 dev_dependencies:
   very_good_analysis: ^10.0.0
 
-# dart_monty_core 0.17.0 (pub.dev) predates the inputs/MontyInternalError/
-# MontyNone work merged in dart_monty_core#99. Point at main until the next
-# core release. dependency_overrides apply to this repo's builds only —
-# downstream consumers still see the pub.dev `^0.17.0` constraint above.
+# Pointing at dart_monty_core PR #102 (feat/futures-driveloop-and-matrix)
+# which:
+#   1. promotes `ReplPlatform` to implement `MontyFutureCapable` (via PR #101
+#      that #102 stacks on), so `useFutures: true` here actually engages the
+#      bridge's futures dispatch path
+#   2. wires `_driveLoop`'s MontyResolveFutures case so Monty.run /
+#      MontyRepl.feedRun work too
+# Pinned to the SHA so the override stays stable through branch deletion.
+# Drop and bump dart_monty_core: ^0.x.y once #102 lands and a release ships.
 dependency_overrides:
   dart_monty_core:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
-      ref: main
+      ref: 458b01e2b8b6c8457ff1e0ee00c90514b2e6fc64

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,17 +30,12 @@ dependencies:
 dev_dependencies:
   very_good_analysis: ^10.0.0
 
-# Pointing at dart_monty_core PR #102 (feat/futures-driveloop-and-matrix)
-# which:
-#   1. promotes `ReplPlatform` to implement `MontyFutureCapable` (via PR #101
-#      that #102 stacks on), so `useFutures: true` here actually engages the
-#      bridge's futures dispatch path
-#   2. wires `_driveLoop`'s MontyResolveFutures case so Monty.run /
-#      MontyRepl.feedRun work too
-# Pinned to the SHA so the override stays stable through branch deletion.
-# Drop and bump dart_monty_core: ^0.x.y once #102 lands and a release ships.
+# dart_monty_core's futures end-to-end work (#102, includes
+# ReplPlatform implements MontyFutureCapable + _driveLoop wiring) lives
+# on main but predates the next release. Drop this block once a
+# dart_monty_core release ships with #102 and bump the version pin above.
 dependency_overrides:
   dart_monty_core:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
-      ref: 458b01e2b8b6c8457ff1e0ee00c90514b2e6fc64
+      ref: main

--- a/test/integration/_runtime_async_matrix_body.dart
+++ b/test/integration/_runtime_async_matrix_body.dart
@@ -1,0 +1,254 @@
+// Shared test body for the Layer 4 (`MontyRuntime.execute`) async/sync
+// matrix.
+//
+// Layer 4 takes a different code path than Layer 2/3 (which go through
+// dart_monty_core's `MontyRepl.feedRun` → `_driveLoop`). MontyRuntime
+// builds a `PlatformBridge` and uses `dispatchToolCallAsFuture` directly
+// when `useFutures: true` is set on the runtime constructor and the
+// platform implements `MontyFutureCapable`. This test pins the cell-by-cell
+// contract from that surface.
+//
+// Both `ffi_runtime_async_matrix_test.dart` calls
+// [runRuntimeAsyncMatrixTests] (FFI only — dart_monty has no WASM-tagged
+// integration suite).
+
+import 'dart:async';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void runRuntimeAsyncMatrixTests() {
+  group('MontyRuntime.execute async/sync matrix', () {
+    HostFunction fetchSync(int Function() onCall) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        description: 'sync fetch',
+        params: [HostParam(name: 'value', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        onCall();
+
+        return (args['value']! as int) + 1;
+      },
+    );
+
+    HostFunction fetchAsync(int Function() onCall) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        description: 'async fetch',
+        params: [HostParam(name: 'value', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        await Future<void>.delayed(Duration.zero);
+        onCall();
+
+        return (args['value']! as int) + 1;
+      },
+    );
+
+    // matrix-cell: (sync Dart) × (sync Python)
+    test('cell 1: sync handler + bare Python call', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchSync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('fetch(7)').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (sync Python)
+    test('cell 2: async handler + bare Python call', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchAsync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('fetch(7)').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (sync Dart) × (Python local async coroutine, no Dart await)
+    test('cell 3: sync handler + Python local coroutine', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchSync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (Python local coroutine)
+    test('cell 4: async handler + Python local coroutine', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchAsync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (Python `await ext()`) — the key cell.
+    // Requires `MontyRuntime(useFutures: true)`.
+    test('cell 5a: useFutures=true wires Python `await fetch(x)`', () async {
+      var calls = 0;
+      final runtime = MontyRuntime(useFutures: true)
+        ..register(fetchAsync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('await fetch(7)').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    test('cell 5b: useFutures=true + asyncio.gather over externals', () async {
+      final fired = <int>[];
+      final runtime = MontyRuntime(useFutures: true)
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(
+              name: 'fetch',
+              description: 'parallel fetch',
+              params: [HostParam(name: 'n', type: HostParamType.integer)],
+            ),
+            handler: (args, _) async {
+              final n = args['n']! as int;
+              fired.add(n);
+              await Future<void>.delayed(Duration.zero);
+
+              return n * 10;
+            },
+          ),
+        );
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, [10, 20, 30]);
+      // Concurrent dispatch — all three callbacks fire (in some order)
+      // before gather yields.
+      expect(fired.toSet(), {1, 2, 3});
+      expect(fired, hasLength(3));
+    });
+
+    // Default-off back-compat: `MontyRuntime()` (no useFutures flag) leaves
+    // Python `await ext()` raising TypeError, exactly as before this PR.
+    test(
+      'useFutures=false: Python `await ext()` still raises TypeError',
+      () async {
+        final runtime = MontyRuntime()..register(fetchAsync(() => 0));
+        addTearDown(runtime.dispose);
+
+        final r = await runtime.execute('await fetch(7)').result;
+
+        expect(r.error, isNotNull);
+        expect(r.error?.excType, equals('TypeError'));
+      },
+    );
+
+    // useFutures + inputs interplay — confirm the new flag composes with
+    // the existing inputs: parameter.
+    test(
+      'useFutures + inputs: inputs visible inside awaited external script',
+      () async {
+        final runtime = MontyRuntime(useFutures: true)
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'greet',
+                description: 'greet by name',
+                params: [HostParam(name: 'name', type: HostParamType.string)],
+              ),
+              handler: (args, _) async {
+                await Future<void>.delayed(Duration.zero);
+
+                return 'hello, ${args['name']}';
+              },
+            ),
+          );
+        addTearDown(runtime.dispose);
+
+        final r = await runtime
+            .execute(
+              'await greet(seed)',
+              inputs: {'seed': 'alice'},
+            )
+            .result;
+
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 'hello, alice');
+      },
+    );
+
+    // asyncio.gather demonstrates wall-clock parallelism — sleep-heavy
+    // handlers run concurrently rather than sequentially when
+    // useFutures: true.
+    test('useFutures=true: gather of slow handlers takes ~one delay, '
+        'not sum-of-delays', () async {
+      const delayMs = 200;
+      final runtime = MontyRuntime(useFutures: true)
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(
+              name: 'slow',
+              description: 'sleeps then returns its argument',
+              params: [HostParam(name: 'n', type: HostParamType.integer)],
+            ),
+            handler: (args, _) async {
+              await Future<void>.delayed(
+                const Duration(milliseconds: delayMs),
+              );
+
+              return args['n'];
+            },
+          ),
+        );
+      addTearDown(runtime.dispose);
+
+      final sw = Stopwatch()..start();
+      final r = await runtime.execute('''
+import asyncio
+await asyncio.gather(slow(1), slow(2), slow(3))
+''').result;
+      sw.stop();
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, [1, 2, 3]);
+      // Sequential would be ~3*delayMs (600ms). Concurrent is ~delayMs
+      // plus dispatch overhead. Use 2x delay as the upper bound — well
+      // below the sequential lower bound and well above any noise.
+      expect(
+        sw.elapsedMilliseconds,
+        lessThan(delayMs * 2),
+        reason:
+            'gather should run handlers concurrently under '
+            'useFutures: true; took ${sw.elapsedMilliseconds}ms',
+      );
+    });
+  });
+}

--- a/test/integration/ffi_runtime_async_matrix_test.dart
+++ b/test/integration/ffi_runtime_async_matrix_test.dart
@@ -1,0 +1,9 @@
+// FFI binding for the Layer 4 `MontyRuntime.execute` async/sync matrix.
+@Tags(['integration'])
+library;
+
+import 'package:test/test.dart';
+
+import '_runtime_async_matrix_body.dart';
+
+void main() => runRuntimeAsyncMatrixTests();


### PR DESCRIPTION
## Summary

Closes the **(async Dart) × (Python \`await ext()\`)** cell at the \`MontyRuntime.execute\` layer (Layer 4 in the matrix). Today \`MontyRuntime\` hardcodes \`useFutures: false\` at all three bridge construction sites (\`runtime.dart:95, 293, 452\`), making the bridge's already-wired \`dispatchToolCallAsFuture\` path unreachable.

## Implementation (Part D2 of the async-matrix plan)

- \`MontyRuntime\` constructor gains \`bool useFutures = false\` (back-compat default).
- All three internal \`PlatformBridge(useFutures: false)\` sites now read from \`_useFutures\`.
- The bridge's existing futures path is left untouched — flipping the runtime flag is enough to engage \`dispatchToolCallAsFuture\` because \`ReplPlatform\` already implements \`MontyFutureCapable\` (via [dart_monty_core PR #101](https://github.com/runyaga/dart_monty_core/pull/101)).

The first commit (\`b6cbdb4\`) is a cherry-pick of [@runyaga's earlier work](https://github.com/runyaga/dart_monty/tree/feat/runtime-use-futures); this PR rebases it cleanly onto current main, drops the unrelated docs commit, replaces the experiment-style test with a proper layer-matrix body, and adds the docs.

## Layer 4 matrix coverage

\`test/integration/_runtime_async_matrix_body.dart\` — **9 tests** asserting both return values and dispatch shape:

| # | Dart shape | Python shape | Status |
|---|---|---|---|
| 1 | sync | bare \`fetch(7)\` | ✅ |
| 2 | async | bare \`fetch(7)\` | ✅ |
| 3 | sync | local async coroutine | ✅ |
| 4 | async | local async coroutine | ✅ |
| 5a | async | \`await fetch(7)\` | ✅ (was ❌ pre-flag) |
| 5b | async | \`asyncio.gather(fetch(1..3))\` | ✅ argument-ordered + concurrent dispatch |
| — | async | \`await fetch(7)\` with \`useFutures: false\` | ✅ still raises TypeError (back-compat) |
| — | async | \`useFutures + inputs\` interplay | ✅ |
| — | async | wall-clock parallelism: 3× 200ms handlers in <2× delay | ✅ |

## Docs

- **\`host-functions-advanced.md\`** Futures Batching section rewritten. Pre-PR claim ("the default") was inaccurate — MontyRuntime hardcoded \`useFutures: false\`. Now describes the opt-in flag, trade-offs (state races vs concurrency), dispatch sequence, and error semantics. Cross-links the async-matrix deep dive in dart_monty_core.
- **\`inputs-and-sub-scripts.md\`** gets a new "Sync vs async handlers" subsection.
