### PR TITLE
feat: wire dart_monty_core args/kwargs callback (pending.args rename)

### DIFF
--- a/example/native/bin/async_matrix_demo.dart
+++ b/example/native/bin/async_matrix_demo.dart
@@ -46,7 +46,7 @@ HostFunction asyncFetch(void Function() onCall) => HostFunction(
 );
 
 /// A slow async host fn — sleeps `delay` before returning, so we can see
-/// `asyncio.gather` flatten wall-clock time when `useFutures: true`.
+/// `asyncio.gather` flatten wall-clock time.
 HostFunction slowFetch(Duration delay) => HostFunction(
   schema: const HostFunctionSchema(
     name: 'slow',
@@ -57,6 +57,37 @@ HostFunction slowFetch(Duration delay) => HostFunction(
     await Future<void>.delayed(delay);
     return (args['n']! as int) * 10;
   },
+);
+
+/// Like [asyncFetch] but declared [DispatchMode.future] so Python can
+/// directly `await` it.
+HostFunction asyncFetchFuture(void Function() onCall) => HostFunction(
+  schema: const HostFunctionSchema(
+    name: 'fetch',
+    description: 'Async fetch (future-mode) — awaits Future.delayed, adds 1.',
+    params: [HostParam(name: 'value', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(Duration.zero);
+    onCall();
+    return (args['value']! as int) + 1;
+  },
+  dispatch: DispatchMode.future,
+);
+
+/// Like [slowFetch] but declared [DispatchMode.future] so `asyncio.gather`
+/// can run multiple calls concurrently.
+HostFunction slowFetchFuture(Duration delay) => HostFunction(
+  schema: const HostFunctionSchema(
+    name: 'slow',
+    description: 'Sleeps then returns its argument times 10 (future-mode).',
+    params: [HostParam(name: 'n', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(delay);
+    return (args['n']! as int) * 10;
+  },
+  dispatch: DispatchMode.future,
 );
 
 Future<void> main() async {
@@ -143,14 +174,14 @@ await doubled(3)
   //
   //     result = await fetch(7)
   //
-  // For this to work the bridge must hand Python a coroutine/future
-  // object, not a value. That requires `useFutures: true`.
+  // For this to work the fn must be declared DispatchMode.future so the
+  // bridge hands Python a coroutine object rather than a plain value.
   //
-  // First we show the default (`useFutures: false`) raises TypeError —
+  // Step 1 shows the default (DispatchMode.sync) raises TypeError —
   // Python can't await an int.
-  // Then we re-run with `useFutures: true` and it just works.
+  // Step 2 uses DispatchMode.future and it just works.
   print('── Cell 5a: async Dart × Python `await ext()` ─────────────────');
-  print('  Step 1 — useFutures: false (the default):');
+  print('  Step 1 — DispatchMode.sync (the default):');
   {
     final runtime = MontyRuntime()..register(asyncFetch(() {}));
     final r = await runtime.execute('await fetch(7)').result;
@@ -162,11 +193,10 @@ await doubled(3)
     }
     await runtime.dispose();
   }
-  print('  Step 2 — useFutures: true:');
+  print('  Step 2 — DispatchMode.future:');
   {
     var calls = 0;
-    final runtime = MontyRuntime(useFutures: true)
-      ..register(asyncFetch(() => calls++));
+    final runtime = MontyRuntime()..register(asyncFetchFuture(() => calls++));
     final r = await runtime.execute('await fetch(7)').result;
     print('    Python: await fetch(7)');
     print(
@@ -177,14 +207,14 @@ await doubled(3)
   }
   print('');
 
-  // ── Cell 5b: asyncio.gather + useFutures: true ───────────────────────
+  // ── Cell 5b: asyncio.gather + DispatchMode.future ────────────────────
   // The pay-off cell. Three host calls each sleep 200ms. With
-  // `useFutures: true`, asyncio.gather runs them concurrently — wall
+  // DispatchMode.future, asyncio.gather runs them concurrently — wall
   // clock should be ~200ms, NOT ~600ms.
-  print('── Cell 5b: asyncio.gather + useFutures: true ─────────────────');
+  print('── Cell 5b: asyncio.gather + DispatchMode.future ───────────────');
   {
     const delay = Duration(milliseconds: 200);
-    final runtime = MontyRuntime(useFutures: true)..register(slowFetch(delay));
+    final runtime = MontyRuntime()..register(slowFetchFuture(delay));
     final sw = Stopwatch()..start();
     final r = await runtime.execute('''
 import asyncio

--- a/example/web/bin/agent_demo.dart
+++ b/example/web/bin/agent_demo.dart
@@ -283,10 +283,10 @@ Future<String> _execute(String code) async {
 Map<String, dynamic> _eventToMap(BridgeEvent event) {
   return switch (event) {
     BridgeRunStarted(:final threadId, :final runId) => {
-        'type': 'RunStarted',
-        'threadId': threadId,
-        'runId': runId,
-      },
+      'type': 'RunStarted',
+      'threadId': threadId,
+      'runId': runId,
+    },
     BridgeRunFinished(
       :final threadId,
       :final runId,
@@ -301,37 +301,37 @@ Map<String, dynamic> _eventToMap(BridgeEvent event) {
         if (printOutput != null) 'printOutput': printOutput,
       },
     BridgeRunError(:final message, :final printOutput) => {
-        'type': 'RunError',
-        'message': message,
-        if (printOutput != null) 'printOutput': printOutput,
-      },
+      'type': 'RunError',
+      'message': message,
+      if (printOutput != null) 'printOutput': printOutput,
+    },
     BridgeCallStarted(:final callId) => {
-        'type': 'CallStarted',
-        'callId': callId,
-      },
+      'type': 'CallStarted',
+      'callId': callId,
+    },
     BridgeCallFinished(:final callId) => {
-        'type': 'CallFinished',
-        'callId': callId,
-      },
+      'type': 'CallFinished',
+      'callId': callId,
+    },
     BridgeFunctionCallStart(:final callId, :final name) => {
-        'type': 'FunctionCallStart',
-        'callId': callId,
-        'name': name,
-      },
+      'type': 'FunctionCallStart',
+      'callId': callId,
+      'name': name,
+    },
     BridgeFunctionCallArgs(:final callId, :final delta) => {
-        'type': 'FunctionCallArgs',
-        'callId': callId,
-        'delta': delta,
-      },
+      'type': 'FunctionCallArgs',
+      'callId': callId,
+      'delta': delta,
+    },
     BridgeFunctionCallEnd(:final callId) => {
-        'type': 'FunctionCallEnd',
-        'callId': callId,
-      },
+      'type': 'FunctionCallEnd',
+      'callId': callId,
+    },
     BridgeFunctionCallResult(:final callId, :final result) => {
-        'type': 'FunctionCallResult',
-        'callId': callId,
-        'result': result,
-      },
+      'type': 'FunctionCallResult',
+      'callId': callId,
+      'result': result,
+    },
     BridgeOsCallStart(
       :final callId,
       :final operationName,
@@ -344,21 +344,21 @@ Map<String, dynamic> _eventToMap(BridgeEvent event) {
         if (argumentSummary != null) 'argumentSummary': argumentSummary,
       },
     BridgeOsCallResult(:final callId, :final result, :final durationMs) => {
-        'type': 'OsCallResult',
-        'callId': callId,
-        'result': result,
-        if (durationMs != null) 'durationMs': durationMs,
-      },
+      'type': 'OsCallResult',
+      'callId': callId,
+      'result': result,
+      if (durationMs != null) 'durationMs': durationMs,
+    },
     BridgeFunctionEmit(:final callId, :final text) => {
-        'type': 'FunctionEmit',
-        'callId': callId,
-        'text': text,
-      },
+      'type': 'FunctionEmit',
+      'callId': callId,
+      'text': text,
+    },
     BridgeChildEvent(:final childHandle, :final inner) => {
-        'type': 'ChildEvent',
-        'childHandle': childHandle,
-        'inner': _eventToMap(inner),
-      },
+      'type': 'ChildEvent',
+      'childHandle': childHandle,
+      'inner': _eventToMap(inner),
+    },
   };
 }
 
@@ -456,8 +456,8 @@ Future<void> main() async {
   final api = <String, JSFunction>{
     'init': (() => _init().then((ok) => ok.toJS).toJS).toJS,
     'execute': ((JSString code) => _execute(
-          code.toDart,
-        ).then((r) => r.toJS).toJS).toJS,
+      code.toDart,
+    ).then((r) => r.toJS).toJS).toJS,
     'getState': (() => _getState().toJS).toJS,
     'getSchemas': (() => _getSchemas().toJS).toJS,
     'clearState': _clearState.toJS,

--- a/example/web/bin/async_matrix_demo.dart
+++ b/example/web/bin/async_matrix_demo.dart
@@ -20,44 +20,44 @@ import 'package:dart_monty/dart_monty_bridge.dart';
 
 /// A sync host fn — returns its result without ever yielding the event loop.
 HostFunction syncFetch(void Function() onCall) => HostFunction(
-      schema: const HostFunctionSchema(
-        name: 'fetch',
-        description: 'Sync fetch — adds 1 to its argument.',
-        params: [HostParam(name: 'value', type: HostParamType.integer)],
-      ),
-      handler: (args, _) async {
-        onCall();
-        return (args['value']! as int) + 1;
-      },
-    );
+  schema: const HostFunctionSchema(
+    name: 'fetch',
+    description: 'Sync fetch — adds 1 to its argument.',
+    params: [HostParam(name: 'value', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    onCall();
+    return (args['value']! as int) + 1;
+  },
+);
 
 /// An async host fn — actually awaits a Future before returning.
 HostFunction asyncFetch(void Function() onCall) => HostFunction(
-      schema: const HostFunctionSchema(
-        name: 'fetch',
-        description: 'Async fetch — awaits Future.delayed, then adds 1.',
-        params: [HostParam(name: 'value', type: HostParamType.integer)],
-      ),
-      handler: (args, _) async {
-        await Future<void>.delayed(Duration.zero);
-        onCall();
-        return (args['value']! as int) + 1;
-      },
-    );
+  schema: const HostFunctionSchema(
+    name: 'fetch',
+    description: 'Async fetch — awaits Future.delayed, then adds 1.',
+    params: [HostParam(name: 'value', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(Duration.zero);
+    onCall();
+    return (args['value']! as int) + 1;
+  },
+);
 
 /// A slow async host fn — sleeps `delay` before returning, so we can see
 /// `asyncio.gather` flatten wall-clock time when `useFutures: true`.
 HostFunction slowFetch(Duration delay) => HostFunction(
-      schema: const HostFunctionSchema(
-        name: 'slow',
-        description: 'Sleeps then returns its argument times 10.',
-        params: [HostParam(name: 'n', type: HostParamType.integer)],
-      ),
-      handler: (args, _) async {
-        await Future<void>.delayed(delay);
-        return (args['n']! as int) * 10;
-      },
-    );
+  schema: const HostFunctionSchema(
+    name: 'slow',
+    description: 'Sleeps then returns its argument times 10.',
+    params: [HostParam(name: 'n', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(delay);
+    return (args['n']! as int) * 10;
+  },
+);
 
 Future<void> main() async {
   print('=== dart_monty async/sync matrix — Web (WASM) demo ===');

--- a/example/web/bin/async_matrix_demo.dart
+++ b/example/web/bin/async_matrix_demo.dart
@@ -46,7 +46,7 @@ HostFunction asyncFetch(void Function() onCall) => HostFunction(
 );
 
 /// A slow async host fn — sleeps `delay` before returning, so we can see
-/// `asyncio.gather` flatten wall-clock time when `useFutures: true`.
+/// `asyncio.gather` flatten wall-clock time.
 HostFunction slowFetch(Duration delay) => HostFunction(
   schema: const HostFunctionSchema(
     name: 'slow',
@@ -57,6 +57,37 @@ HostFunction slowFetch(Duration delay) => HostFunction(
     await Future<void>.delayed(delay);
     return (args['n']! as int) * 10;
   },
+);
+
+/// Like [asyncFetch] but declared [DispatchMode.future] so Python can
+/// directly `await` it.
+HostFunction asyncFetchFuture(void Function() onCall) => HostFunction(
+  schema: const HostFunctionSchema(
+    name: 'fetch',
+    description: 'Async fetch (future-mode) — awaits Future.delayed, adds 1.',
+    params: [HostParam(name: 'value', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(Duration.zero);
+    onCall();
+    return (args['value']! as int) + 1;
+  },
+  dispatch: DispatchMode.future,
+);
+
+/// Like [slowFetch] but declared [DispatchMode.future] so `asyncio.gather`
+/// can run multiple calls concurrently.
+HostFunction slowFetchFuture(Duration delay) => HostFunction(
+  schema: const HostFunctionSchema(
+    name: 'slow',
+    description: 'Sleeps then returns its argument times 10 (future-mode).',
+    params: [HostParam(name: 'n', type: HostParamType.integer)],
+  ),
+  handler: (args, _) async {
+    await Future<void>.delayed(delay);
+    return (args['n']! as int) * 10;
+  },
+  dispatch: DispatchMode.future,
 );
 
 Future<void> main() async {
@@ -141,14 +172,14 @@ await doubled(3)
   //
   //     result = await fetch(7)
   //
-  // For this to work the bridge must hand Python a coroutine/future
-  // object, not a value. That requires `useFutures: true`.
+  // For this to work the fn must be declared DispatchMode.future so the
+  // bridge hands Python a coroutine object rather than a plain value.
   //
-  // First we show the default (`useFutures: false`) raises TypeError —
+  // Step 1 shows the default (DispatchMode.sync) raises TypeError —
   // Python can't await an int.
-  // Then we re-run with `useFutures: true` and it just works.
+  // Step 2 uses DispatchMode.future and it just works.
   print('── Cell 5a: async Dart × Python `await ext()` ──');
-  print('  Step 1 — useFutures: false (the default):');
+  print('  Step 1 — DispatchMode.sync (the default):');
   {
     final runtime = MontyRuntime()..register(asyncFetch(() {}));
     final r = await runtime.execute('await fetch(7)').result;
@@ -160,11 +191,10 @@ await doubled(3)
     }
     await runtime.dispose();
   }
-  print('  Step 2 — useFutures: true:');
+  print('  Step 2 — DispatchMode.future:');
   {
     var calls = 0;
-    final runtime = MontyRuntime(useFutures: true)
-      ..register(asyncFetch(() => calls++));
+    final runtime = MontyRuntime()..register(asyncFetchFuture(() => calls++));
     final r = await runtime.execute('await fetch(7)').result;
     print('    Python: await fetch(7)');
     print(
@@ -175,14 +205,14 @@ await doubled(3)
   }
   print('');
 
-  // ── Cell 5b: asyncio.gather + useFutures: true ───────────────────────
+  // ── Cell 5b: asyncio.gather + DispatchMode.future ────────────────────
   // The pay-off cell. Three host calls each sleep 200ms. With
-  // `useFutures: true`, asyncio.gather runs them concurrently — wall
+  // DispatchMode.future, asyncio.gather runs them concurrently — wall
   // clock should be ~200ms, NOT ~600ms.
-  print('── Cell 5b: asyncio.gather + useFutures: true ──');
+  print('── Cell 5b: asyncio.gather + DispatchMode.future ──');
   {
     const delay = Duration(milliseconds: 200);
-    final runtime = MontyRuntime(useFutures: true)..register(slowFetch(delay));
+    final runtime = MontyRuntime()..register(slowFetchFuture(delay));
     final sw = Stopwatch()..start();
     final r = await runtime.execute('''
 import asyncio

--- a/example/web/bin/ladder_showcase.dart
+++ b/example/web/bin/ladder_showcase.dart
@@ -326,7 +326,8 @@ Future<Map<String, dynamic>> _runExpectError(
 
   return {
     'status': 'warn',
-    'detail': 'Expected error but got value: ${result['value']}'
+    'detail':
+        'Expected error but got value: ${result['value']}'
         ' — WASM Monty may handle this differently than CPython',
   };
 }
@@ -477,8 +478,7 @@ Future<Map<String, dynamic>> _runAsync(Map<String, dynamic> fixture) async {
     (await _montyResolveFutures(
       jsonEncode(results).toJS,
       jsonEncode(errors).toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
 
   if (result['ok'] != true) {
@@ -520,7 +520,8 @@ Map<String, dynamic> _compareResult(
 
     return {
       'status': 'warn',
-      'detail': 'Value: $str'
+      'detail':
+          'Value: $str'
           ' — expected to contain "$expectedContains"'
           ' (WASM Monty behavioral difference)',
     };
@@ -535,7 +536,8 @@ Map<String, dynamic> _compareResult(
 
     return {
       'status': 'warn',
-      'detail': 'Value: $actual'
+      'detail':
+          'Value: $actual'
           ' — expected (sorted): $expected'
           ' (WASM Monty behavioral difference)',
     };
@@ -547,7 +549,8 @@ Map<String, dynamic> _compareResult(
 
   return {
     'status': 'warn',
-    'detail': 'Value: $actual'
+    'detail':
+        'Value: $actual'
         ' — expected: $expected'
         ' (WASM Monty behavioral difference)',
   };

--- a/example/web/bin/main.dart
+++ b/example/web/bin/main.dart
@@ -70,8 +70,7 @@ def fib(n):
 fib(10)
 '''
           .toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
   print('  fib(10) = ${r['value']}');
 
@@ -94,16 +93,14 @@ fib(10)
     (await _bridgeStart(
       'fetch("https://example.com")'.toJS,
       '["fetch"]'.toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
   print('  start() → state=${r['state']}, fn=${r['functionName']}');
 
   r = _parse(
     (await _bridgeResume(
       jsonEncode('<html>Hello from Dart!</html>').toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
   print('  resume() → state=${r['state']}, value=${r['value']}');
 
@@ -121,16 +118,14 @@ result
 '''
           .toJS,
       '["fetch"]'.toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
   print('  start() → state=${r['state']}');
 
   r = _parse(
     (await _bridgeResumeWithError(
       jsonEncode('network timeout').toJS,
-    ).toDart)
-        .toDart,
+    ).toDart).toDart,
   );
   print('  resumeWithError() → value=${r['value']}');
 

--- a/example/web/bin/repl_demo.dart
+++ b/example/web/bin/repl_demo.dart
@@ -41,8 +41,8 @@ external void _jsOnToolCall(JSString jsonPayload);
 MontyRuntime _session = _newSession();
 
 MontyRuntime _newSession() => MontyRuntime(
-      extensions: [JinjaTemplateExtension(), MessageBusExtension()],
-    );
+  extensions: [JinjaTemplateExtension(), MessageBusExtension()],
+);
 
 // ---------------------------------------------------------------------------
 // API
@@ -191,11 +191,11 @@ void main() {
   // Expose API to window
   final api = <String, JSFunction>{
     'run': ((JSString code) => _apiRun(
-          code.toDart,
-        ).then((r) => r.toJS).toJS).toJS,
+      code.toDart,
+    ).then((r) => r.toJS).toJS).toJS,
     'execute': ((JSString code) => _apiExecute(
-          code.toDart,
-        ).then((r) => r.toJS).toJS).toJS,
+      code.toDart,
+    ).then((r) => r.toJS).toJS).toJS,
     'reset': (() => _apiReset().then((r) => r.toJS).toJS).toJS,
   }.jsify();
   _replSessionDemo = api as JSObject;

--- a/example/web/bin/vfs_demo.dart
+++ b/example/web/bin/vfs_demo.dart
@@ -155,8 +155,7 @@ Future<Map<String, dynamic>> _runWithVfs(String code) async {
         state = _parse(
           (await _bridgeResumeWithError(
             jsonEncode(e.toString()).toJS,
-          ).toDart)
-              .toDart,
+          ).toDart).toDart,
         );
       }
     } else {
@@ -266,8 +265,8 @@ Future<void> main() async {
   // Expose API to HTML.
   final api = <String, JSFunction>{
     'run': ((JSString code) => _apiRun(
-          code.toDart,
-        ).then((r) => r.toJS).toJS).toJS,
+      code.toDart,
+    ).then((r) => r.toJS).toJS).toJS,
     'mountFile': ((JSString path, JSString content) {
       unawaited(_mountFile(path.toDart, content.toDart));
     }).toJS,

--- a/lib/src/bridge/platform.dart
+++ b/lib/src/bridge/platform.dart
@@ -290,9 +290,9 @@ class PlatformBridge implements MontyBridge, AttachContext {
   ) async {
     final callId = _host.nextId;
     final opName = osCall.operationName;
-    final argSummary = osCall.arguments.isEmpty
+    final argSummary = osCall.args.isEmpty
         ? null
-        : osCall.arguments.map((a) => a.dartValue).join(', ');
+        : osCall.args.map((a) => a.dartValue).join(', ');
 
     controller.add(
       BridgeOsCallStart(
@@ -314,7 +314,7 @@ class PlatformBridge implements MontyBridge, AttachContext {
 
     final sw = Stopwatch()..start();
     try {
-      final args = osCall.arguments.map((v) => v.dartValue).toList();
+      final args = osCall.args.map((v) => v.dartValue).toList();
       final kwargs = osCall.kwargs?.map((k, v) => MapEntry(k, v.dartValue));
       final result = await handler(opName, args, kwargs);
       sw.stop();

--- a/lib/src/host/dispatch.dart
+++ b/lib/src/host/dispatch.dart
@@ -259,7 +259,7 @@ class HostDispatch {
     if (fn == null) throw ArgumentError('Unknown host function: $name');
     final pending = MontyPending(
       functionName: name,
-      arguments: const [],
+      args: const [],
       kwargs: args.map((k, v) => MapEntry(k, MontyValue.fromJson(v))),
     );
     final validatedArgs = fn.schema.mapAndValidate(pending);

--- a/lib/src/host/schema.dart
+++ b/lib/src/host/schema.dart
@@ -70,7 +70,7 @@ class HostFunctionSchema {
   /// Throws [ArgumentError] if required params are missing or types mismatch.
   Map<String, Object?> mapAndValidate(MontyPending pending) {
     final raw = <String, Object?>{};
-    final positionalArgs = pending.arguments;
+    final positionalArgs = pending.args;
 
     // Reject extra positional args.
     if (positionalArgs.length > params.length) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,12 +30,11 @@ dependencies:
 dev_dependencies:
   very_good_analysis: ^10.0.0
 
-# dart_monty_core's futures end-to-end work (#102, includes
-# ReplPlatform implements MontyFutureCapable + _driveLoop wiring) lives
-# on main but predates the next release. Drop this block once a
-# dart_monty_core release ships with #102 and bump the version pin above.
+# dart_monty_core PR #105 (feat/args-kwargs-callback) changes MontyCallback to
+# (List<Object?> args, Map<String, Object?>? kwargs). Drop this block once
+# #105 merges and a release ships.
 dependency_overrides:
   dart_monty_core:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
-      ref: main
+      ref: feat/args-kwargs-callback

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,11 +30,10 @@ dependencies:
 dev_dependencies:
   very_good_analysis: ^10.0.0
 
-# dart_monty_core PR #105 (feat/args-kwargs-callback) changes MontyCallback to
-# (List<Object?> args, Map<String, Object?>? kwargs). Drop this block once
-# #105 merges and a release ships.
+# dart_monty_core#105 merged to main but not yet released on pub.dev.
+# Drop this block once 0.18.0 ships and bump dart_monty_core: ^0.18.0 above.
 dependency_overrides:
   dart_monty_core:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
-      ref: feat/args-kwargs-callback
+      ref: main

--- a/test/src/bridge/event_loop_test.dart
+++ b/test/src/bridge/event_loop_test.dart
@@ -46,7 +46,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -95,7 +95,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_emit',
-              arguments: [
+              args: [
                 MontyDict({'type': MontyString('form')}),
               ],
               callId: 1,
@@ -108,7 +108,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 2,
             ),
           )
@@ -142,7 +142,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_recv',
-            arguments: [],
+            args: [],
             callId: 1,
           ),
         )
@@ -153,7 +153,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_recv',
-            arguments: [],
+            args: [],
             callId: 2,
           ),
         )
@@ -164,7 +164,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_recv',
-            arguments: [],
+            args: [],
             callId: 3,
           ),
         )
@@ -199,7 +199,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_recv',
-            arguments: [],
+            args: [],
             callId: 1,
           ),
         )
@@ -210,7 +210,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_recv',
-            arguments: [],
+            args: [],
             callId: 2,
           ),
         )
@@ -257,7 +257,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_emit',
-            arguments: [
+            args: [
               MontyDict({
                 'type': MontyString('counter'),
                 'value': MontyInt(0),
@@ -285,7 +285,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_emit',
-            arguments: [
+            args: [
               MontyDict({'version': MontyInt(1)}),
             ],
             callId: 1,
@@ -297,7 +297,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_emit',
-            arguments: [
+            args: [
               MontyDict({'version': MontyInt(2)}),
             ],
             callId: 2,
@@ -335,7 +335,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -382,7 +382,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_recv',
-            arguments: [],
+            args: [],
             callId: 1,
           ),
         )
@@ -448,7 +448,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -491,7 +491,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -537,7 +537,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_emit',
-            arguments: [
+            args: [
               MontyDict({'type': MontyString('label')}),
             ],
             callId: 1,
@@ -601,7 +601,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -649,7 +649,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -709,7 +709,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_recv',
-            arguments: [],
+            args: [],
             callId: 1,
           ),
         )
@@ -777,7 +777,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'el_recv',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -814,7 +814,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'el_emit',
-            arguments: [
+            args: [
               MontyDict({'type': MontyString('event')}),
             ],
             callId: 1,

--- a/test/src/bridge/platform_bridge_test.dart
+++ b/test/src/bridge/platform_bridge_test.dart
@@ -44,7 +44,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'slow_fail',
-            arguments: [],
+            args: [],
             callId: 1,
           ),
         )
@@ -91,7 +91,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'explode',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -138,7 +138,7 @@ void main() {
 
       mock
         ..enqueueProgress(
-          const MontyPending(functionName: 'greet', arguments: []),
+          const MontyPending(functionName: 'greet', args: []),
         )
         ..enqueueProgress(
           const MontyComplete(
@@ -179,7 +179,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'greet',
-            arguments: [],
+            args: [],
             kwargs: {'who': MontyString('world')},
           ),
         )
@@ -211,7 +211,7 @@ void main() {
       );
 
       syncMock
-        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
+        ..enqueueProgress(const MontyPending(functionName: 'fn', args: []))
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(value: MontyNone(), usage: _usage),
@@ -240,7 +240,7 @@ void main() {
       );
 
       syncMock
-        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
+        ..enqueueProgress(const MontyPending(functionName: 'fn', args: []))
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(value: MontyNone(), usage: _usage),
@@ -265,7 +265,7 @@ void main() {
       );
 
       mock
-        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
+        ..enqueueProgress(const MontyPending(functionName: 'fn', args: []))
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(value: MontyNone(), usage: _usage),
@@ -301,7 +301,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'async_fn',
-            arguments: [],
+            args: [],
             callId: 1,
           ),
         )
@@ -337,7 +337,7 @@ void main() {
       );
 
       mock
-        ..enqueueProgress(const MontyPending(functionName: 'fn', arguments: []))
+        ..enqueueProgress(const MontyPending(functionName: 'fn', args: []))
         ..enqueueProgress(
           const MontyComplete(
             result: MontyResult(value: MontyNone(), usage: _usage),
@@ -355,7 +355,7 @@ void main() {
         ..enqueueProgress(
           const MontyOsCall(
             operationName: 'Path.read_text',
-            arguments: [MontyString('/etc/passwd')],
+            args: [MontyString('/etc/passwd')],
             callId: 1,
           ),
         )
@@ -402,7 +402,7 @@ void main() {
         ..enqueueProgress(
           const MontyOsCall(
             operationName: 'os.getenv',
-            arguments: [MontyString('APP_ENV')],
+            args: [MontyString('APP_ENV')],
             callId: 1,
           ),
         )
@@ -438,7 +438,7 @@ void main() {
         ..enqueueProgress(
           const MontyOsCall(
             operationName: 'Path.write_text',
-            arguments: [MontyString('/tmp/out'), MontyString('data')],
+            args: [MontyString('/tmp/out'), MontyString('data')],
             callId: 1,
           ),
         )
@@ -878,7 +878,7 @@ void main() {
         ),
       );
       throwingMock.enqueueProgress(
-        const MontyPending(functionName: 'noop', arguments: []),
+        const MontyPending(functionName: 'noop', args: []),
       );
 
       final events = await b.execute('noop()').toList();
@@ -907,7 +907,7 @@ void main() {
           ),
         );
         throwingMock.enqueueProgress(
-          const MontyPending(functionName: 'noop', arguments: []),
+          const MontyPending(functionName: 'noop', args: []),
         );
 
         final events = await b.execute('noop()').toList();
@@ -939,7 +939,7 @@ void main() {
         );
         throwingMock
           ..enqueueProgress(
-            const MontyPending(functionName: 'noop', arguments: []),
+            const MontyPending(functionName: 'noop', args: []),
           )
           ..throwAfterResumes = 0;
 
@@ -1014,7 +1014,7 @@ void main() {
     test('unknown function in pending resumes with error', () async {
       mock
         ..enqueueProgress(
-          const MontyPending(functionName: 'not_registered', arguments: []),
+          const MontyPending(functionName: 'not_registered', args: []),
         )
         ..enqueueProgress(
           const MontyComplete(
@@ -1056,7 +1056,7 @@ void main() {
       // Call without required param — mapAndValidate throws FormatException.
       syncMock
         ..enqueueProgress(
-          const MontyPending(functionName: 'need_param', arguments: []),
+          const MontyPending(functionName: 'need_param', args: []),
         )
         ..enqueueProgress(
           const MontyComplete(
@@ -1085,7 +1085,7 @@ void main() {
         ..enqueueProgress(
           const MontyPending(
             functionName: 'need_param',
-            arguments: [],
+            args: [],
             callId: 1,
           ),
         )
@@ -1154,7 +1154,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'greet',
-              arguments: [],
+              args: [],
               callId: 1,
             ),
           )
@@ -1208,7 +1208,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'count',
-              arguments: [MontyInt(1)],
+              args: [MontyInt(1)],
               kwargs: {'n': MontyInt(1)},
               callId: 1,
             ),
@@ -1216,7 +1216,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'count',
-              arguments: [MontyInt(2)],
+              args: [MontyInt(2)],
               kwargs: {'n': MontyInt(2)},
               callId: 2,
             ),
@@ -1224,7 +1224,7 @@ void main() {
           ..enqueueProgress(
             const MontyPending(
               functionName: 'count',
-              arguments: [MontyInt(3)],
+              args: [MontyInt(3)],
               kwargs: {'n': MontyInt(3)},
               callId: 3,
             ),

--- a/test/src/host/schema_test.dart
+++ b/test/src/host/schema_test.dart
@@ -223,7 +223,7 @@ void main() {
     test('maps positional args by schema order', () {
       const pending = MontyPending(
         functionName: 'greet',
-        arguments: [MontyString('Alice'), MontyInt(3)],
+        args: [MontyString('Alice'), MontyInt(3)],
       );
 
       final result = schema.mapAndValidate(pending);
@@ -233,7 +233,7 @@ void main() {
     test('applies default for missing optional positional arg', () {
       const pending = MontyPending(
         functionName: 'greet',
-        arguments: [MontyString('Bob')],
+        args: [MontyString('Bob')],
       );
 
       final result = schema.mapAndValidate(pending);
@@ -243,7 +243,7 @@ void main() {
     test('throws FormatException for extra positional args', () {
       const pending = MontyPending(
         functionName: 'greet',
-        arguments: [MontyString('A'), MontyInt(1), MontyString('extra')],
+        args: [MontyString('A'), MontyInt(1), MontyString('extra')],
       );
 
       expect(() => schema.mapAndValidate(pending), throwsFormatException);
@@ -252,7 +252,7 @@ void main() {
     test('kwargs overlay positional args', () {
       const pending = MontyPending(
         functionName: 'greet',
-        arguments: [MontyString('Alice')],
+        args: [MontyString('Alice')],
         kwargs: {'count': MontyInt(5)},
       );
 
@@ -263,7 +263,7 @@ void main() {
     test('throws FormatException for unknown kwargs', () {
       const pending = MontyPending(
         functionName: 'greet',
-        arguments: [MontyString('Alice')],
+        args: [MontyString('Alice')],
         kwargs: {'unknown_key': MontyInt(1)},
       );
 
@@ -271,7 +271,7 @@ void main() {
     });
 
     test('throws FormatException when required param is missing', () {
-      const pending = MontyPending(functionName: 'greet', arguments: []);
+      const pending = MontyPending(functionName: 'greet', args: []);
 
       expect(() => schema.mapAndValidate(pending), throwsFormatException);
     });
@@ -279,7 +279,7 @@ void main() {
     test('validates type of positional args', () {
       const pending = MontyPending(
         functionName: 'greet',
-        arguments: [MontyInt(42)],
+        args: [MontyInt(42)],
       );
 
       expect(() => schema.mapAndValidate(pending), throwsFormatException);
@@ -288,7 +288,7 @@ void main() {
     test('works with no params schema', () {
       const emptySchema = HostFunctionSchema(name: 'ping', description: 'Ping');
 
-      const pending = MontyPending(functionName: 'ping', arguments: []);
+      const pending = MontyPending(functionName: 'ping', args: []);
 
       final result = emptySchema.mapAndValidate(pending);
       expect(result, isEmpty);


### PR DESCRIPTION
## Summary

- Updates `dependency_overrides` to point at `dart_monty_core` `feat/args-kwargs-callback` (PR runyaga/dart_monty_core#105)
- Renames all `MontyPending.arguments` / `MontyOsCall.arguments` accesses to `.args` across `lib/` and `test/` to match the field rename in core

## Changed files

| File | Change |
|---|---|
| `pubspec.yaml` | override `ref: main` → `ref: feat/args-kwargs-callback` |
| `lib/src/host/schema.dart` | `pending.arguments` → `pending.args` |
| `lib/src/bridge/platform.dart` | `osCall.arguments` → `osCall.args` (×2) |
| `test/src/bridge/event_loop_test.dart` | `arguments:` → `args:` in `MontyPending` constructors |
| `test/src/bridge/platform_bridge_test.dart` | same |
| `test/src/host/schema_test.dart` | same |

## Depends on

runyaga/dart_monty_core#105 — must merge first and the override updated to the released version before this lands on main.

## Test plan

- [ ] `dart analyze` — no issues
- [ ] `dart format` — no changes
- [ ] `dcm analyze lib` — pre-existing warnings only