### PR TITLE
fix(example): dataclass_demo returns a MontyDataclass, not a `__type` map

### DIFF
--- a/example/dataclass_demo.dart
+++ b/example/dataclass_demo.dart
@@ -38,15 +38,21 @@ class User {
   String toString() => 'User(name=$name, age=$age)';
 }
 
-Map<String, Object?> _userEnvelope({required String name, required int age}) =>
-    {
-      '__type': 'dataclass',
-      'name': 'User',
-      'type_id': 1,
-      'field_names': ['name', 'age'],
-      'attrs': {'name': name, 'age': age},
-      'frozen': false,
-    };
+// Say it with the type, not with a hand-built envelope.
+//
+// dart_monty_core 0.19 routes host callback returns through
+// `MontyValue.encodeForWire`, so a Map spelling `{'__type': 'dataclass', ...}`
+// by hand is no longer honoured as a dataclass — it arrives in Python as a
+// plain dict, `user.name` reads as null, and the cast below throws. Returning a
+// `MontyDataclass` is the documented replacement (core CHANGELOG, 0.19.0
+// Breaking).
+MontyDataclass _userValue({required String name, required int age}) =>
+    MontyDataclass(
+      name: 'User',
+      typeId: 1,
+      fieldNames: const ['name', 'age'],
+      attrs: {'name': MontyString(name), 'age': MontyInt(age)},
+    );
 
 Future<void> main() async {
   final runtime = MontyRuntime()
@@ -60,7 +66,7 @@ Future<void> main() async {
             HostParam(name: 'age', type: HostParamType.integer),
           ],
         ),
-        handler: (args, _) async => _userEnvelope(
+        handler: (args, _) async => _userValue(
           name: args['name']! as String,
           age: args['age']! as int,
         ),


### PR DESCRIPTION
**Stacked on #440** (`chore/core-git-ref`), because it only fails — and only
gets meaningfully tested — when CI resolves dart_monty_core's 0.19 branch.
Merge #440 first.

Part of #432. This is the **last host-authored envelope** in the repo.

## The red

#440 made this visible in CI for the first time. Its `Example smoke tests` job:

```
── 2. user.name ──
   value: null
type 'MontyNone' is not a subtype of type 'MontyDataclass' in type cast
  example/dataclass_demo.dart:85:31        exit=255
```

Reproduced locally against core `ee25b42` (`MontyDict` locally vs `MontyNone` on
CI — same cause, the envelope is inert; the concrete value differs with the core
sha).

Before #440, CI resolved published 0.18.1, where the hand-built map still
worked, so this incompatibility was invisible.

## The fix

`MontyValue.encodeForWire` now wraps host callback returns, so a Map spelling
`{'__type': 'dataclass', ...}` by hand is no longer honoured as that type. Return
a `MontyDataclass` instead — the replacement core's CHANGELOG prescribes for
exactly this case.

`_userEnvelope` is renamed `_userValue`: it no longer builds an envelope, and
the old name would have described the thing this commit removes.

## After

```
── 1. user = make_user(...) ──
── 2. user.name ──          value: alice
── 3. user ──               typed: MontyDataclass
                            hydrated: User(name=alice, age=30)
── 4. after re-binding ──   hydrated: User(name=bob, age=42)
exit 0
```

| check | before | after |
|---|---|---|
| `example_smoke_test` | 3 passed / **1 failed** | **4 passed** |
| `dart analyze --fatal-infos` | clean | clean |
| `dart test test/src -p vm` | 460 | 460 (untouched) |

The example also still demonstrates what it is for — durable Python state across
`execute()` calls, with the typed value surviving the round trip.

## Scope

0.19-forward by design and **not** verified against published 0.18.1: under
0.18.1 the hand-built map still worked, so this belongs on the 0.19 line, not on
`main`. That is why the base is #440's branch rather than `feat/monty-019`.