### PR TITLE
Migrate to dart_monty_core 0.18.x (monty v0.0.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.18.0
+
+Requires `dart_monty_core` 0.18.1 (monty v0.0.18). See its changelog for the
+new `open()`/file I/O, the `MontyFileHandle` value, and typed OS exceptions
+(`except FileNotFoundError:` / `PermissionError:` now work). No `dart_monty`
+API changes — the 0.18.x additions are additive and surface automatically
+through the existing `OsCallHandler` / runtime.
+
 ## 0.17.1
 
 Requires `dart_monty_core` 0.17.1 — see its changelog for `MontyCallback`,

--- a/example/web/pubspec.yaml
+++ b/example/web/pubspec.yaml
@@ -12,11 +12,10 @@ dependencies:
   web: ^1.1.1
 
 # Mirror the override from ../../pubspec.yaml — dependency_overrides do not
-# transit through path: deps, so the example needs its own copy until the
-# next dart_monty_core release ships with #99 (inputsToCode + MontyNone +
-# MontyInternalError exports).
+# transit through path: deps, so the example needs its own copy until
+# dart_monty_core 0.18.1 (monty v0.0.18) ships to pub.dev.
 dependency_overrides:
   dart_monty_core:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
-      ref: main
+      ref: followups/test-hooks-cm

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty
 description: Script your Dart/Flutter app with sandboxed Python — runtime extensions, Flutter glue, and FFI/WASM asset loading on top of dart_monty_core.
-version: 0.17.1
+version: 0.18.0
 homepage: https://github.com/runyaga/dart_monty
 repository: https://github.com/runyaga/dart_monty
 issue_tracker: https://github.com/runyaga/dart_monty/issues
@@ -15,7 +15,7 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  dart_monty_core: ^0.17.1
+  dart_monty_core: 0.18.1
   dinja: ^1.0.0
   file: ^7.0.0
   meta: ^1.11.0
@@ -29,3 +29,12 @@ dependencies:
 
 dev_dependencies:
   very_good_analysis: ^10.0.0
+
+# dart_monty_core 0.18.1 (monty v0.0.18: open()/file I/O + typed OS
+# exceptions) is not yet published to pub.dev. Until it is, resolve it from
+# the branch carrying those changes. Drop this block once 0.18.1 ships.
+dependency_overrides:
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: followups/test-hooks-cm


### PR DESCRIPTION
Base of the dart_monty 0.18 stack.

Migrates dart_monty onto **dart_monty_core 0.18.x / monty v0.0.18**, depending
on the core stack that carries the file-I/O + context-manager surface
(runyaga/dart_monty_core: upgrade → file-io-open → … → open-primitive).

**Stack (bottom → top):**
1. **migrate/monty-0.0.18 → main** ← *this PR*
2. followups/fix-ladder-gate
3. followups/file-io-wiring

Depends on dart_monty_core #108–#113.