### PR TITLE
feat(host): per-fn DispatchMode, drop runtime-wide useFutures

### DIFF
--- a/lib/src/bridge/bridge.dart
+++ b/lib/src/bridge/bridge.dart
@@ -24,7 +24,6 @@ abstract class MontyBridge implements AttachContext {
   factory MontyBridge({
     required MontyPlatform platform,
     MontyLimits? limits,
-    bool useFutures,
     BridgeLogger? logger,
     MontyInterceptor? interceptor,
   }) = PlatformBridge;

--- a/lib/src/bridge/platform.dart
+++ b/lib/src/bridge/platform.dart
@@ -117,13 +117,11 @@ class PlatformBridge implements MontyBridge, AttachContext {
   PlatformBridge({
     required MontyPlatform platform,
     MontyLimits? limits,
-    bool useFutures = true,
     BridgeLogger? logger,
     MontyInterceptor? interceptor,
     MontyRuntimeRef? runtime,
   }) : _platform = platform,
        _limits = limits,
-       _useFutures = useFutures,
        log = logger ?? StructLogBridgeLogger.root(LogManager.instance),
        _host = HostDispatch(
          platform: platform,
@@ -138,7 +136,6 @@ class PlatformBridge implements MontyBridge, AttachContext {
 
   final MontyPlatform _platform;
   final MontyLimits? _limits;
-  final bool _useFutures;
   final HostDispatch _host;
 
   OsCallHandler? _osHandler;
@@ -363,7 +360,7 @@ class PlatformBridge implements MontyBridge, AttachContext {
     controller.add(BridgeRunStarted(threadId: threadId, runId: runId));
 
     final externalFunctions = _host.schemas.map((s) => s.name).toList();
-    final futuresCapable = _useFutures && _platform is MontyFutureCapable;
+    final futuresCapable = _platform is MontyFutureCapable;
     _host.clearPendingFutures();
 
     try {

--- a/lib/src/extensions/event_loop.dart
+++ b/lib/src/extensions/event_loop.dart
@@ -169,6 +169,7 @@ class EventLoopExtension extends MontyExtension
             'Pause execution until an event is dispatched from the host.',
       ),
       handler: _handleRecv,
+      dispatch: DispatchMode.future,
     ),
     HostFunction(
       schema: const HostFunctionSchema(
@@ -183,6 +184,7 @@ class EventLoopExtension extends MontyExtension
         ],
       ),
       handler: _handleEmit,
+      dispatch: DispatchMode.future,
     ),
   ];
 

--- a/lib/src/extensions/sandbox.dart
+++ b/lib/src/extensions/sandbox.dart
@@ -605,7 +605,6 @@ class SandboxExtension extends MontyExtension
       bridge = PlatformBridge(
         platform: platform,
         limits: limits,
-        useFutures: false,
         logger: logger.child('child.${spawnContext.childId}'),
       );
       logger.debug(

--- a/lib/src/host/dispatch.dart
+++ b/lib/src/host/dispatch.dart
@@ -307,6 +307,7 @@ class HostDispatch {
 
       final useFutureDispatch =
           fn.dispatch == DispatchMode.future && futuresCapable;
+
       return useFutureDispatch
           ? dispatchToolCallAsFuture(fn, pending, controller)
           : dispatchToolCall(fn, pending, controller);

--- a/lib/src/host/dispatch.dart
+++ b/lib/src/host/dispatch.dart
@@ -4,7 +4,8 @@ import 'dart:convert';
 import 'package:dart_monty/src/bridge/event.dart';
 import 'package:dart_monty/src/bridge/logger.dart';
 import 'package:dart_monty/src/host/context.dart';
-import 'package:dart_monty/src/host/function.dart';
+import 'package:dart_monty/src/host/function.dart'
+    show DispatchMode, HostFunction;
 import 'package:dart_monty/src/host/function_surface.dart';
 import 'package:dart_monty/src/host/schema.dart';
 import 'package:dart_monty/src/runtime/runtime_ref.dart';
@@ -304,7 +305,9 @@ class HostDispatch {
     if (fn != null) {
       _log.trace('Host function call', attributes: {'name': name});
 
-      return futuresCapable
+      final useFutureDispatch =
+          fn.dispatch == DispatchMode.future && futuresCapable;
+      return useFutureDispatch
           ? dispatchToolCallAsFuture(fn, pending, controller)
           : dispatchToolCall(fn, pending, controller);
     }

--- a/lib/src/host/function.dart
+++ b/lib/src/host/function.dart
@@ -8,9 +8,9 @@ import 'package:meta/meta.dart';
 /// How the bridge dispatches calls to a [HostFunction].
 enum DispatchMode {
   /// Bridge awaits the handler's Future before resuming Python. Python
-  /// sees a plain value at the call site. Required for synchronous-
-  /// blocking semantics (e.g. `el_recv` blocks until Dart dispatches)
-  /// and for FIFO ordering invariants (e.g. MessageBus).
+  /// sees a plain value at the call site. Use for functions with
+  /// FIFO ordering invariants (e.g. MessageBus) or simple request-
+  /// response handlers that don't benefit from concurrency.
   sync,
 
   /// Bridge launches the handler unawaited, replies with

--- a/lib/src/host/function.dart
+++ b/lib/src/host/function.dart
@@ -5,6 +5,21 @@ import 'package:dart_monty/src/host/schema.dart';
 import 'package:dart_monty/src/runtime/backend_kind.dart';
 import 'package:meta/meta.dart';
 
+/// How the bridge dispatches calls to a [HostFunction].
+enum DispatchMode {
+  /// Bridge awaits the handler's Future before resuming Python. Python
+  /// sees a plain value at the call site. Required for synchronous-
+  /// blocking semantics (e.g. `el_recv` blocks until Dart dispatches)
+  /// and for FIFO ordering invariants (e.g. MessageBus).
+  sync,
+
+  /// Bridge launches the handler unawaited, replies with
+  /// `resumeAsFuture()`, batch-resolves via `resolveFutures` when
+  /// Python suspends. Enables `asyncio.gather` parallelism and
+  /// `await ext()` from Python.
+  future,
+}
+
 /// Async handler that receives validated named arguments and a [HostContext].
 typedef HostFunctionHandler =
     Future<Object?> Function(Map<String, Object?> args, HostContext ctx);
@@ -30,6 +45,11 @@ class HostFunction {
   /// child sandboxes spawned from the parent runtime. Defaults to
   /// [ChildPropagation.exclude] — children see only extension
   /// functions, not ad-hoc functions registered via `extraFunctions:`.
+  ///
+  /// [dispatch] controls whether the bridge dispatches this function
+  /// synchronously (default [DispatchMode.sync]) or as a deferred future
+  /// ([DispatchMode.future]). Use [DispatchMode.future] only for handlers
+  /// that benefit from concurrency (network I/O, `asyncio.gather` patterns).
   const HostFunction({
     required this.schema,
     HostFunctionHandler? handler,
@@ -38,6 +58,7 @@ class HostFunction {
     this.isInfra = false,
     this.surfaces = const {FunctionSurface.python},
     this.childPropagation = ChildPropagation.exclude,
+    this.dispatch = DispatchMode.sync,
   }) : ffiHandler = ffiHandler ?? handler,
        wasmHandler = wasmHandler ?? handler;
 
@@ -70,6 +91,13 @@ class HostFunction {
   /// `ExtensionCoordinator.attachTo` — extension-provided functions are
   /// governed by [MontyExtension.childPolicy] instead.
   final ChildPropagation childPropagation;
+
+  /// How the bridge dispatches calls to this function.
+  ///
+  /// Defaults to [DispatchMode.sync] — the bridge awaits the handler before
+  /// resuming Python. Set to [DispatchMode.future] for handlers that benefit
+  /// from concurrent dispatch (e.g. network I/O, `asyncio.gather` callers).
+  final DispatchMode dispatch;
 
   /// The handler for the current backend, or `null` if not available.
   ///

--- a/lib/src/runtime/runtime.dart
+++ b/lib/src/runtime/runtime.dart
@@ -73,7 +73,6 @@ class MontyRuntime implements MontyRuntimeRef {
     BridgeLogger? logger,
     MontyInterceptor? interceptor,
     bool sandbox = false,
-    bool useFutures = false,
     DescriptionProvider? descriptionProvider,
   }) : assert(
          os == null || osHandlers == null,
@@ -84,7 +83,6 @@ class MontyRuntime implements MontyRuntimeRef {
        _logger = logger,
        _interceptor = interceptor,
        _sandbox = sandbox,
-       _useFutures = useFutures,
        _descriptionProvider = descriptionProvider {
     if (!sandbox) {
       // Shared mode: create persistent REPL-backed interpreter.
@@ -94,7 +92,6 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
       _sharedBridge = PlatformBridge(
         platform: _sharedPlatform!,
-        useFutures: _useFutures,
         logger: logger,
         interceptor: interceptor,
         runtime: this,
@@ -117,7 +114,6 @@ class MontyRuntime implements MontyRuntimeRef {
   final BridgeLogger? _logger;
   final MontyInterceptor? _interceptor;
   final bool _sandbox;
-  final bool _useFutures;
   final DescriptionProvider? _descriptionProvider;
 
   // Shared mode state.
@@ -293,7 +289,6 @@ class MontyRuntime implements MontyRuntimeRef {
       _sharedPlatform = ReplPlatform(repl: _sharedRepl!);
       _sharedBridge = PlatformBridge(
         platform: _sharedPlatform!,
-        useFutures: _useFutures,
         logger: _logger,
         runtime: this,
       );
@@ -452,7 +447,6 @@ class MontyRuntime implements MontyRuntimeRef {
   PlatformBridge _buildBridge({MontyPlatform? platform}) {
     final b = PlatformBridge(
       platform: platform ?? ReplPlatform(repl: MontyRepl()),
-      useFutures: _useFutures,
       logger: _logger,
       interceptor: _interceptor,
       runtime: this,
@@ -483,6 +477,7 @@ class MontyRuntime implements MontyRuntimeRef {
       isInfra: fn.isInfra,
       surfaces: fn.surfaces,
       childPropagation: fn.childPropagation,
+      dispatch: fn.dispatch,
     );
   }
 }

--- a/test/integration/_runtime_async_matrix_body.dart
+++ b/test/integration/_runtime_async_matrix_body.dart
@@ -3,14 +3,11 @@
 //
 // Layer 4 takes a different code path than Layer 2/3 (which go through
 // dart_monty_core's `MontyRepl.feedRun` → `_driveLoop`). MontyRuntime
-// builds a `PlatformBridge` and uses `dispatchToolCallAsFuture` directly
-// when `useFutures: true` is set on the runtime constructor and the
-// platform implements `MontyFutureCapable`. This test pins the cell-by-cell
-// contract from that surface.
+// builds a `PlatformBridge` that is always futures-capable; per-fn
+// `DispatchMode` selects sync vs future dispatch for each call.
 //
-// Both `ffi_runtime_async_matrix_test.dart` calls
-// [runRuntimeAsyncMatrixTests] (FFI only — dart_monty has no WASM-tagged
-// integration suite).
+// `ffi_runtime_async_matrix_test.dart` calls [runRuntimeAsyncMatrixTests]
+// (FFI only — dart_monty has no WASM-tagged integration suite).
 
 import 'dart:async';
 
@@ -44,6 +41,21 @@ void runRuntimeAsyncMatrixTests() {
 
         return (args['value']! as int) + 1;
       },
+    );
+
+    HostFunction fetchAsyncFuture(int Function() onCall) => HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        description: 'async fetch (future-mode)',
+        params: [HostParam(name: 'value', type: HostParamType.integer)],
+      ),
+      handler: (args, _) async {
+        await Future<void>.delayed(Duration.zero);
+        onCall();
+
+        return (args['value']! as int) + 1;
+      },
+      dispatch: DispatchMode.future,
     );
 
     // matrix-cell: (sync Dart) × (sync Python)
@@ -107,59 +119,68 @@ await doubled(3)
     });
 
     // matrix-cell: (async Dart) × (Python `await ext()`) — the key cell.
-    // Requires `MontyRuntime(useFutures: true)`.
-    test('cell 5a: useFutures=true wires Python `await fetch(x)`', () async {
-      var calls = 0;
-      final runtime = MontyRuntime(useFutures: true)
-        ..register(fetchAsync(() => calls++));
-      addTearDown(runtime.dispose);
+    // Handler declares DispatchMode.future so the bridge uses resumeAsFuture.
+    test(
+      'cell 5a: DispatchMode.future wires Python `await fetch(x)`',
+      () async {
+        var calls = 0;
+        final runtime = MontyRuntime()
+          ..register(fetchAsyncFuture(() => calls++));
+        addTearDown(runtime.dispose);
 
-      final r = await runtime.execute('await fetch(7)').result;
+        final r = await runtime.execute('await fetch(7)').result;
 
-      expect(r.error, isNull);
-      expect(r.value.dartValue, 8);
-      expect(calls, 1);
-    });
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 8);
+        expect(calls, 1);
+      },
+    );
 
-    test('cell 5b: useFutures=true + asyncio.gather over externals', () async {
-      final fired = <int>[];
-      final runtime = MontyRuntime(useFutures: true)
-        ..register(
-          HostFunction(
-            schema: const HostFunctionSchema(
-              name: 'fetch',
-              description: 'parallel fetch',
-              params: [HostParam(name: 'n', type: HostParamType.integer)],
+    test(
+      'cell 5b: DispatchMode.future + asyncio.gather over externals',
+      () async {
+        final fired = <int>[];
+        final runtime = MontyRuntime()
+          ..register(
+            HostFunction(
+              schema: const HostFunctionSchema(
+                name: 'fetch',
+                description: 'parallel fetch',
+                params: [HostParam(name: 'n', type: HostParamType.integer)],
+              ),
+              handler: (args, _) async {
+                final n = args['n']! as int;
+                fired.add(n);
+                await Future<void>.delayed(Duration.zero);
+
+                return n * 10;
+              },
+              dispatch: DispatchMode.future,
             ),
-            handler: (args, _) async {
-              final n = args['n']! as int;
-              fired.add(n);
-              await Future<void>.delayed(Duration.zero);
+          );
+        addTearDown(runtime.dispose);
 
-              return n * 10;
-            },
-          ),
-        );
-      addTearDown(runtime.dispose);
-
-      final r = await runtime.execute('''
+        final r = await runtime.execute('''
 import asyncio
 results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
 results
 ''').result;
 
-      expect(r.error, isNull);
-      expect(r.value.dartValue, [10, 20, 30]);
-      // Concurrent dispatch — all three callbacks fire (in some order)
-      // before gather yields.
-      expect(fired.toSet(), {1, 2, 3});
-      expect(fired, hasLength(3));
-    });
+        expect(r.error, isNull);
+        expect(r.value.dartValue, [10, 20, 30]);
+        // Concurrent dispatch — all three callbacks fire (in some order)
+        // before gather yields.
+        expect(fired.toSet(), {1, 2, 3});
+        expect(fired, hasLength(3));
+      },
+    );
 
-    // Default-off back-compat: `MontyRuntime()` (no useFutures flag) leaves
-    // Python `await ext()` raising TypeError, exactly as before this PR.
+    // Back-compat: handler with default DispatchMode.sync leaves Python
+    // `await ext()` raising TypeError — same observable failure as before,
+    // now because the handler declared sync rather than because a runtime
+    // flag was unset.
     test(
-      'useFutures=false: Python `await ext()` still raises TypeError',
+      'DispatchMode.sync (default): Python `await ext()` raises TypeError',
       () async {
         final runtime = MontyRuntime()..register(fetchAsync(() => 0));
         addTearDown(runtime.dispose);
@@ -171,12 +192,12 @@ results
       },
     );
 
-    // useFutures + inputs interplay — confirm the new flag composes with
-    // the existing inputs: parameter.
+    // DispatchMode.future + inputs interplay — confirm per-fn dispatch
+    // composes with the existing inputs: parameter.
     test(
-      'useFutures + inputs: inputs visible inside awaited external script',
+      'DispatchMode.future + inputs: inputs visible inside awaited external',
       () async {
-        final runtime = MontyRuntime(useFutures: true)
+        final runtime = MontyRuntime()
           ..register(
             HostFunction(
               schema: const HostFunctionSchema(
@@ -189,6 +210,7 @@ results
 
                 return 'hello, ${args['name']}';
               },
+              dispatch: DispatchMode.future,
             ),
           );
         addTearDown(runtime.dispose);
@@ -206,12 +228,12 @@ results
     );
 
     // asyncio.gather demonstrates wall-clock parallelism — sleep-heavy
-    // handlers run concurrently rather than sequentially when
-    // useFutures: true.
-    test('useFutures=true: gather of slow handlers takes ~one delay, '
+    // handlers run concurrently rather than sequentially when declared
+    // DispatchMode.future.
+    test('DispatchMode.future: gather of slow handlers takes ~one delay, '
         'not sum-of-delays', () async {
       const delayMs = 200;
-      final runtime = MontyRuntime(useFutures: true)
+      final runtime = MontyRuntime()
         ..register(
           HostFunction(
             schema: const HostFunctionSchema(
@@ -226,6 +248,7 @@ results
 
               return args['n'];
             },
+            dispatch: DispatchMode.future,
           ),
         );
       addTearDown(runtime.dispose);
@@ -247,7 +270,7 @@ await asyncio.gather(slow(1), slow(2), slow(3))
         lessThan(delayMs * 2),
         reason:
             'gather should run handlers concurrently under '
-            'useFutures: true; took ${sw.elapsedMilliseconds}ms',
+            'DispatchMode.future; took ${sw.elapsedMilliseconds}ms',
       );
     });
   });

--- a/test/integration/ffi_raw_bridge_http_test.dart
+++ b/test/integration/ffi_raw_bridge_http_test.dart
@@ -44,7 +44,6 @@ void main() {
       final platform = createPlatformMonty();
       final bridge = PlatformBridge(
         platform: platform,
-        useFutures: false,
       )..register(_httpGetFn());
 
       for (var i = 1; i <= 3; i++) {
@@ -66,7 +65,6 @@ void main() {
       final platform = createPlatformMonty();
       final bridge = PlatformBridge(
         platform: platform,
-        useFutures: false,
       )..register(_httpGetFn());
 
       for (var i = 1; i <= 3; i++) {

--- a/test/integration/message_bus_integration_test.dart
+++ b/test/integration/message_bus_integration_test.dart
@@ -43,8 +43,7 @@ void main() {
 
   String spawn(String childCode) => 'sandbox_spawn(code="$childCode")';
 
-  MontyBridge createBridge() =>
-      MontyBridge(platform: createPlatform(), useFutures: false);
+  MontyBridge createBridge() => MontyBridge(platform: createPlatform());
 
   Future<MontyBridge> createBridgeWithMessageBus() async {
     final bridge = createBridge();
@@ -66,7 +65,7 @@ void main() {
     final bridge = await createBridgeWithMessageBus();
 
     // Child blocks on msg_recv until the parent sends, then returns the value.
-    // useFutures: false on child bridges (#212) — direct call, no await.
+    // Child bridge dispatch is sync by default — direct call, no await.
     const childCode = r'msg_recv(name=\"inbox\")';
 
     final result = await run(
@@ -91,7 +90,7 @@ void main() {
     // and replies with a rich result — demonstrating first-class Dart
     // objects (maps, lists, ints, strings, bools) flowing both directions,
     // unlike print() which only returns flat strings.
-    // useFutures: false on child bridges (#212) — direct calls, no await.
+    // Child bridge dispatch is sync by default — direct calls, no await.
     final childCode = [
       r'task = msg_recv(name=\"work\")',
       r'items = task[\"items\"]',
@@ -126,7 +125,7 @@ void main() {
 
     // Each worker receives a value on its input channel, doubles it, and
     // sends the result on its output channel.
-    // useFutures: false on child bridges (#212) — direct calls, no await.
+    // Child bridge dispatch is sync by default — direct calls, no await.
     String workerCode(String inCh, String outCh) {
       final recvLine = 'task = msg_recv(name=\\"$inCh\\")';
       const doubleLine = r'doubled = task[\"value\"] * 2';

--- a/test/integration/sandbox_error_structure_test.dart
+++ b/test/integration/sandbox_error_structure_test.dart
@@ -28,8 +28,7 @@ void main() {
 
   MontyPlatform createPlatform() => MontyFfi(bindings: bindings);
 
-  MontyBridge createBridge() =>
-      MontyBridge(platform: createPlatform(), useFutures: false);
+  MontyBridge createBridge() => MontyBridge(platform: createPlatform());
 
   /// Spawns a child via plugin handler and awaits it, expecting a
   /// [ChildSandboxException]. Returns the caught exception.

--- a/test/integration/sandbox_gather_test.dart
+++ b/test/integration/sandbox_gather_test.dart
@@ -28,8 +28,7 @@ void main() {
 
   MontyPlatform createPlatform() => MontyFfi(bindings: bindings);
 
-  MontyBridge createBridge() =>
-      MontyBridge(platform: createPlatform(), useFutures: false);
+  MontyBridge createBridge() => MontyBridge(platform: createPlatform());
 
   group('sandbox_gather with real FFI', () {
     test(

--- a/test/integration/sandbox_inheritance_test.dart
+++ b/test/integration/sandbox_inheritance_test.dart
@@ -44,11 +44,7 @@ void main() {
   /// Python expression: `sandbox_spawn(code="[childCode]")`.
   String spawn(String childCode) => 'sandbox_spawn(code="$childCode")';
 
-  // Parent bridge uses useFutures: false for simpler test code.
-  // Child bridges (created by SandboxExtension) also use useFutures: false
-  // (see #212 — prevents unawaited Future leaking as Python coroutine).
-  MontyBridge createBridge() =>
-      MontyBridge(platform: createPlatform(), useFutures: false);
+  MontyBridge createBridge() => MontyBridge(platform: createPlatform());
 
   // ---------------------------------------------------------------------------
   // Baseline: child sandboxs work without plugins
@@ -63,8 +59,7 @@ void main() {
         );
       await registry.attachTo(bridge);
 
-      // Host functions are called synchronously from Python — the parent
-      // bridge has useFutures: false.
+      // Host functions are called synchronously (DispatchMode.sync default).
       final result = await run(
         bridge,
         'h = ${spawn("2 + 3")}\n'
@@ -130,7 +125,7 @@ void main() {
         );
       await registry.attachTo(bridge);
 
-      // Child bridge uses useFutures: false (#212) — direct calls.
+      // Child bridge dispatch is sync by default — direct calls.
       const cc = r'greeter_hello(name=\"child\")';
       final result = await run(
         bridge,
@@ -180,7 +175,7 @@ void main() {
       await registry.attachTo(bridge);
 
       // Each child increments its own counter independently.
-      // useFutures: false — direct calls, no async/await needed.
+      // Dispatch is sync (DispatchMode.sync default) — direct calls, no async/await needed.
       final cc = ['counter_increment()', 'counter_get()'].join(r'\n');
       final result = await run(
         bridge,

--- a/test/integration/sandbox_logging_test.dart
+++ b/test/integration/sandbox_logging_test.dart
@@ -47,7 +47,6 @@ void main() {
 
   MontyBridge createBridge() => MontyBridge(
     platform: createPlatform(),
-    useFutures: false,
     logger: StructLogBridgeLogger.root(LogManager.instance),
   );
 

--- a/test/src/bridge/event_loop_test.dart
+++ b/test/src/bridge/event_loop_test.dart
@@ -695,7 +695,6 @@ void main() {
       final syncPlugin = EventLoopExtension();
       final syncBridge = PlatformBridge(
         platform: syncMock,
-        useFutures: false,
       );
       await syncPlugin.onAttach(syncBridge);
       for (final fn in syncPlugin.functions) {
@@ -850,7 +849,6 @@ void main() {
         final lockMock = MockMontyPlatform();
         final lockBridge = PlatformBridge(
           platform: lockMock,
-          useFutures: false,
         );
         addTearDown(lockBridge.dispose);
 

--- a/test/src/bridge/platform_bridge_test.dart
+++ b/test/src/bridge/platform_bridge_test.dart
@@ -34,6 +34,7 @@ void main() {
           handler: (_, _) async {
             throw StateError('async kaboom');
           },
+          dispatch: DispatchMode.future,
         ),
       );
 

--- a/test/src/bridge/platform_bridge_test.dart
+++ b/test/src/bridge/platform_bridge_test.dart
@@ -197,7 +197,7 @@ void main() {
       final syncMock = MockMontyPlatform();
       final syncBridge = MontyBridge(
         platform: syncMock,
-        useFutures: false,
+
         interceptor: (name, args, next) async => 'blocked',
       );
       addTearDown(syncBridge.dispose);
@@ -226,7 +226,7 @@ void main() {
       final syncMock = MockMontyPlatform();
       final syncBridge = MontyBridge(
         platform: syncMock,
-        useFutures: false,
+
         interceptor: (name, args, next) => throw StateError('Access denied'),
       );
       addTearDown(syncBridge.dispose);
@@ -863,7 +863,7 @@ void main() {
       );
       final b = MontyBridge(
         platform: throwingMock,
-        useFutures: false,
+
         logger: const NullBridgeLogger(),
       );
       addTearDown(b.dispose);
@@ -894,7 +894,7 @@ void main() {
         );
         final b = MontyBridge(
           platform: throwingMock,
-          useFutures: false,
+
           logger: const NullBridgeLogger(),
         );
         addTearDown(b.dispose);
@@ -925,7 +925,7 @@ void main() {
         final throwingMock = _PrintThenThrowPlatform();
         final b = MontyBridge(
           platform: throwingMock,
-          useFutures: false,
+
           logger: const NullBridgeLogger(),
         );
         addTearDown(b.dispose);
@@ -1036,7 +1036,7 @@ void main() {
       final syncMock = MockMontyPlatform();
       final syncBridge = MontyBridge(
         platform: syncMock,
-        useFutures: false,
+
         logger: const NullBridgeLogger(),
       );
       addTearDown(syncBridge.dispose);
@@ -1102,12 +1102,11 @@ void main() {
 
   group('ResolveFutures without futures-capable platform', () {
     test('resumes with null when not futures-capable and no pending', () async {
-      // MontyBridge with useFutures: false — ResolveFutures just resumes
-      // with null.
+      // Non-futures-capable platform — ResolveFutures just resumes with null.
       final syncMock = MockMontyPlatform();
       final syncBridge = MontyBridge(
         platform: syncMock,
-        useFutures: false,
+
         logger: const NullBridgeLogger(),
       );
       addTearDown(syncBridge.dispose);
@@ -1137,7 +1136,7 @@ void main() {
       () async {
         // Platform throws when resume() is called with 'hello'.
         final failMock = _ResumeFailsPlatform()..failOnValue = 'hello';
-        final failBridge = MontyBridge(platform: failMock, useFutures: false)
+        final failBridge = MontyBridge(platform: failMock)
           ..register(
             HostFunction(
               schema: const HostFunctionSchema(
@@ -1187,7 +1186,7 @@ void main() {
       () async {
         // Fail when resuming with value '3' (the 3rd call).
         final failMock = _ResumeFailsPlatform()..failOnValue = '3';
-        final failBridge = MontyBridge(platform: failMock, useFutures: false)
+        final failBridge = MontyBridge(platform: failMock)
           ..register(
             HostFunction(
               schema: const HostFunctionSchema(


### PR DESCRIPTION
## Summary

Replaces the runtime-wide `useFutures: bool` toggle with a per-function `DispatchMode` on `HostFunction`. Each host function now declares independently whether it should be dispatched synchronously or as an async future — no global flag required.

- Added `DispatchMode` enum (`sync` | `future`) and `dispatch` field to `HostFunction` (default `sync`)
- `HostDispatch.handlePending` selects `dispatchToolCallAsFuture` vs `dispatchToolCall` based on `fn.dispatch == DispatchMode.future && futuresCapable`
- Removed `useFutures` constructor param from `MontyRuntime`, `PlatformBridge`, and `MontyBridge`; `futuresCapable` is now purely derived from `_platform is MontyFutureCapable`
- `_applyDescription` threads `dispatch: fn.dispatch` through HostFunction rebuilds
- Integration test matrix (`_runtime_async_matrix_body.dart`): cells 5a/5b/gather use `HostFunction(dispatch: DispatchMode.future)`; back-compat test verifies sync-dispatched function against Python `await` still raises `TypeError`

## Test plan

- [ ] `dart test` passes on FFI and WASM targets
- [ ] `dcm analyze lib` clean
- [ ] `dart format --set-exit-if-changed .` clean