### PR TITLE
fix(ladder): restore the headless WASM ladder gate

### DIFF
--- a/example/web/bin/ladder_showcase.dart
+++ b/example/web/bin/ladder_showcase.dart
@@ -163,6 +163,20 @@ bool _valuesMatch(Object? actual, Object? expected) {
   return '$actual' == '$expected';
 }
 
+/// Emits a machine-readable result line to the browser console for the
+/// headless ladder gate (tool/test_python_ladder.sh). `tier` is the fixture
+/// FILE name (e.g. `tier_07_advanced.json`) so the key matches
+/// known_failures.txt (`tier_file:test_name`). `ok` is false only for hard
+/// failures — warn/xfail/xpass/skip count as passing for the gate.
+void _emitLadderResult(String tierFile, String name, String status) {
+  final tier = tierFile.split('/').last;
+  // print() is the headless gate's transport (dart2js -> console.log).
+  // ignore: avoid_print
+  print(
+    'LADDER_RESULT:${jsonEncode({'tier': tier, 'name': name, 'ok': status != 'fail'})}',
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
@@ -209,6 +223,7 @@ Future<void> main() async {
             'skip'.toJS,
             'Skipped (native only)'.toJS,
           );
+          _emitLadderResult(_tierFiles[tierIdx], name, 'skip');
           continue;
         }
 
@@ -235,6 +250,7 @@ Future<void> main() async {
           status.toJS,
           detail.toJS,
         );
+        _emitLadderResult(_tierFiles[tierIdx], name, status);
       }
     } on Object catch (e) {
       totalFailed++;
@@ -246,6 +262,7 @@ Future<void> main() async {
         'fail'.toJS,
         'Failed to load ${_tierFiles[tierIdx]}: $e'.toJS,
       );
+      _emitLadderResult(_tierFiles[tierIdx], 'Tier load error', 'fail');
     }
   }
 
@@ -258,6 +275,11 @@ Future<void> main() async {
     totalXfailed.toJS,
     totalXpassed.toJS,
   );
+
+  // Completion marker for the headless gate — lets it distinguish a finished
+  // run from a Chrome crash/timeout that emitted only partial results.
+  // ignore: avoid_print
+  print('LADDER_DONE:${jsonEncode({'total': totalTests})}');
 }
 
 // ---------------------------------------------------------------------------

--- a/tool/test_python_ladder.sh
+++ b/tool/test_python_ladder.sh
@@ -62,18 +62,22 @@ dart pub get >/dev/null
 if [ -n "${DART_MONTY_CORE_DIR:-}" ] && [ -d "$DART_MONTY_CORE_DIR/lib/assets" ]; then
   CORE_ASSETS="$DART_MONTY_CORE_DIR/lib/assets"
 else
-  CORE_ASSETS_GLOB="$(dart pub cache dir)/hosted/pub.dev/dart_monty_core-"*/lib/assets
-  CORE_ASSETS=""
-  for d in $CORE_ASSETS_GLOB; do
-    if [ -d "$d" ]; then CORE_ASSETS="$d"; break; fi
-  done
-  if [ -z "$CORE_ASSETS" ]; then
-    # git: deps land under ~/.pub-cache/git/<pkg>-<sha>/lib/assets.
-    CORE_ASSETS=$(find "$HOME/.pub-cache/git" -maxdepth 3 -type d \
-      -name 'dart_monty_core-*' 2>/dev/null \
-      | head -1)
-    [ -n "$CORE_ASSETS" ] && CORE_ASSETS="$CORE_ASSETS/lib/assets"
-  fi
+  # Resolve dart_monty_core's root from package_config.json — works for path,
+  # git, and hosted deps uniformly (`dart pub cache dir` was removed in newer
+  # SDKs). Run from $EXAMPLE so this reads the example's resolution.
+  CORE_ROOT=$(python3 - <<'PY'
+import json, urllib.parse
+try:
+    cfg = json.load(open(".dart_tool/package_config.json"))
+except OSError:
+    raise SystemExit(0)
+for p in cfg.get("packages", []):
+    if p["name"] == "dart_monty_core":
+        print(urllib.parse.unquote(urllib.parse.urlparse(p["rootUri"]).path))
+        break
+PY
+)
+  CORE_ASSETS="${CORE_ROOT%/}/lib/assets"
 fi
 
 if [ ! -d "$CORE_ASSETS" ]; then
@@ -163,10 +167,21 @@ timeout 90 "$CHROME" \
   2>"$CONSOLE_LOG" || true
 
 WEB_RESULTS=$(grep -o 'LADDER_RESULT:{[^}]*}' "$CONSOLE_LOG" 2>/dev/null || true)
+DONE_LINE=$(grep -o 'LADDER_DONE:{[^}]*}' "$CONSOLE_LOG" 2>/dev/null | head -1 || true)
 rm -f "$CONSOLE_LOG"
 
-if [ -z "$WEB_RESULTS" ]; then
-  echo "  WASM  INCONCLUSIVE (no LADDER_RESULT lines from Chrome)"
+if [ -z "$WEB_RESULTS" ] || [ -z "$DONE_LINE" ]; then
+  echo "  WASM  INCONCLUSIVE (no results or no completion marker from Chrome)"
+  echo "=== Ladder: INCONCLUSIVE ==="
+  exit 1
+fi
+
+# Guard against a Chrome crash/timeout mid-run: the number of result lines
+# must match the total the showcase reported on completion.
+EXPECTED_TOTAL=$(echo "$DONE_LINE" | sed -E 's/.*"total"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/')
+ACTUAL_COUNT=$(printf '%s\n' "$WEB_RESULTS" | grep -c .)
+if [ "$ACTUAL_COUNT" != "$EXPECTED_TOTAL" ]; then
+  echo "  WASM  INCONCLUSIVE (got $ACTUAL_COUNT results, expected $EXPECTED_TOTAL)"
   echo "=== Ladder: INCONCLUSIVE ==="
   exit 1
 fi


### PR DESCRIPTION
Stacked on #424.

Restores the dead headless WASM ladder gate. The showcase emitted no console
output for the harness to scrape, and `dart pub cache dir` (used to locate core
assets) was removed in newer SDKs — together the gate silently ran nothing.

**Stack:** migrate/monty-0.0.18 (#424) → **fix-ladder-gate** → file-io-wiring