### PR TITLE
DIAG (do not merge): x64 dataclass round-trip probe

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,8 @@ jobs:
         with:
           sdk: 3.11.4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      # DIAG: rust-cache disabled — testing whether it restores a stale
+      # native/target built against an older dart_monty_core.
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,9 +70,6 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
-      # Core's build hook shells out to cargo; without this every run pays a
-      # full cold build of the ruff/ty crate tree.
-      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache
@@ -155,7 +152,6 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
-      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,11 @@ jobs:
   test:
     name: Dart test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 30, not 15: dart_monty_core is a git dependency on this branch, so its
+    # native asset is compiled from source rather than coming prebuilt from the
+    # pub.dev archive. A cold cargo build of the ruff/ty crate tree does not fit
+    # in 15 minutes.
+    timeout-minutes: 30
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     steps:
@@ -66,6 +70,9 @@ jobs:
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
+      # Core's build hook shells out to cargo; without this every run pays a
+      # full cold build of the ruff/ty crate tree.
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache
@@ -140,12 +147,15 @@ jobs:
     needs: [changes]
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # See the `test` job: the git dependency means cargo builds core from
+    # source, which does not fit in 15 minutes cold.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: 3.11.4
+      - uses: Swatinem/rust-cache@v2
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache

--- a/example/dataclass_demo.dart
+++ b/example/dataclass_demo.dart
@@ -38,15 +38,21 @@ class User {
   String toString() => 'User(name=$name, age=$age)';
 }
 
-Map<String, Object?> _userEnvelope({required String name, required int age}) =>
-    {
-      '__type': 'dataclass',
-      'name': 'User',
-      'type_id': 1,
-      'field_names': ['name', 'age'],
-      'attrs': {'name': name, 'age': age},
-      'frozen': false,
-    };
+// Say it with the type, not with a hand-built envelope.
+//
+// dart_monty_core 0.19 routes host callback returns through
+// `MontyValue.encodeForWire`, so a Map spelling `{'__type': 'dataclass', ...}`
+// by hand is no longer honoured as a dataclass — it arrives in Python as a
+// plain dict, `user.name` reads as null, and the cast below throws. Returning a
+// `MontyDataclass` is the documented replacement (core CHANGELOG, 0.19.0
+// Breaking).
+MontyDataclass _userValue({required String name, required int age}) =>
+    MontyDataclass(
+      name: 'User',
+      typeId: 1,
+      fieldNames: const ['name', 'age'],
+      attrs: {'name': MontyString(name), 'age': MontyInt(age)},
+    );
 
 Future<void> main() async {
   final runtime = MontyRuntime()
@@ -60,7 +66,7 @@ Future<void> main() async {
             HostParam(name: 'age', type: HostParamType.integer),
           ],
         ),
-        handler: (args, _) async => _userEnvelope(
+        handler: (args, _) async => _userValue(
           name: args['name']! as String,
           age: args['age']! as int,
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,16 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  dart_monty_core: ^0.18.1
+  # 0.19 integration branch: dart_monty_core 0.19.0 is NOT published, so CI
+  # cannot resolve it from pub.dev. Track the branch directly so PRs against
+  # this line get real CI against the code they target.
+  #
+  # Revert to `dart_monty_core: ^0.19.0` before merging to main — a git
+  # dependency cannot be published to pub.dev.
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: feat/monty-019-p1a
   dinja: ^1.0.0
   file: ^7.0.0
   meta: ^1.11.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,16 +15,7 @@ environment:
 
 dependencies:
   collection: ^1.18.0
-  # 0.19 integration branch: dart_monty_core 0.19.0 is NOT published, so CI
-  # cannot resolve it from pub.dev. Track the branch directly so PRs against
-  # this line get real CI against the code they target.
-  #
-  # Revert to `dart_monty_core: ^0.19.0` before merging to main — a git
-  # dependency cannot be published to pub.dev.
-  dart_monty_core:
-    git:
-      url: https://github.com/runyaga/dart_monty_core.git
-      ref: feat/monty-019-p1a
+  dart_monty_core: ^0.18.1
   dinja: ^1.0.0
   file: ^7.0.0
   meta: ^1.11.0
@@ -38,3 +29,19 @@ dependencies:
 
 dev_dependencies:
   very_good_analysis: ^10.0.0
+
+# 0.19 integration branch ONLY. dart_monty_core 0.19.0 is not published, so CI
+# would otherwise resolve ^0.18.1 and test this line against a dependency it
+# does not target.
+#
+# This is a `dependency_overrides` and NOT a `dependencies` entry on purpose:
+# `dart analyze --fatal-infos` rejects a git dependency in a publishable
+# package (`invalid_dependency`), and overrides are ignored on publish.
+#
+# DELETE THIS BLOCK before merging to main or releasing, and move the
+# `dart_monty_core` constraint above to ^0.19.0.
+dependency_overrides:
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: feat/monty-019-p1a

--- a/test/src/tmp_x64_diag_test.dart
+++ b/test/src/tmp_x64_diag_test.dart
@@ -1,4 +1,6 @@
 @TestOn('vm')
+// Diagnostic prints are the entire point of this throwaway file.
+// ignore_for_file: avoid_print
 library;
 
 import 'dart:io';

--- a/test/src/tmp_x64_diag_test.dart
+++ b/test/src/tmp_x64_diag_test.dart
@@ -33,14 +33,28 @@ void main() {
           schema: const HostFunctionSchema(
             name: 'make_user',
             description: 'Construct a User dataclass.',
-            params: [HostParam(name: 'name', type: HostParamType.string)],
+            params: [
+              HostParam(name: 'name', type: HostParamType.string),
+              HostParam(name: 'age', type: HostParamType.integer),
+            ],
           ),
-          handler: (args, _) async => dc,
+          handler: (args, kwargs) async {
+            // The demo does `args['age']! as int`. If `age` is absent on this
+            // platform the `!` throws, the host call fails, `user` never binds,
+            // and the demo reads MontyNone two calls later. Print, do not throw.
+            print('DIAG args=$args');
+            print('DIAG kwargs=$kwargs');
+            final age = args['age'];
+            final nm = args['name'];
+            print('DIAG age=$age type=${age.runtimeType}');
+            print('DIAG name=$nm type=${nm.runtimeType}');
+            return dc;
+          },
         ),
       );
 
     // Layer 2: does the assignment succeed? dataclass_demo ignores this error.
-    final r1 = await runtime.execute('user = make_user(name="alice")').result;
+    final r1 = await runtime.execute('user = make_user(name="alice", age=30)').result;
     print('DIAG assign error=${r1.error}');
 
     // Layer 3: what does Python think it received?

--- a/test/src/tmp_x64_diag_test.dart
+++ b/test/src/tmp_x64_diag_test.dart
@@ -1,0 +1,56 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+// TEMPORARY diagnostic. Prints only; always passes. Deleted once it has
+// reported. `dataclass_demo` fails on linux-x64 CI but passes on macOS-arm64
+// and linux-arm64: the host-returned MontyDataclass never binds, so `user.name`
+// is null and `user` comes back MontyNone. This narrows WHICH layer drops it.
+void main() {
+  test('DIAG host MontyDataclass round-trip', () async {
+    print('DIAG arch=${Platform.version} os=${Platform.operatingSystem}');
+
+    const dc = MontyDataclass(
+      name: 'User',
+      typeId: 1,
+      fieldNames: ['name', 'age'],
+      attrs: {'name': MontyString('alice'), 'age': MontyInt(30)},
+    );
+    // Layer 1: does the Dart side encode it correctly on this arch?
+    print('DIAG toJson=${dc.toJson()}');
+    print('DIAG encodeForWire=${MontyValue.encodeForWire(dc)}');
+
+    final runtime = MontyRuntime()
+      ..register(
+        HostFunction(
+          schema: const HostFunctionSchema(
+            name: 'make_user',
+            description: 'Construct a User dataclass.',
+            params: [HostParam(name: 'name', type: HostParamType.string)],
+          ),
+          handler: (args, _) async => dc,
+        ),
+      );
+
+    // Layer 2: does the assignment succeed? dataclass_demo ignores this error.
+    final r1 = await runtime.execute('user = make_user(name="alice")').result;
+    print('DIAG assign error=${r1.error}');
+
+    // Layer 3: what does Python think it received?
+    final r2 = await runtime
+        .execute('{"t": type(user).__name__, "r": repr(user)}')
+        .result;
+    print('DIAG inspect error=${r2.error} value=${r2.value.dartValue}');
+
+    // Layer 4: the read dataclass_demo actually casts.
+    final r3 = await runtime.execute('user').result;
+    print('DIAG read type=${r3.value.runtimeType} error=${r3.error}');
+
+    await runtime.dispose();
+  });
+}

--- a/test/src/tmp_x64_diag_test.dart
+++ b/test/src/tmp_x64_diag_test.dart
@@ -41,7 +41,7 @@ void main() {
           handler: (args, kwargs) async {
             // The demo does `args['age']! as int`. If `age` is absent on this
             // platform the `!` throws, the host call fails, `user` never binds,
-            // and the demo reads MontyNone two calls later. Print, do not throw.
+            // and the demo reads MontyNone later. Print, do not throw.
             print('DIAG args=$args');
             print('DIAG kwargs=$kwargs');
             final age = args['age'];
@@ -54,7 +54,9 @@ void main() {
       );
 
     // Layer 2: does the assignment succeed? dataclass_demo ignores this error.
-    final r1 = await runtime.execute('user = make_user(name="alice", age=30)').result;
+    final r1 = await runtime
+        .execute('user = make_user(name="alice", age=30)')
+        .result;
     print('DIAG assign error=${r1.error}');
 
     // Layer 3: what does Python think it received?


### PR DESCRIPTION
Temporary diagnostic. **Do not merge — will be closed and deleted.**

`dataclass_demo` fails deterministically on linux-x64 CI (two independent runs)
while passing on macOS-arm64 (path dep AND git dep, direct AND via the smoke
harness) and on linux-arm64. Symptom: the host-returned `MontyDataclass` never
binds — `user.name` is null, `user` reads back `MontyNone`.

This probe prints each layer so the failing one is named rather than guessed:

1. `toJson()` / `encodeForWire()` — does the **Dart** side encode correctly on x64?
2. the assignment's error — `dataclass_demo` ignores it, so it may have been failing all along
3. `type(user).__name__` / `repr(user)` — what Python actually received
4. the typed read the demo casts

Local macOS-arm64 baseline, all correct:

```
DIAG encodeForWire={"__type":"dataclass","name":"User","type_id":1,
  "field_names":["name","age"],"attrs":{"__type":"dict",
  "value":{"name":"alice","age":30}},"frozen":false}
DIAG assign error=null
DIAG inspect value={t: dataclass, r: User(name='alice', age=30)}
DIAG read type=MontyDataclass
```
