### PR TITLE
chore(deps): track dart_monty_core's 0.19 branch so this line gets real CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,9 +70,6 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
-      # Core's build hook shells out to cargo; without this every run pays a
-      # full cold build of the ruff/ty crate tree.
-      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache
@@ -155,7 +152,6 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
-      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,11 @@ jobs:
   test:
     name: Dart test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30, not 15: dart_monty_core is a git dependency on this branch, so its
+    # native asset is compiled from source rather than coming prebuilt from the
+    # pub.dev archive. A cold cargo build of the ruff/ty crate tree does not fit
+    # in 15 minutes.
+    timeout-minutes: 30
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     steps:
@@ -66,6 +70,9 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
+      # Core's build hook shells out to cargo; without this every run pays a
+      # full cold build of the ruff/ty crate tree.
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache
@@ -140,12 +147,15 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # See the `test` job: the git dependency means cargo builds core from
+    # source, which does not fit in 15 minutes cold.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache

--- a/example/dataclass_demo.dart
+++ b/example/dataclass_demo.dart
@@ -38,15 +38,21 @@ class User {
   String toString() => 'User(name=$name, age=$age)';
 }
 
-Map<String, Object?> _userEnvelope({required String name, required int age}) =>
-    {
-      '__type': 'dataclass',
-      'name': 'User',
-      'type_id': 1,
-      'field_names': ['name', 'age'],
-      'attrs': {'name': name, 'age': age},
-      'frozen': false,
-    };
+// Say it with the type, not with a hand-built envelope.
+//
+// dart_monty_core 0.19 routes host callback returns through
+// `MontyValue.encodeForWire`, so a Map spelling `{'__type': 'dataclass', ...}`
+// by hand is no longer honoured as a dataclass — it arrives in Python as a
+// plain dict, `user.name` reads as null, and the cast below throws. Returning a
+// `MontyDataclass` is the documented replacement (core CHANGELOG, 0.19.0
+// Breaking).
+MontyDataclass _userValue({required String name, required int age}) =>
+    MontyDataclass(
+      name: 'User',
+      typeId: 1,
+      fieldNames: const ['name', 'age'],
+      attrs: {'name': MontyString(name), 'age': MontyInt(age)},
+    );
 
 Future<void> main() async {
   final runtime = MontyRuntime()
@@ -60,7 +66,7 @@ Future<void> main() async {
             HostParam(name: 'age', type: HostParamType.integer),
           ],
         ),
-        handler: (args, _) async => _userEnvelope(
+        handler: (args, _) async => _userValue(
           name: args['name']! as String,
           age: args['age']! as int,
         ),

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,3 +9,18 @@ dependencies:
   dart_monty:
     path: ../
   file: ^7.0.0
+
+# 0.19 integration branch ONLY — see the matching block in ../pubspec.yaml.
+#
+# `dependency_overrides` do NOT propagate from the parent package, so without
+# this the examples resolve dart_monty_core from pub.dev (0.18.1) while the root
+# package uses the 0.19 branch. That is not a theoretical mismatch: it made
+# `example_smoke_test` run dataclass_demo against 0.18.1 and fail with
+# `MontyNone`, while every other job passed.
+#
+# DELETE THIS BLOCK when ../pubspec.yaml's override goes.
+dependency_overrides:
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: feat/monty-019-p1a

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,16 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  dart_monty_core: ^0.18.1
+  # 0.19 integration branch: dart_monty_core 0.19.0 is NOT published, so CI
+  # cannot resolve it from pub.dev. Track the branch directly so PRs against
+  # this line get real CI against the code they target.
+  #
+  # Revert to `dart_monty_core: ^0.19.0` before merging to main — a git
+  # dependency cannot be published to pub.dev.
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: feat/monty-019-p1a
   dinja: ^1.0.0
   file: ^7.0.0
   meta: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,16 +15,7 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  # 0.19 integration branch: dart_monty_core 0.19.0 is NOT published, so CI
-  # cannot resolve it from pub.dev. Track the branch directly so PRs against
-  # this line get real CI against the code they target.
-  #
-  # Revert to `dart_monty_core: ^0.19.0` before merging to main — a git
-  # dependency cannot be published to pub.dev.
-  dart_monty_core:
-    git:
-      url: https://github.com/runyaga/dart_monty_core.git
-      ref: feat/monty-019-p1a
+  dart_monty_core: ^0.18.1
   dinja: ^1.0.0
   file: ^7.0.0
   meta: ^1.11.0
@@ -38,3 +29,19 @@ dependencies:
 
 dev_dependencies:
   very_good_analysis: ^10.0.0
+
+# 0.19 integration branch ONLY. dart_monty_core 0.19.0 is not published, so CI
+# would otherwise resolve ^0.18.1 and test this line against a dependency it
+# does not target.
+#
+# This is a `dependency_overrides` and NOT a `dependencies` entry on purpose:
+# `dart analyze --fatal-infos` rejects a git dependency in a publishable
+# package (`invalid_dependency`), and overrides are ignored on publish.
+#
+# DELETE THIS BLOCK before merging to main or releasing, and move the
+# `dart_monty_core` constraint above to ^0.19.0.
+dependency_overrides:
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: feat/monty-019-p1a


### PR DESCRIPTION
Base is **`feat/monty-019`**, not `main`.

## Why

`dart_monty_core` 0.19.0 is not published. So `dart_monty_core: ^0.18.1` meant
every PR against the 0.19 line was being tested against a dependency it does
not target — the envelope, os-call and wire-format changes this branch exists
to adapt to were not present in CI at all. A green check proved nothing about
0.19.

Pointing at the branch makes CI test the code the PR is actually for.

```yaml
dart_monty_core:
  git:
    url: https://github.com/runyaga/dart_monty_core.git
    ref: feat/monty-019-p1a
```

Prerequisite confirmed: `feat/monty-019-p1a` is fully pushed (`2edc719`, zero
unpushed), so the ref resolves to current code. Earlier today it was 5 commits
behind its remote, which would have pinned a stale core silently.

## Scoped to this branch on purpose

`main` stays on published `^0.18.1`. Its HEAD commit removed git-ref overrides
deliberately; that is not being undone here.

## CI has to change with it

The pub.dev archive ships a prebuilt `native/target/**` dylib. A git checkout
does not, so core's build hook compiles the ruff/ty crate tree from source in
every job that resolves core.

Rust does **not** need installing — `ubuntu-latest` ships it, which is why the
existing jobs work today even though only `test-examples` declares a toolchain.
What was missing is caching and headroom:

| job | timeout | rust-cache |
|---|---|---|
| `test` | 15 → **30** | none → **added** |
| `test-wasm` | 15 → **30** | none → **added** |
| `test-examples` | 20 (unchanged) | already had it |

Without this the git ref would time both jobs out.

## Verification

Local, against branch tip `2edc719`, overrides removed so it resolved the git
dep exactly as CI will:

- `dart pub get` → resolves to `~/.pub-cache/git/dart_monty_core-2edc719…`
- `dart test test/src -p vm` → **460 passed, 2m49s** including the cargo build

That number is **warm-cache, arm64, local**. The same cold build took 15–25
minutes in a Linux container, which is what the 30-minute timeout is sized for.
This PR's own CI run is the real measurement.

## Breaking / must revert before release

A git dependency **cannot be published to pub.dev**. This must become
`dart_monty_core: ^0.19.0` before this line merges to main or is released. The
pubspec carries that note inline so it is not lost.