### PR TITLE
docs(examples): async/sync matrix demos (FFI + web)

### DIFF
--- a/docs/tutorials/host-functions-advanced.md
+++ b/docs/tutorials/host-functions-advanced.md
@@ -446,30 +446,82 @@ await registry1.disposeAll();
 Each extension instance maintains its own state. Two `StorageExtension`
 instances do not share data.
 
-## Futures Batching
+## Futures Batching (`MontyRuntime(useFutures: true)`)
 
-When `useFutures: true` (the default) and the platform implements
-`MontyFutureCapable`, the bridge dispatches host function calls as
-futures. This enables concurrent handler execution within a single
-Python execution:
+By default `MontyRuntime` dispatches host functions **serially**: each
+call awaits its handler before resuming Python. Set `useFutures: true`
+on the constructor to flip the bridge into the futures-batching path —
+host calls dispatch concurrently within a single Python execution, and
+Python's `await ext()` against a Dart-registered handler returns the
+resolved value instead of raising `TypeError`.
 
-1. Python calls a host function.
-2. Instead of blocking until the handler completes, the bridge calls
-   `resumeAsFuture()` to tell the platform "this call is pending."
-3. Python continues executing. If it calls more host functions before
-   using the return value, those are also dispatched as futures.
-4. When Python actually **reads** a return value from a host function
-   call (e.g., assigns it to a variable, passes it to another function,
-   or uses it in an expression), the Monty runtime needs the concrete
-   result. At that point the platform emits `MontyResolveFutures` with
-   the list of pending call IDs.
-5. The bridge awaits all pending handler futures and feeds the results
-   back in a batch.
+```dart
+final runtime = MontyRuntime(useFutures: true)
+  ..register(slowHostFn);
 
-This is transparent to the Python code and the handler implementations.
-It only affects execution ordering: handlers may run concurrently if
-the platform supports futures.
+await runtime.execute('''
+import asyncio
+results = await asyncio.gather(slow(1), slow(2), slow(3))
+''').result;
+// All three host calls dispatch concurrently; total wall time ≈ one delay,
+// not three.
+```
 
-If a handler throws synchronously (before returning a `Future`), the
-bridge catches it immediately and feeds the error back via
-`resumeWithError()` to avoid deadlocking the platform.
+What changes when `useFutures: true`:
+
+1. Python calls a host function. The bridge dispatches it via
+   `dispatchToolCallAsFuture` — the handler is launched as an unawaited
+   `Future` and registered in `_pendingFutures`. The platform is
+   resumed via `resumeAsFuture()` so Python keeps running.
+2. If Python calls more host functions before suspending, those are
+   also dispatched as futures, in parallel with earlier ones.
+3. When Python's interpreter actually needs the concrete result of a
+   host call (any `await fn()` or implicit await inside `asyncio.gather`),
+   the platform emits `MontyResolveFutures` with the list of pending
+   call IDs.
+4. The bridge awaits each registered future, collects values into
+   `results` and per-call exceptions into `errors`, then feeds the
+   batch back via `(_platform as MontyFutureCapable).resolveFutures(
+   results, errors: errors)`.
+
+This is transparent to handler implementations — they're written the
+same way regardless of the flag. The only difference is execution
+ordering.
+
+### When to leave the flag off (the default)
+
+- Your handlers don't benefit from concurrency (sync values, fast pure
+  computations).
+- Your handlers mutate shared state and you need the legacy serial-
+  dispatch guarantee. Concurrent dispatch lets handlers race against
+  each other; serialising at the dispatch boundary is the simplest way
+  to avoid that.
+- You want bit-for-bit back-compat with pre-flag behaviour.
+
+### When to flip it on
+
+- Your script uses Python `await ext()` against a Dart-registered host
+  function (the only way to express "this call is async" inside
+  Python). Without `useFutures: true`, that line raises
+  `TypeError: 'str' object can't be awaited` because the eager dispatch
+  path returns a plain value.
+- Your handlers do real I/O (HTTP, file, sub-process) and you want
+  `asyncio.gather` to actually parallelise — sequential dispatch costs
+  you the sum of all handler latencies.
+
+### Error handling
+
+`useFutures: true` collects per-call errors into the `errors` map and
+hands them to `resolveFutures`. The pydantic-monty engine surfaces a
+failed future as a script termination (`MontyScriptError`) with the
+error message verbatim — Python's own `try / except RuntimeError`
+around `await fn()` does **not** catch it today. If you want recovery
+semantics, do the catching Dart-side inside the handler and return a
+sentinel value.
+
+For the cell-by-cell contract across every (Dart × Python × API layer
+× backend) combination, see
+[dart_monty_core's async-matrix deep dive][async-matrix] and the
+matrix tests in `test/integration/_runtime_async_matrix_body.dart`.
+
+[async-matrix]: https://github.com/runyaga/dart_monty_core/blob/main/docs/deep-dives/async-matrix.md

--- a/docs/tutorials/inputs-and-sub-scripts.md
+++ b/docs/tutorials/inputs-and-sub-scripts.md
@@ -251,3 +251,46 @@ Inside `mainScript`, Python can call `run_script('helper.py', inputs={…})`
 to dispatch into a separate file, with the helper's own injected
 inputs. Each helper runs in its own fresh interpreter via `subExecute`
 — no deadlock, no leakage, no surprises.
+
+## Sync vs async handlers
+
+A `HostFunctionHandler` always returns `Future<Object?>`, but how the
+bridge dispatches it depends on `MontyRuntime(useFutures: …)`:
+
+- **`MontyRuntime()` (default, `useFutures: false`)** — handlers are
+  awaited inline before the bridge resumes Python. Python sees the
+  resolved value as a plain object. This is the simplest mental model:
+  one host call → one round-trip → one Python `resume`. **Limitation:**
+  Python `await ext()` against the host function raises
+  `TypeError: 'str' object can't be awaited` — by the time Python
+  evaluates `await`, the value is already a plain `str`/`int`, not a
+  future.
+
+- **`MontyRuntime(useFutures: true)`** — handlers are launched as
+  unawaited futures and the bridge replies with `resumeAsFuture()`.
+  Python keeps running, can fire more host calls in parallel
+  (`asyncio.gather` parallelises across externals), and the bridge
+  batch-resolves them when Python actually suspends on a value.
+  Concurrent dispatch is the whole point. **Trade-off:** handlers can
+  race over shared state, so be deliberate about flipping the flag for
+  any runtime whose handlers are stateful.
+
+```dart
+// Default (serial, simple): bare calls only — `await fetch(x)` would fail.
+await MontyRuntime().execute('result = fetch(7)\nresult').result;
+
+// Futures mode: Python `await fetch(x)` works, gather parallelises.
+await MontyRuntime(useFutures: true).execute('''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''').result;
+```
+
+For the cell-by-cell contract — every combination of (Dart sync vs
+async) × (Python bare call vs `await`) × API layer × backend — see
+[dart_monty_core's async-matrix deep dive][async-matrix] and the
+matrix test bodies (Layer 4 lives at
+`test/integration/_runtime_async_matrix_body.dart` in this repo).
+
+[async-matrix]: https://github.com/runyaga/dart_monty_core/blob/main/docs/deep-dives/async-matrix.md

--- a/example/native/bin/async_matrix_demo.dart
+++ b/example/native/bin/async_matrix_demo.dart
@@ -1,0 +1,210 @@
+// Printing to stdout is expected in an example.
+// ignore_for_file: avoid_print
+/// Async / sync matrix demo — FFI (native).
+///
+/// Walks through the six cells of the (Dart × Python) async/sync matrix
+/// from a user's perspective. Each cell prints what it's doing so a
+/// developer skimming the source can learn the matrix in five minutes.
+///
+/// Prerequisites:
+///   cd native && cargo build --release   # one-time, from repo root
+///
+/// Run from the repo root:
+///   dart run example/native/bin/async_matrix_demo.dart
+///
+/// Spec:
+///   dart_monty_core/docs/deep-dives/async-matrix.md
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+
+/// A sync host fn — returns its result without ever yielding the event loop.
+HostFunction syncFetch(void Function() onCall) => HostFunction(
+  schema: const HostFunctionSchema(
+    name: 'fetch',
+    description: 'Sync fetch — adds 1 to its argument.',
+    params: [HostParam(name: 'value', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    onCall();
+    return (args['value']! as int) + 1;
+  },
+);
+
+/// An async host fn — actually awaits a Future before returning.
+HostFunction asyncFetch(void Function() onCall) => HostFunction(
+  schema: const HostFunctionSchema(
+    name: 'fetch',
+    description: 'Async fetch — awaits Future.delayed, then adds 1.',
+    params: [HostParam(name: 'value', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(Duration.zero);
+    onCall();
+    return (args['value']! as int) + 1;
+  },
+);
+
+/// A slow async host fn — sleeps `delay` before returning, so we can see
+/// `asyncio.gather` flatten wall-clock time when `useFutures: true`.
+HostFunction slowFetch(Duration delay) => HostFunction(
+  schema: const HostFunctionSchema(
+    name: 'slow',
+    description: 'Sleeps then returns its argument times 10.',
+    params: [HostParam(name: 'n', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(delay);
+    return (args['n']! as int) * 10;
+  },
+);
+
+Future<void> main() async {
+  print('═══════════════════════════════════════════════════════════════');
+  print(' dart_monty async/sync matrix — FFI demo');
+  print('═══════════════════════════════════════════════════════════════');
+  print('');
+  print('Each cell exercises one (Dart handler shape) × (Python call shape)');
+  print('combination. Spec: dart_monty_core/docs/deep-dives/async-matrix.md');
+  print('');
+
+  // ── Cell 1: sync Dart × bare Python ──────────────────────────────────
+  // The simplest possible interaction. Python calls fetch(7), Dart
+  // returns synchronously, Python sees the value. No `await` anywhere.
+  print('── Cell 1: sync Dart × bare Python ────────────────────────────');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(syncFetch(() => calls++));
+    final r = await runtime.execute('fetch(7)').result;
+    print('  Python: fetch(7)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 2: async Dart × bare Python ─────────────────────────────────
+  // Same Python, but the handler awaits a Future before returning.
+  // The bridge resolves the Dart-side Future for us; Python is none the
+  // wiser — it sees the value, not a coroutine.
+  print('── Cell 2: async Dart × bare Python ───────────────────────────');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(asyncFetch(() => calls++));
+    final r = await runtime.execute('fetch(7)').result;
+    print('  Python: fetch(7)   (handler awaits Future.delayed first)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 3: sync Dart × Python local coroutine ───────────────────────
+  // Now Python wraps the call in a coroutine. The `await doubled(3)` is
+  // a Python-local await — it does NOT cross the FFI boundary as a
+  // future. fetch() is still called bare from inside the coroutine.
+  // No MontyResolveFutures involved.
+  print('── Cell 3: sync Dart × Python local coroutine ─────────────────');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(syncFetch(() => calls++));
+    final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+    print('  Python: async def doubled(n): return fetch(n) * 2');
+    print('          await doubled(3)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 4: async Dart × Python local coroutine ──────────────────────
+  // Same Python as cell 3. Same Python-side semantics. The handler is
+  // async on the Dart side now, but from Python's point of view nothing
+  // changes — fetch() returns a value, not a future.
+  print('── Cell 4: async Dart × Python local coroutine ────────────────');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(asyncFetch(() => calls++));
+    final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+    print('  Python: async def doubled(n): return fetch(n) * 2');
+    print('          await doubled(3)   (handler is async Dart)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 5a: async Dart × Python `await ext()` ───────────────────────
+  // The KEY cell. Python directly awaits the host fn:
+  //
+  //     result = await fetch(7)
+  //
+  // For this to work the bridge must hand Python a coroutine/future
+  // object, not a value. That requires `useFutures: true`.
+  //
+  // First we show the default (`useFutures: false`) raises TypeError —
+  // Python can't await an int.
+  // Then we re-run with `useFutures: true` and it just works.
+  print('── Cell 5a: async Dart × Python `await ext()` ─────────────────');
+  print('  Step 1 — useFutures: false (the default):');
+  {
+    final runtime = MontyRuntime()..register(asyncFetch(() {}));
+    final r = await runtime.execute('await fetch(7)').result;
+    if (r.isError) {
+      print('    Python raised ${r.error?.excType}: ${r.error?.message}');
+      print('    (Expected — int is not awaitable.)');
+    } else {
+      print('    unexpectedly succeeded: ${r.value.dartValue}');
+    }
+    await runtime.dispose();
+  }
+  print('  Step 2 — useFutures: true:');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime(useFutures: true)
+      ..register(asyncFetch(() => calls++));
+    final r = await runtime.execute('await fetch(7)').result;
+    print('    Python: await fetch(7)');
+    print(
+      '    → value = ${r.value.dartValue}, '
+      'callback fired $calls time(s).',
+    );
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 5b: asyncio.gather + useFutures: true ───────────────────────
+  // The pay-off cell. Three host calls each sleep 200ms. With
+  // `useFutures: true`, asyncio.gather runs them concurrently — wall
+  // clock should be ~200ms, NOT ~600ms.
+  print('── Cell 5b: asyncio.gather + useFutures: true ─────────────────');
+  {
+    const delay = Duration(milliseconds: 200);
+    final runtime = MontyRuntime(useFutures: true)..register(slowFetch(delay));
+    final sw = Stopwatch()..start();
+    final r = await runtime.execute('''
+import asyncio
+results = await asyncio.gather(slow(1), slow(2), slow(3))
+results
+''').result;
+    sw.stop();
+    print('  Python: await asyncio.gather(slow(1), slow(2), slow(3))');
+    print('          (each handler sleeps ${delay.inMilliseconds}ms)');
+    print('  → value      = ${r.value.dartValue}');
+    print('  → wall clock = ${sw.elapsedMilliseconds}ms');
+    print(
+      '    (sequential would be ~${delay.inMilliseconds * 3}ms; '
+      'concurrent should be ~${delay.inMilliseconds}ms.)',
+    );
+    await runtime.dispose();
+  }
+  print('');
+
+  print('═══════════════════════════════════════════════════════════════');
+  print(' Done.');
+  print('═══════════════════════════════════════════════════════════════');
+}

--- a/example/web/bin/async_matrix_demo.dart
+++ b/example/web/bin/async_matrix_demo.dart
@@ -1,0 +1,207 @@
+// Standalone JS-compiled demo, not a package:test file.
+// ignore_for_file: avoid_print
+/// Async / sync matrix demo — Web (WASM).
+///
+/// Walks through the six cells of the (Dart × Python) async/sync matrix
+/// from a user's perspective. Each cell prints what it's doing so a
+/// developer skimming the source can learn the matrix in five minutes.
+///
+/// Build:
+///   dart compile js example/web/bin/async_matrix_demo.dart \
+///     -o example/web/web/async_matrix_demo.dart.js
+///
+/// Open example/web/web/async_matrix.html (linked from index.html).
+///
+/// Spec:
+///   dart_monty_core/docs/deep-dives/async-matrix.md
+library;
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+
+/// A sync host fn — returns its result without ever yielding the event loop.
+HostFunction syncFetch(void Function() onCall) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        description: 'Sync fetch — adds 1 to its argument.',
+        params: [HostParam(name: 'value', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        onCall();
+        return (args['value']! as int) + 1;
+      },
+    );
+
+/// An async host fn — actually awaits a Future before returning.
+HostFunction asyncFetch(void Function() onCall) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        description: 'Async fetch — awaits Future.delayed, then adds 1.',
+        params: [HostParam(name: 'value', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        await Future<void>.delayed(Duration.zero);
+        onCall();
+        return (args['value']! as int) + 1;
+      },
+    );
+
+/// A slow async host fn — sleeps `delay` before returning, so we can see
+/// `asyncio.gather` flatten wall-clock time when `useFutures: true`.
+HostFunction slowFetch(Duration delay) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'slow',
+        description: 'Sleeps then returns its argument times 10.',
+        params: [HostParam(name: 'n', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        await Future<void>.delayed(delay);
+        return (args['n']! as int) * 10;
+      },
+    );
+
+Future<void> main() async {
+  print('=== dart_monty async/sync matrix — Web (WASM) demo ===');
+  print('');
+  print('Each cell exercises one (Dart handler shape) × (Python call shape)');
+  print('combination. Spec: dart_monty_core/docs/deep-dives/async-matrix.md');
+  print('');
+
+  // ── Cell 1: sync Dart × bare Python ──────────────────────────────────
+  // The simplest possible interaction. Python calls fetch(7), Dart
+  // returns synchronously, Python sees the value. No `await` anywhere.
+  print('── Cell 1: sync Dart × bare Python ──');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(syncFetch(() => calls++));
+    final r = await runtime.execute('fetch(7)').result;
+    print('  Python: fetch(7)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 2: async Dart × bare Python ─────────────────────────────────
+  // Same Python, but the handler awaits a Future before returning.
+  // The bridge resolves the Dart-side Future for us; Python is none the
+  // wiser — it sees the value, not a coroutine.
+  print('── Cell 2: async Dart × bare Python ──');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(asyncFetch(() => calls++));
+    final r = await runtime.execute('fetch(7)').result;
+    print('  Python: fetch(7)   (handler awaits Future.delayed first)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 3: sync Dart × Python local coroutine ───────────────────────
+  // Now Python wraps the call in a coroutine. The `await doubled(3)` is
+  // a Python-local await — it does NOT cross the WASM boundary as a
+  // future. fetch() is still called bare from inside the coroutine.
+  // No MontyResolveFutures involved.
+  print('── Cell 3: sync Dart × Python local coroutine ──');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(syncFetch(() => calls++));
+    final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+    print('  Python: async def doubled(n): return fetch(n) * 2');
+    print('          await doubled(3)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 4: async Dart × Python local coroutine ──────────────────────
+  // Same Python as cell 3. Same Python-side semantics. The handler is
+  // async on the Dart side now, but from Python's point of view nothing
+  // changes — fetch() returns a value, not a future.
+  print('── Cell 4: async Dart × Python local coroutine ──');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime()..register(asyncFetch(() => calls++));
+    final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+    print('  Python: async def doubled(n): return fetch(n) * 2');
+    print('          await doubled(3)   (handler is async Dart)');
+    print('  → value = ${r.value.dartValue}, callback fired $calls time(s).');
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 5a: async Dart × Python `await ext()` ───────────────────────
+  // The KEY cell. Python directly awaits the host fn:
+  //
+  //     result = await fetch(7)
+  //
+  // For this to work the bridge must hand Python a coroutine/future
+  // object, not a value. That requires `useFutures: true`.
+  //
+  // First we show the default (`useFutures: false`) raises TypeError —
+  // Python can't await an int.
+  // Then we re-run with `useFutures: true` and it just works.
+  print('── Cell 5a: async Dart × Python `await ext()` ──');
+  print('  Step 1 — useFutures: false (the default):');
+  {
+    final runtime = MontyRuntime()..register(asyncFetch(() {}));
+    final r = await runtime.execute('await fetch(7)').result;
+    if (r.isError) {
+      print('    Python raised ${r.error?.excType}: ${r.error?.message}');
+      print('    (Expected — int is not awaitable.)');
+    } else {
+      print('    unexpectedly succeeded: ${r.value.dartValue}');
+    }
+    await runtime.dispose();
+  }
+  print('  Step 2 — useFutures: true:');
+  {
+    var calls = 0;
+    final runtime = MontyRuntime(useFutures: true)
+      ..register(asyncFetch(() => calls++));
+    final r = await runtime.execute('await fetch(7)').result;
+    print('    Python: await fetch(7)');
+    print(
+      '    → value = ${r.value.dartValue}, '
+      'callback fired $calls time(s).',
+    );
+    await runtime.dispose();
+  }
+  print('');
+
+  // ── Cell 5b: asyncio.gather + useFutures: true ───────────────────────
+  // The pay-off cell. Three host calls each sleep 200ms. With
+  // `useFutures: true`, asyncio.gather runs them concurrently — wall
+  // clock should be ~200ms, NOT ~600ms.
+  print('── Cell 5b: asyncio.gather + useFutures: true ──');
+  {
+    const delay = Duration(milliseconds: 200);
+    final runtime = MontyRuntime(useFutures: true)..register(slowFetch(delay));
+    final sw = Stopwatch()..start();
+    final r = await runtime.execute('''
+import asyncio
+results = await asyncio.gather(slow(1), slow(2), slow(3))
+results
+''').result;
+    sw.stop();
+    print('  Python: await asyncio.gather(slow(1), slow(2), slow(3))');
+    print('          (each handler sleeps ${delay.inMilliseconds}ms)');
+    print('  → value      = ${r.value.dartValue}');
+    print('  → wall clock = ${sw.elapsedMilliseconds}ms');
+    print(
+      '    (sequential would be ~${delay.inMilliseconds * 3}ms; '
+      'concurrent should be ~${delay.inMilliseconds}ms.)',
+    );
+    await runtime.dispose();
+  }
+  print('');
+
+  print('=== Done. ===');
+  print('EXAMPLE_DONE');
+}

--- a/example/web/web/async_matrix.html
+++ b/example/web/web/async_matrix.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>dart_monty — Async/Sync Matrix Demo</title>
+  <style>
+    :root {
+      --bg: #1a1b26; --surface: #24283b; --border: #3b4261;
+      --text: #c0caf5; --text-dim: #565f89; --accent: #7aa2f7;
+      --green: #9ece6a; --cyan: #7dcfff;
+      --mono: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, sans-serif; background: var(--bg); color: var(--text); height: 100vh; display: flex; flex-direction: column; }
+    header { padding: 12px 20px; background: var(--surface); border-bottom: 1px solid var(--border); display: flex; align-items: center; gap: 16px; }
+    header a { color: var(--text-dim); text-decoration: none; font-size: 13px; }
+    header a:hover { color: var(--text); }
+    header h1 { font-size: 16px; font-weight: 600; color: var(--accent); }
+    .tag { font-size: 11px; padding: 2px 8px; border-radius: 4px; background: #2d3a5e; color: var(--cyan); }
+    main { flex: 1; overflow-y: auto; padding: 20px; font-family: var(--mono); font-size: 13px; line-height: 1.6; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <header>
+    <a href="index.html">&larr; Home</a>
+    <h1>Async/Sync Matrix Demo</h1>
+    <span class="tag">WASM</span>
+    <span class="tag">useFutures</span>
+  </header>
+  <main id="output">Loading WASM...</main>
+  <script>
+    const out = document.getElementById('output');
+    out.textContent = '';
+    const origLog = console.log.bind(console);
+    console.log = (...args) => {
+      origLog(...args);
+      out.textContent += args.join(' ') + '\n';
+    };
+  </script>
+  <script src="coi-serviceworker.js"></script>
+  <script src="dart_monty_core_bridge.js"></script>
+  <script src="async_matrix_demo.dart.js"></script>
+</body>
+</html>

--- a/example/web/web/index.html
+++ b/example/web/web/index.html
@@ -372,6 +372,10 @@ dart_monty_core (backends)
         <h4>Basic Execution</h4>
         <p>One-shot Python execution, error handling, external functions.</p>
       </a>
+      <a href="async_matrix.html" class="demo-link">
+        <h4>Async/Sync Matrix</h4>
+        <p>Six-cell walkthrough of the (Dart × Python) async matrix, including <code>useFutures: true</code>.</p>
+      </a>
       <a href="vfs.html" class="demo-link">
         <h4>Virtual Filesystem</h4>
         <p>Python pathlib operations against in-memory VFS.</p>

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -73,6 +73,7 @@ class MontyRuntime implements MontyRuntimeRef {
     BridgeLogger? logger,
     MontyInterceptor? interceptor,
     bool sandbox = false,
+    bool useFutures = false,
     DescriptionProvider? descriptionProvider,
   }) : assert(
          os == null || osHandlers == null,
@@ -83,6 +84,7 @@ class MontyRuntime implements MontyRuntimeRef {
        _logger = logger,
        _interceptor = interceptor,
        _sandbox = sandbox,
+       _useFutures = useFutures,
        _descriptionProvider = descriptionProvider {
     if (!sandbox) {
       // Shared mode: create persistent REPL-backed interpreter.
@@ -92,7 +94,7 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
       _sharedBridge = PlatformBridge(
         platform: _sharedPlatform!,
-        useFutures: false,
+        useFutures: _useFutures,
         logger: logger,
         interceptor: interceptor,
         runtime: this,
@@ -115,6 +117,7 @@ class MontyRuntime implements MontyRuntimeRef {
   final BridgeLogger? _logger;
   final MontyInterceptor? _interceptor;
   final bool _sandbox;
+  final bool _useFutures;
   final DescriptionProvider? _descriptionProvider;
 
   // Shared mode state.
@@ -290,7 +293,7 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
       _sharedBridge = PlatformBridge(
         platform: _sharedPlatform!,
-        useFutures: false,
+        useFutures: _useFutures,
         logger: _logger,
         runtime: this,
       );
@@ -449,7 +452,7 @@ class MontyRuntime implements MontyRuntimeRef {
   PlatformBridge _buildBridge({MontyPlatform? platform}) {
     final b = PlatformBridge(
       platform: platform ?? ReplPlatform(repl: MontyRepl()),
-      useFutures: false,
+      useFutures: _useFutures,
       logger: _logger,
       interceptor: _interceptor,
       runtime: this,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,12 +30,17 @@ dependencies:
 dev_dependencies:
   very_good_analysis: ^10.0.0
 
-# dart_monty_core 0.17.0 (pub.dev) predates the inputs/MontyInternalError/
-# MontyNone work merged in dart_monty_core#99. Point at main until the next
-# core release. dependency_overrides apply to this repo's builds only —
-# downstream consumers still see the pub.dev `^0.17.0` constraint above.
+# Pointing at dart_monty_core PR #102 (feat/futures-driveloop-and-matrix)
+# which:
+#   1. promotes `ReplPlatform` to implement `MontyFutureCapable` (via PR #101
+#      that #102 stacks on), so `useFutures: true` here actually engages the
+#      bridge's futures dispatch path
+#   2. wires `_driveLoop`'s MontyResolveFutures case so Monty.run /
+#      MontyRepl.feedRun work too
+# Pinned to the SHA so the override stays stable through branch deletion.
+# Drop and bump dart_monty_core: ^0.x.y once #102 lands and a release ships.
 dependency_overrides:
   dart_monty_core:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
-      ref: main
+      ref: 458b01e2b8b6c8457ff1e0ee00c90514b2e6fc64

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,17 +30,12 @@ dependencies:
 dev_dependencies:
   very_good_analysis: ^10.0.0
 
-# Pointing at dart_monty_core PR #102 (feat/futures-driveloop-and-matrix)
-# which:
-#   1. promotes `ReplPlatform` to implement `MontyFutureCapable` (via PR #101
-#      that #102 stacks on), so `useFutures: true` here actually engages the
-#      bridge's futures dispatch path
-#   2. wires `_driveLoop`'s MontyResolveFutures case so Monty.run /
-#      MontyRepl.feedRun work too
-# Pinned to the SHA so the override stays stable through branch deletion.
-# Drop and bump dart_monty_core: ^0.x.y once #102 lands and a release ships.
+# dart_monty_core's futures end-to-end work (#102, includes
+# ReplPlatform implements MontyFutureCapable + _driveLoop wiring) lives
+# on main but predates the next release. Drop this block once a
+# dart_monty_core release ships with #102 and bump the version pin above.
 dependency_overrides:
   dart_monty_core:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
-      ref: 458b01e2b8b6c8457ff1e0ee00c90514b2e6fc64
+      ref: main

--- a/test/integration/_runtime_async_matrix_body.dart
+++ b/test/integration/_runtime_async_matrix_body.dart
@@ -1,0 +1,254 @@
+// Shared test body for the Layer 4 (`MontyRuntime.execute`) async/sync
+// matrix.
+//
+// Layer 4 takes a different code path than Layer 2/3 (which go through
+// dart_monty_core's `MontyRepl.feedRun` → `_driveLoop`). MontyRuntime
+// builds a `PlatformBridge` and uses `dispatchToolCallAsFuture` directly
+// when `useFutures: true` is set on the runtime constructor and the
+// platform implements `MontyFutureCapable`. This test pins the cell-by-cell
+// contract from that surface.
+//
+// Both `ffi_runtime_async_matrix_test.dart` calls
+// [runRuntimeAsyncMatrixTests] (FFI only — dart_monty has no WASM-tagged
+// integration suite).
+
+import 'dart:async';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void runRuntimeAsyncMatrixTests() {
+  group('MontyRuntime.execute async/sync matrix', () {
+    HostFunction fetchSync(int Function() onCall) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        description: 'sync fetch',
+        params: [HostParam(name: 'value', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        onCall();
+
+        return (args['value']! as int) + 1;
+      },
+    );
+
+    HostFunction fetchAsync(int Function() onCall) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        description: 'async fetch',
+        params: [HostParam(name: 'value', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        await Future<void>.delayed(Duration.zero);
+        onCall();
+
+        return (args['value']! as int) + 1;
+      },
+    );
+
+    // matrix-cell: (sync Dart) × (sync Python)
+    test('cell 1: sync handler + bare Python call', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchSync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('fetch(7)').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (sync Python)
+    test('cell 2: async handler + bare Python call', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchAsync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('fetch(7)').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (sync Dart) × (Python local async coroutine, no Dart await)
+    test('cell 3: sync handler + Python local coroutine', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchSync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (Python local coroutine)
+    test('cell 4: async handler + Python local coroutine', () async {
+      var calls = 0;
+      final runtime = MontyRuntime()..register(fetchAsync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (Python `await ext()`) — the key cell.
+    // Requires `MontyRuntime(useFutures: true)`.
+    test('cell 5a: useFutures=true wires Python `await fetch(x)`', () async {
+      var calls = 0;
+      final runtime = MontyRuntime(useFutures: true)
+        ..register(fetchAsync(() => calls++));
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('await fetch(7)').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    test('cell 5b: useFutures=true + asyncio.gather over externals', () async {
+      final fired = <int>[];
+      final runtime = MontyRuntime(useFutures: true)
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(
+              name: 'fetch',
+              description: 'parallel fetch',
+              params: [HostParam(name: 'n', type: HostParamType.integer)],
+            ),
+            handler: (args, _) async {
+              final n = args['n']! as int;
+              fired.add(n);
+              await Future<void>.delayed(Duration.zero);
+
+              return n * 10;
+            },
+          ),
+        );
+      addTearDown(runtime.dispose);
+
+      final r = await runtime.execute('''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''').result;
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, [10, 20, 30]);
+      // Concurrent dispatch — all three callbacks fire (in some order)
+      // before gather yields.
+      expect(fired.toSet(), {1, 2, 3});
+      expect(fired, hasLength(3));
+    });
+
+    // Default-off back-compat: `MontyRuntime()` (no useFutures flag) leaves
+    // Python `await ext()` raising TypeError, exactly as before this PR.
+    test(
+      'useFutures=false: Python `await ext()` still raises TypeError',
+      () async {
+        final runtime = MontyRuntime()..register(fetchAsync(() => 0));
+        addTearDown(runtime.dispose);
+
+        final r = await runtime.execute('await fetch(7)').result;
+
+        expect(r.error, isNotNull);
+        expect(r.error?.excType, equals('TypeError'));
+      },
+    );
+
+    // useFutures + inputs interplay — confirm the new flag composes with
+    // the existing inputs: parameter.
+    test(
+      'useFutures + inputs: inputs visible inside awaited external script',
+      () async {
+        final runtime = MontyRuntime(useFutures: true)
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'greet',
+                description: 'greet by name',
+                params: [HostParam(name: 'name', type: HostParamType.string)],
+              ),
+              handler: (args, _) async {
+                await Future<void>.delayed(Duration.zero);
+
+                return 'hello, ${args['name']}';
+              },
+            ),
+          );
+        addTearDown(runtime.dispose);
+
+        final r = await runtime
+            .execute(
+              'await greet(seed)',
+              inputs: {'seed': 'alice'},
+            )
+            .result;
+
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 'hello, alice');
+      },
+    );
+
+    // asyncio.gather demonstrates wall-clock parallelism — sleep-heavy
+    // handlers run concurrently rather than sequentially when
+    // useFutures: true.
+    test('useFutures=true: gather of slow handlers takes ~one delay, '
+        'not sum-of-delays', () async {
+      const delayMs = 200;
+      final runtime = MontyRuntime(useFutures: true)
+        ..register(
+          HostFunction(
+            schema: const HostFunctionSchema(
+              name: 'slow',
+              description: 'sleeps then returns its argument',
+              params: [HostParam(name: 'n', type: HostParamType.integer)],
+            ),
+            handler: (args, _) async {
+              await Future<void>.delayed(
+                const Duration(milliseconds: delayMs),
+              );
+
+              return args['n'];
+            },
+          ),
+        );
+      addTearDown(runtime.dispose);
+
+      final sw = Stopwatch()..start();
+      final r = await runtime.execute('''
+import asyncio
+await asyncio.gather(slow(1), slow(2), slow(3))
+''').result;
+      sw.stop();
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, [1, 2, 3]);
+      // Sequential would be ~3*delayMs (600ms). Concurrent is ~delayMs
+      // plus dispatch overhead. Use 2x delay as the upper bound — well
+      // below the sequential lower bound and well above any noise.
+      expect(
+        sw.elapsedMilliseconds,
+        lessThan(delayMs * 2),
+        reason:
+            'gather should run handlers concurrently under '
+            'useFutures: true; took ${sw.elapsedMilliseconds}ms',
+      );
+    });
+  });
+}

--- a/test/integration/ffi_runtime_async_matrix_test.dart
+++ b/test/integration/ffi_runtime_async_matrix_test.dart
@@ -1,0 +1,9 @@
+// FFI binding for the Layer 4 `MontyRuntime.execute` async/sync matrix.
+@Tags(['integration'])
+library;
+
+import 'package:test/test.dart';
+
+import '_runtime_async_matrix_body.dart';
+
+void main() => runRuntimeAsyncMatrixTests();


### PR DESCRIPTION
## Summary

- Add `example/native/bin/async_matrix_demo.dart` — FFI demo (`dart run` cleanly).
- Add `example/web/bin/async_matrix_demo.dart` plus `example/web/web/async_matrix.html` (linked from `index.html`) — compiles cleanly via `dart compile js`.
- Both demos walk the six cells of the (Dart × Python) async/sync matrix from a user's perspective: heavy comments, narration via `print`, no asserts.

## Matrix coverage

| Cell | What it shows |
|---|---|
| 1 | sync Dart × bare Python |
| 2 | async Dart × bare Python |
| 3 | sync Dart × Python local coroutine |
| 4 | async Dart × Python local coroutine |
| 5a | async Dart × Python `await ext()` — `useFutures: false` raises TypeError, then `useFutures: true` returns the value |
| 5b | `asyncio.gather` + `useFutures: true` — three 200ms calls complete in ~200ms wall clock |

## Why this base?

Based on `feat/montyruntime-usefutures-matrix` (#411) because the demos use `MontyRuntime(useFutures: true)`, which only exists on that branch. Will rebase / re-target once #411 lands.

## Spec

- `dart_monty_core/docs/deep-dives/async-matrix.md`
- Backed by: `dart_monty_core` PR #102 (merged) and `dart_monty` #411.

Closes #412.

## Test plan

- [x] `dart run example/native/bin/async_matrix_demo.dart` — all 6 cells print expected output; cell 5b wall clock ~205ms (vs 600ms sequential).
- [x] `dart compile js example/web/bin/async_matrix_demo.dart -o /tmp/check.js` succeeds (582 KB output).
- [x] `dart format` — 0 changed.
- [x] `dart analyze` — no issues.
- [ ] Open `example/web/web/async_matrix.html` in a browser after `run.sh` and confirm cell output streams.