### PR TITLE
fix(os_call)!: timeHandler returns MontyDate/MontyDateTime, not `__type` maps

### DIFF
--- a/lib/src/os_call/platform_handlers.dart
+++ b/lib/src/os_call/platform_handlers.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid-unsafe-collection-methods
 // ignore_for_file: avoid-unnecessary-futures, newline-before-return
 import 'package:dart_monty/src/os_call/os_handlers.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
 
 /// Handler for `date.*` and `datetime.*` operations.
 ///
@@ -17,24 +18,26 @@ OsCallHandler timeHandler({DateTime Function()? clock}) {
   return (operation, args, kwargs) async {
     final t = now();
     return switch (operation) {
-      'date.today' => {
-        '__type': 'date',
-        'year': t.year,
-        'month': t.month,
-        'day': t.day,
-      },
-      'datetime.now' => {
-        '__type': 'datetime',
-        'year': t.year,
-        'month': t.month,
-        'day': t.day,
-        'hour': t.hour,
-        'minute': t.minute,
-        'second': t.second,
-        'microsecond': t.microsecond,
-        'offset_seconds': t.timeZoneOffset.inSeconds,
-        'timezone_name': t.timeZoneName,
-      },
+      // dart_monty_core 0.19 stopped honouring host-authored `__type` maps:
+      // they arrive in Python as plain dicts, so `date.today().year` raised
+      // AttributeError with no error at the boundary. Returning a MontyValue
+      // subclass is the documented replacement (core CHANGELOG, 0.19.0
+      // Breaking).
+      'date.today' => MontyDate(year: t.year, month: t.month, day: t.day),
+      // Constructed explicitly rather than handing `t` to MontyValue.fromDart:
+      // that arm calls .toUtc() and leaves offsetSeconds/timezoneName null,
+      // which would silently drop both fields this handler has always emitted.
+      'datetime.now' => MontyDateTime(
+        year: t.year,
+        month: t.month,
+        day: t.day,
+        hour: t.hour,
+        minute: t.minute,
+        second: t.second,
+        microsecond: t.microsecond,
+        offsetSeconds: t.timeZoneOffset.inSeconds,
+        timezoneName: t.timeZoneName,
+      ),
       _ => throw UnsupportedError('Unsupported datetime operation: $operation'),
     };
   };

--- a/test/src/os_call/overlay_fs_handler_test.dart
+++ b/test/src/os_call/overlay_fs_handler_test.dart
@@ -182,8 +182,9 @@ void main() {
 
       final result = await overlayWithTime('date.today', const [], null);
 
-      expect(result, isA<Map<String, Object?>>());
-      expect((result! as Map)['__type'], 'date');
+      // timeHandler returns a typed MontyDate since dart_monty_core 0.19;
+      // a hand-built `{'__type': 'date'}` Map would decode as a plain dict.
+      expect(result, isA<MontyDate>());
     });
   });
 }

--- a/test/src/os_call/time_handler_envelope_test.dart
+++ b/test/src/os_call/time_handler_envelope_test.dart
@@ -1,0 +1,97 @@
+@TestOn('vm')
+library;
+
+// Engine-backed: MontyRuntime boots the FFI engine. dart_monty's chrome job
+// deliberately covers only engine-free handler logic (see ci.yaml test-wasm);
+// the end-to-end web path is covered by dart_monty_core's WASM fixture corpus.
+// Regression test for the dart_monty_core 0.19 breaking change:
+//
+//   "A hand-built `{'__type': ...}` Dart `Map` is no longer honoured as that
+//    type — it is a dict."  (dart_monty_core CHANGELOG.md, 0.19.0 Breaking)
+//
+// Host callback returns are routed through `MontyValue.encodeForWire`, so an
+// envelope-shaped Map built by `timeHandler` arrives in sandboxed Python as a
+// plain dict. `date.today().year` then raises `AttributeError` instead of
+// returning an int, with no error at the boundary — the change "fails quietly".
+//
+// These tests assert the CORRECT behaviour: `date.today()` and `datetime.now()`
+// must arrive as real Python date/datetime objects. They fail against a
+// timeHandler that returns hand-built Maps and pass once it returns
+// `MontyDate`/`MontyDateTime`.
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // A frozen clock keeps these deterministic — never assert on "today".
+  final frozen = DateTime(2024, 3, 15, 10, 30, 45);
+  final time = timeHandler(clock: () => frozen);
+
+  group('timeHandler returns typed values across the boundary', () {
+    test('date.today() is a Python date, and .year is an int', () async {
+      final session = MontyRuntime(
+        osHandlers: {'date.': time, 'datetime.': time},
+      );
+      addTearDown(session.dispose);
+
+      final result = await session
+          .execute(
+            'from datetime import date\n'
+            'd = date.today()\n'
+            '{"type": type(d).__name__, "year": d.year, "month": d.month, '
+            '"day": d.day}',
+          )
+          .result;
+
+      expect(result.error, isNull, reason: 'attribute access must not raise');
+      final v = result.value.dartValue! as Map<String, Object?>;
+      expect(v['type'], 'date', reason: 'must be a date, not a dict');
+      expect(v['year'], frozen.year);
+      expect(v['month'], frozen.month);
+      expect(v['day'], frozen.day);
+    });
+
+    test('datetime.now() is a Python datetime and keeps its offset', () async {
+      final session = MontyRuntime(
+        osHandlers: {'date.': time, 'datetime.': time},
+      );
+      addTearDown(session.dispose);
+
+      final result = await session
+          .execute(
+            // NB: monty implements a subset of CPython's datetime — there is
+            // no utcoffset(). tzinfo is present, so assert on that.
+            'from datetime import datetime\n'
+            'n = datetime.now()\n'
+            '{"type": type(n).__name__, "hour": n.hour, "minute": n.minute, '
+            '"naive": n.tzinfo is None, "tz": repr(n.tzinfo)}',
+          )
+          .result;
+
+      expect(result.error, isNull);
+      final v = result.value.dartValue! as Map<String, Object?>;
+      // monty reports the qualified name here ('datetime.datetime') while
+      // `date` reports the bare 'date' — assert what it actually emits.
+      expect(
+        v['type'],
+        'datetime.datetime',
+        reason: 'must be a datetime, not a dict',
+      );
+      expect(v['hour'], frozen.hour);
+      expect(v['minute'], frozen.minute);
+      // The pre-0.19 handler emitted offset_seconds/timezone_name. Converting
+      // via a bare Dart DateTime would drop both (MontyValue.fromDart calls
+      // .toUtc(), leaving offsetSeconds/timezoneName null), so pin that the
+      // datetime is tz-aware and carries this machine's zone name.
+      expect(
+        v['naive'],
+        isFalse,
+        reason: 'offsetSeconds must not be silently dropped',
+      );
+      expect(
+        v['tz']! as String,
+        contains(frozen.timeZoneName),
+        reason: 'timezoneName must survive the boundary',
+      );
+    });
+  });
+}

--- a/test/src/os_call/time_os_provider_test.dart
+++ b/test/src/os_call/time_os_provider_test.dart
@@ -1,57 +1,50 @@
 import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('timeHandler', () {
-    test('date.today returns date map with __type', () async {
+    test('date.today returns a MontyDate', () async {
       final handler = timeHandler();
       final result =
-          (await handler('date.today', const [], null))!
-              as Map<String, Object?>;
+          (await handler('date.today', const [], null))! as MontyDate;
 
-      expect(result['__type'], 'date');
-      expect(result['year'], isA<int>());
-      expect(result['month'], isA<int>());
-      expect(result['day'], isA<int>());
-      expect(result.containsKey('hour'), isFalse);
+      expect(result.year, isA<int>());
+      expect(result.month, isA<int>());
+      expect(result.day, isA<int>());
     });
 
-    test('datetime.now returns datetime map with __type', () async {
+    test('datetime.now returns a MontyDateTime', () async {
       final handler = timeHandler();
       final result =
-          (await handler('datetime.now', const [], null))!
-              as Map<String, Object?>;
+          (await handler('datetime.now', const [], null))! as MontyDateTime;
 
-      expect(result['__type'], 'datetime');
-      expect(result['year'], isA<int>());
-      expect(result['month'], isA<int>());
-      expect(result['day'], isA<int>());
-      expect(result['hour'], isA<int>());
-      expect(result['minute'], isA<int>());
-      expect(result['second'], isA<int>());
-      expect(result['microsecond'], isA<int>());
-      expect(result['offset_seconds'], isA<int>());
-      expect(result['timezone_name'], isA<String>());
+      expect(result.year, isA<int>());
+      expect(result.month, isA<int>());
+      expect(result.day, isA<int>());
+      expect(result.hour, isA<int>());
+      expect(result.minute, isA<int>());
+      expect(result.second, isA<int>());
+      expect(result.microsecond, isA<int>());
+      expect(result.offsetSeconds, isA<int>());
+      expect(result.timezoneName, isA<String>());
     });
 
     test('injected clock is used (frozen time)', () async {
       final frozen = DateTime(2026, 3, 15, 10, 30, 45, 123, 456);
       final handler = timeHandler(clock: () => frozen);
 
-      final date =
-          (await handler('date.today', const [], null))!
-              as Map<String, Object?>;
-      expect(date['year'], 2026);
-      expect(date['month'], 3);
-      expect(date['day'], 15);
+      final date = (await handler('date.today', const [], null))! as MontyDate;
+      expect(date.year, 2026);
+      expect(date.month, 3);
+      expect(date.day, 15);
 
       final dt =
-          (await handler('datetime.now', const [], null))!
-              as Map<String, Object?>;
-      expect(dt['year'], 2026);
-      expect(dt['hour'], 10);
-      expect(dt['minute'], 30);
-      expect(dt['second'], 45);
+          (await handler('datetime.now', const [], null))! as MontyDateTime;
+      expect(dt.year, 2026);
+      expect(dt.hour, 10);
+      expect(dt.minute, 30);
+      expect(dt.second, 45);
     });
 
     test('unknown date/datetime operation throws', () {
@@ -71,14 +64,13 @@ void main() {
       final handler = timeHandler();
       final before = DateTime.now();
       final result =
-          (await handler('datetime.now', const [], null))!
-              as Map<String, Object?>;
+          (await handler('datetime.now', const [], null))! as MontyDateTime;
       final after = DateTime.now();
 
-      expect(result['year'], before.year);
+      expect(result.year, before.year);
       // Day should be within the range of the test run.
-      expect(result['day'], greaterThanOrEqualTo(before.day));
-      expect(result['day'], lessThanOrEqualTo(after.day));
+      expect(result.day, greaterThanOrEqualTo(before.day));
+      expect(result.day, lessThanOrEqualTo(after.day));
     });
 
     test('timezone offset populated correctly', () async {
@@ -86,10 +78,9 @@ void main() {
       final handler = timeHandler(clock: () => frozen);
 
       final result =
-          (await handler('datetime.now', const [], null))!
-              as Map<String, Object?>;
-      expect(result['offset_seconds'], frozen.timeZoneOffset.inSeconds);
-      expect(result['timezone_name'], frozen.timeZoneName);
+          (await handler('datetime.now', const [], null))! as MontyDateTime;
+      expect(result.offsetSeconds, frozen.timeZoneOffset.inSeconds);
+      expect(result.timezoneName, frozen.timeZoneName);
     });
   });
 }


### PR DESCRIPTION
Part of #432 (0.19 semantic adaptation). One change: the `date.*`/`datetime.*`
os-call handler.

## The defect

dart_monty_core 0.19 routes host callback returns through
`MontyValue.encodeForWire`, so a Map the **host** hand-builds containing a
`__type` key is no longer honoured as that type — it arrives in sandboxed
Python as a plain dict. Core's CHANGELOG flags this as the breaking change that
**"FAILS QUIETLY"**.

`timeHandler` built exactly such maps. Measured before this change:

    from datetime import date
    d = date.today()
    type(d).__name__   # 'dict'
    repr(d)            # {'__type': 'date', 'year': 2026, 'month': 8, 'day': 2}
    d.year             # AttributeError: 'dict' object has no attribute 'year'

No error at the boundary — `monty_runtime_test.dart`'s
`date.today() returns reasonable year` simply observed `null`.

## Red first

`test/src/os_call/time_handler_envelope_test.dart` is new and was watched
failing **2/2** before any `lib/` edit:

    Expected: null
      Actual: MontyException: AttributeError: 'dict' object has no attribute 'hour'

## The fix

Return the replacement core's CHANGELOG prescribes — a `MontyValue` subclass.

`MontyDateTime` is constructed **explicitly** rather than handing the Dart
`DateTime` to `MontyValue.fromDart`: that arm calls `.toUtc()` and leaves
`offsetSeconds`/`timezoneName` null (`monty_value.dart:72-80`), which would
silently drop two fields this handler has always emitted. Confirmed the offset
survives:

    tzinfo=datetime.timezone(datetime.timedelta(days=-1, seconds=68400), 'CDT')

`time_os_provider_test.dart` and `overlay_fs_handler_test.dart` asserted the old
Map contract and move with it.

## Verification

| | published core 0.18.1 | local core 0.19 |
|---|---|---|
| new test | 2/2 | 2/2 |
| `dart test test/src -p vm` | 460 | 462 |
| `dart test test/src -p chrome` | 428 | 430 |
| `dart analyze --fatal-infos` | clean | clean |

**Backward compatible** — deliberately verified against published 0.18.1, since
0.19 is not published and CI resolves `^0.18.1`.

The new test is `@TestOn('vm')`: it boots the engine, and this repo's chrome job
covers engine-free handler logic only (see the `test-wasm` job comment in
`ci.yaml`), with the end-to-end web path covered by dart_monty_core's WASM
fixture corpus.

## Breaking

`timeHandler` returned `Map<String, Object?>` for `date.today`/`datetime.now`;
it now returns `MontyDate`/`MontyDateTime`. Direct inspectors change from
`result['year']` to `result.year`.