### PR TITLE
ci(wasm): gate dart_monty's open()/overlay handlers on dart2js in Chrome

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,33 @@ jobs:
           dart test test/integration/example_smoke_test.dart \
             -p vm --run-skipped --tags=example --reporter=expanded
 
+  # ---------------------------------------------------------------------------
+  # WASM / Chrome — dart_monty's open()/file-I/O + overlay handler logic must
+  # compile to dart2js and run in a real browser, mirroring dart_monty_core's
+  # WASM gate. The handlers run directly here (MemoryFileSystem, no dart:io and
+  # no engine), so plain `dart test -p chrome` is the gate; the end-to-end
+  # Python open() flow is covered by dart_monty_core's WASM fixture corpus.
+  # ---------------------------------------------------------------------------
+  test-wasm:
+    name: WASM/Chrome tests
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.yaml') }}
+          restore-keys: pub-${{ runner.os }}-
+      - run: dart pub get
+      - name: Run WASM/Chrome tests (dart2js in headless Chrome)
+        run: dart test -p chrome test/experiments/*_wasm_test.dart --reporter=expanded
+
   patch-coverage:
     name: Patch coverage gate (70%)
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Follow-up to the 0.18 migration (#426). Adds the WASM CI parity gate that
dart_monty was missing relative to dart_monty_core.

## What
A new `test-wasm` CI job runs dart_monty's WASM handler tests on dart2js in
headless Chrome:

```
dart test -p chrome test/experiments/*_wasm_test.dart
```

This covers the `open()`/file-I/O and overlay handler logic on the browser
backend (the handlers use `MemoryFileSystem` — no `dart:io`, no engine — so a
plain `dart test -p chrome` is sufficient; no asset staging / COI server is
needed). The end-to-end Python `open()` flow remains covered by
dart_monty_core's WASM fixture corpus.

Mirrors dart_monty_core's WASM gate, closing the FFI+WASM parity gap.

## Verified
`dart test -p chrome` on both `file_io_wasm_test.dart` and
`e6_overlay_fs_wasm_test.dart` passes locally (9 tests).

## Note on patch coverage
The non-required `Patch coverage gate` red on #426 was a one-time artifact of
the migration's new handler lines (some exercised by `ffi`-tagged tests that
the default `--coverage` run skips). It's moot here — this PR adds no lib
lines. Broadening the coverage run to include the `ffi`-tagged handler tests
(needs the Rust dylib in that job) can be a separate change if we want codecov
to reflect them.