### PR TITLE
chore: changelog, README, and example for 0.17.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,34 @@ jobs:
           path: coverage/lcov.info
           retention-days: 1
 
+  # ---------------------------------------------------------------------------
+  # Example smoke tests — every example/*.dart must compile and exit 0.
+  # Installs Rust so dart_monty_core's native-asset hook can compile the dylib.
+  # ---------------------------------------------------------------------------
+  test-examples:
+    name: Example smoke tests
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.yaml') }}
+          restore-keys: pub-${{ runner.os }}-
+      - run: dart pub get
+      - name: Run example smoke tests
+        run: |
+          dart test test/integration/example_smoke_test.dart \
+            -p vm --run-skipped --tags=example --reporter=expanded
+
   patch-coverage:
     name: Patch coverage gate (70%)
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 0.18.0
+
+Requires `dart_monty_core` 0.18.0 — see its changelog for `MontyCallback`,
+`.args`, and `inputs:` details.
+
+### Breaking
+
+- **`MontyRuntime(useFutures: true)` removed.** Set `dispatch: DispatchMode.future`
+  on each `HostFunction` that Python should be able to `await` instead.
+- **`MontyCallback`/`.args` rename** — inherited from `dart_monty_core` 0.18.0;
+  update all handler signatures and `MontyPending`/`MontyOsCall` field accesses.
+
+### Added
+
+- **`DispatchMode.future`** on `HostFunction` — makes a handler `await`-able from
+  Python; `asyncio.gather` over multiple such functions runs them concurrently.
+- **`execute(inputs:)`** — inject Dart values as Python variables for one call.
+- **`buildRunScriptFunction`** — `HostFunction` factory that runs a named Python
+  script.
+- **`HostContext.parent` / `subExecute`** — safe sub-execution from inside a
+  handler; direct `runtime.execute()` re-entrancy is guarded.
+
 ## 0.17.0
 
 - Low-level bindings have been factored into a separate package,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
-## 0.18.0
+## 0.17.1
 
-Requires `dart_monty_core` 0.18.0 — see its changelog for `MontyCallback`,
+Requires `dart_monty_core` 0.17.1 — see its changelog for `MontyCallback`,
 `.args`, and `inputs:` details.
 
 ### Breaking
 
 - **`MontyRuntime(useFutures: true)` removed.** Set `dispatch: DispatchMode.future`
   on each `HostFunction` that Python should be able to `await` instead.
-- **`MontyCallback`/`.args` rename** — inherited from `dart_monty_core` 0.18.0;
+- **`MontyCallback`/`.args` rename** — inherited from `dart_monty_core` 0.17.1;
   update all handler signatures and `MontyPending`/`MontyOsCall` field accesses.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -90,21 +90,40 @@ Future<void> main() async {
 }
 ```
 
-**3. Runtime with extensions**
+**3. Runtime with host functions and extensions**
 
-For more advanced use cases, create a `MontyRuntime` to manage extensions and sessions:
+`MontyRuntime` manages host functions, extensions, and long-lived sessions.
+Register `HostFunction`s to expose Dart callbacks to Python:
 
 ```dart
 Future<void> main() async {
-  final runtime = MontyRuntime(
-    extensions: [JinjaTemplateExtension(), MessageBusExtension()],
-  );
+  final runtime = MontyRuntime()
+    ..register(HostFunction(
+      schema: const HostFunctionSchema(
+        name: 'fetch',
+        params: [HostParam(name: 'url', type: HostParamType.string)],
+      ),
+      // DispatchMode.future lets Python `await fetch(url)` directly.
+      // asyncio.gather over multiple calls runs them concurrently.
+      dispatch: DispatchMode.future,
+      handler: (args, _) async => httpClient.get(args['url']! as String),
+    ));
+
   final result = await runtime.execute(
-    "tmpl_render(template='Hello {{ name }}!', context={'name': 'World'})",
+    'await fetch(base_url)',
+    inputs: {'base_url': 'https://example.com/api'},
   ).result;
-  print(result.value); // 'Hello World!'
+  print(result.value);
   await runtime.dispose();
 }
+```
+
+For plugin-style wiring, pass `extensions`:
+
+```dart
+final runtime = MontyRuntime(
+  extensions: [JinjaTemplateExtension(), MessageBusExtension()],
+);
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -160,9 +160,8 @@ before upgrading.
 
 We expect to stabilise the API and adopt semver when the package goes into
 production — roughly 1–3 months from now. If you are planning to depend on
-this package, please let us know (open an issue or email
-[alan@enfoldsystems.com](mailto:alan@enfoldsystems.com)) so we can factor
-your use-case into the stabilisation work.
+this package, please open an issue so we can factor your use-case into the
+stabilisation work.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ server), see `example/native/run.sh` and `example/web/run.sh`.
 - [**Contributing**](CONTRIBUTING.md) — Build, run tests, gate scripts, release process
 - [**Contributor Setup**](docs/contributor/setup.md) — Toolchain install (Rust, Dart, Python)
 
+## Stability and versioning
+
+This package does **not** follow semantic versioning. Breaking changes can
+land in any release. The [CHANGELOG](CHANGELOG.md) is kept up-to-date with
+every breaking change, so pin to a specific version and read the changelog
+before upgrading.
+
+We expect to stabilise the API and adopt semver when the package goes into
+production — roughly 1–3 months from now. If you are planning to depend on
+this package, please let us know (open an issue or email
+[alan@enfoldsystems.com](mailto:alan@enfoldsystems.com)) so we can factor
+your use-case into the stabilisation work.
+
 ## License
 
 MIT License. See [LICENSE](LICENSE).

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -3,3 +3,5 @@ tags:
     skip: "Skipped by default (slow). Run: dart test --run-skipped --tags=integration"
   ladder:
     skip: "Skipped by default (slow). Run: dart test --run-skipped --tags=ladder"
+  example:
+    skip: "Skipped by default (boots FFI dylib). Run: dart test --run-skipped --tags=example"

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,23 +1,85 @@
 // Printing to stdout is expected in an example.
 // ignore_for_file: avoid_print
+//
+// dart_monty — featured example
+//
+// Higher-level abstractions on top of dart_monty_core:
+//
+//  1. One-shot     — Monty.exec
+//  2. Inputs       — chain programs: output of one run feeds the next
+//  3. HostFunction — typed schema-backed callbacks; DispatchMode.future
+//                    lets Python await and asyncio.gather runs concurrently
+//  4. VFS          — sandboxed in-memory filesystem via Python pathlib
+//  5. Persistence  — variables and functions survive across execute() calls
+//
+// Run: dart run example/example.dart
+
 import 'package:dart_monty/dart_monty.dart';
+import 'package:dart_monty/dart_monty_bridge.dart';
 
 Future<void> main() async {
-  // Run a simple Python expression.
-  final result = await Monty.exec('2 + 2');
-  print('Result: ${result.value}'); // 4
+  // ── 1. One-shot ───────────────────────────────────────────────────────────
+  final r = await Monty.exec('2 ** 10');
+  print('2**10 = ${r.value.dartValue}'); // 1024
 
-  // Run with resource limits.
-  final limited = await Monty.exec(
-    'sum(range(100))',
-    limits: const MontyLimits(timeoutMs: 5000, memoryBytes: 10 * 1024 * 1024),
+  // ── 2. Inputs — chaining programs ────────────────────────────────────────
+  // Feed the result of one Monty run into the next as a named Python variable.
+  final squares = await Monty('[x**2 for x in range(10)]').run();
+
+  final total = await Monty('sum(squares)').run(
+    inputs: {'squares': squares.value.dartValue},
   );
-  print('Sum: ${limited.value}'); // 4950
+  print('sum of squares 0–9² = ${total.value.dartValue}'); // 285
 
-  // Handle errors.
-  final bad = await Monty.exec('1 / 0');
-  final err = bad.error;
-  if (err != null) {
-    print('Error: ${err.message}');
-  }
+  // ── 3. HostFunction + DispatchMode.future ────────────────────────────────
+  // Schema-backed Dart callbacks on a persistent runtime. DispatchMode.future
+  // lets Python `await` the handler; asyncio.gather runs calls concurrently.
+  final runtime = MontyRuntime()
+    ..register(
+      HostFunction(
+        dispatch: DispatchMode.future,
+        schema: const HostFunctionSchema(
+          name: 'fetch',
+          description: 'Simulates an async fetch — returns n × 10.',
+          params: [HostParam(name: 'n', type: HostParamType.integer)],
+        ),
+        handler: (args, _) async => (args['n']! as int) * 10,
+      ),
+    );
+
+  final gathered = await runtime.execute('''
+import asyncio
+a, b = await asyncio.gather(fetch(n=1), fetch(n=2))
+a + b
+''').result;
+  print('gather result = ${gathered.value.dartValue}'); // 30
+
+  // ── 4. VFS — sandboxed in-memory filesystem ───────────────────────────────
+  // Python pathlib.Path reads and writes an isolated MemoryFileSystem.
+  // The host filesystem is never accessed; VFS state persists across calls.
+  final vfs = MontyRuntime(osHandlers: {'Path.': memoryFsHandler()});
+
+  await vfs.execute('''
+from pathlib import Path
+Path('/tmp/msg.txt').write_text('Hello from Python!')
+''').result;
+
+  final msg = await vfs.execute('''
+from pathlib import Path
+Path('/tmp/msg.txt').read_text()
+''').result;
+  print('VFS file: ${msg.value.dartValue}'); // Hello from Python!
+
+  // ── 5. Persistent state across execute() calls ────────────────────────────
+  // Variables and functions defined in one execute() survive into subsequent
+  // calls — the registered `fetch` from section 3 is still available.
+  await runtime
+      .execute('def fib(n): return n if n < 2 else fib(n-1) + fib(n-2)')
+      .result;
+  await runtime.execute('result = fib(10)').result;
+  final fib = await runtime.execute('result').result;
+  print('fib(10) = ${fib.value.dartValue}'); // 55
+
+  await runtime.dispose();
+  await vfs.dispose();
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Script your Dart/Flutter app with sandboxed Python — runtime extensions, Flutter glue, and FFI/WASM asset loading on top of dart_monty_core.
-version: 0.17.0
+version: 0.17.1
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  dart_monty_core: ^0.17.0
+  dart_monty_core: ^0.17.1
   dinja: ^1.0.0
   file: ^7.0.0
   meta: ^1.11.0
@@ -30,8 +30,8 @@ dependencies:
 dev_dependencies:
   very_good_analysis: ^10.0.0
 
-# dart_monty_core#105 merged to main but not yet released on pub.dev.
-# Drop this block once 0.18.0 ships and bump dart_monty_core: ^0.18.0 above.
+# dart_monty_core 0.17.1 not yet released on pub.dev.
+# Drop this block once 0.17.1 ships and bump dart_monty_core: ^0.17.1 above.
 dependency_overrides:
   dart_monty_core:
     git:

--- a/test/integration/example_smoke_test.dart
+++ b/test/integration/example_smoke_test.dart
@@ -1,0 +1,62 @@
+// Smoke test: every example/*.dart compiles and exits 0.
+//
+// `dart analyze` checks types but does not execute examples. This test fills
+// the runtime-rot gap by running each file via `dart run` and asserting exit 0.
+// stdout / stderr surface in the failure reason so regressions are debuggable.
+//
+// Tagged 'example' — skipped in default `dart test` runs because each example
+// boots an FFI dylib + interpreter (slow for fast-loop unit testing).
+//
+// Run: dart test -p vm --run-skipped --tags=example
+
+@Tags(['integration', 'example'])
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// Examples that currently fail or hang on `main`. Add entries here for known
+/// regressions with a TODO reason; remove the entry once the example is fixed.
+const _skipReasons = <String, String>{};
+
+void main() {
+  final examples =
+      Directory('example')
+          .listSync()
+          .whereType<File>()
+          .where(
+            (f) =>
+                f.path.endsWith('.dart') &&
+                !f.path.contains('/native/') &&
+                !f.path.contains('/web/'),
+          )
+          .map((f) => f.path)
+          .toList()
+        ..sort();
+
+  group('example smoke', () {
+    for (final ex in examples) {
+      test(
+        ex,
+        () async {
+          final skipReason = _skipReasons[ex];
+          if (skipReason != null) {
+            markTestSkipped(skipReason);
+            return;
+          }
+          final result = await Process.run('dart', ['run', ex]);
+          expect(
+            result.exitCode,
+            equals(0),
+            reason:
+                'exit=${result.exitCode}\n'
+                '--- stdout ---\n${result.stdout}\n'
+                '--- stderr ---\n${result.stderr}',
+          );
+        },
+        timeout: const Timeout(Duration(minutes: 2)),
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Summary

- Adds 0.18.0 CHANGELOG entry (breaking changes + new features since v0.17.0)
- Updates README quick-start for `HostFunction` / `DispatchMode.future` / `execute(inputs:)`