### PR TITLE
fix(ci): run CI on every PR, not only those targeting main or feat/**

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, 'feat/**']
+  # No `branches:` filter — a PR gets CI whatever it targets.
+  #
+  # This previously read `branches: [main, 'feat/**']`, which silently gave
+  # ZERO test jobs to any PR based on another branch. #441 merged having run
+  # only `label` and `trufflehog`: its "CLEAN / mergeable" status was not
+  # evidence of anything. Stacked PRs are normal here, so enumerating prefixes
+  # would just move the gap; not filtering closes it.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -9,7 +9,13 @@ on:
       - 'dcm_options.yaml'
       - 'analysis_options.yaml'
   pull_request:
-    branches: [main, 'feat/**']
+  # No `branches:` filter — a PR gets CI whatever it targets.
+  #
+  # This previously read `branches: [main, 'feat/**']`, which silently gave
+  # ZERO test jobs to any PR based on another branch. #441 merged having run
+  # only `label` and `trufflehog`: its "CLEAN / mergeable" status was not
+  # evidence of anything. Stacked PRs are normal here, so enumerating prefixes
+  # would just move the gap; not filtering closes it.
     paths:
       - 'lib/**/*.dart'
       - 'test/**/*.dart'


### PR DESCRIPTION
## The gap

Both `ci.yaml` and `dcm.yaml` had:

```yaml
pull_request:
  branches: [main, 'feat/**']
```

A PR based on any other branch got **zero test jobs** — silently, and with a
green tick.

**#441 is the proof.** It was a real code change to `example/dataclass_demo.dart`,
based on `chore/core-git-ref`, and it merged having run only `label` and
`trufflehog`. Its `CLEAN / mergeable` status was not evidence that anything
worked. Nothing bad landed only because it was verified locally and the parent
PR re-tested the merged result — neither of which is a control.

## The fix

Drop the `branches:` filter from `pull_request` in both workflows.

Stacked PRs are normal here — the whole 0.19 line is a stack — so adding
`chore/**` and `fix/**` would just move the gap to the next prefix someone
invents. A PR is a PR.

`dcm.yaml` keeps its `paths:` filter, which is a different and correct
restriction: DCM should run when Dart files change, whatever the PR targets.

## Trade-off

PRs targeting throwaway branches now consume CI minutes. That is the intended
direction: a test job that does not run is worse than one that runs
unnecessarily.

## Verification

**This PR's own run does not prove the fix** — it targets `feat/monty-019`,
which matched the old filter too. The real check is the next stacked PR: it
should show `Dart test`, `Example smoke tests` and `WASM/Chrome tests` rather
than only `label` and `trufflehog`. Happy to demonstrate with a throwaway PR
once this lands.