### PR TITLE
fix(os_call)!: datetime.now honours the requested timezone, and is naive without one

### DIFF
--- a/lib/src/os_call/platform_handlers.dart
+++ b/lib/src/os_call/platform_handlers.dart
@@ -24,23 +24,71 @@ OsCallHandler timeHandler({DateTime Function()? clock}) {
       // subclass is the documented replacement (core CHANGELOG, 0.19.0
       // Breaking).
       'date.today' => MontyDate(year: t.year, month: t.month, day: t.day),
-      // Constructed explicitly rather than handing `t` to MontyValue.fromDart:
-      // that arm calls .toUtc() and leaves offsetSeconds/timezoneName null,
-      // which would silently drop both fields this handler has always emitted.
-      'datetime.now' => MontyDateTime(
-        year: t.year,
-        month: t.month,
-        day: t.day,
-        hour: t.hour,
-        minute: t.minute,
-        second: t.second,
-        microsecond: t.microsecond,
-        offsetSeconds: t.timeZoneOffset.inSeconds,
-        timezoneName: t.timeZoneName,
-      ),
+      'datetime.now' => _datetimeNow(t, _requestedZone(args)),
       _ => throw UnsupportedError('Unsupported datetime operation: $operation'),
     };
   };
+}
+
+/// The timezone `datetime.now(tz)` asked for, or `null` for `datetime.now()`.
+///
+/// monty passes the requested zone positionally: `DateTimeNow` projects it into
+/// `args[0]`, `None` when the call was naive. Arguments reach a handler already
+/// lowered to `dartValue`, so a zone arrives as the wire map
+/// `{'__type': 'timezone', …}`; [MontyValue.fromJson] turns that back into the
+/// typed value rather than making this function key into a raw map.
+MontyTimeZone? _requestedZone(List<Object?> args) {
+  if (args.isEmpty || args.first == null) return null;
+  final decoded = MontyValue.fromJson(args.first);
+  if (decoded is MontyTimeZone) return decoded;
+  if (decoded is MontyNone) return null;
+  // Loudly, not silently: monty only ever sends None or a timezone here, so
+  // anything else means the contract changed and guessing would hide it.
+  throw ArgumentError.value(
+    args.first,
+    'args[0]',
+    'datetime.now expects a timezone or None, got ${decoded.runtimeType}',
+  );
+}
+
+/// Answers `datetime.now(tz)` the way monty specifies.
+///
+/// `tz == null` is **naive**: local wall-clock, and no offset or zone name.
+/// Returning an aware value here diverges from CPython and from monty's own
+/// contract ("`None` for a naive result", `OsFunctionCall::DateTimeNow`).
+///
+/// `tz != null` is **aware**: the same instant expressed in the requested zone,
+/// carrying its offset and name — mirroring upstream's reference embedder
+/// (`dispatch_datetime_now`, monty `crates/monty-datatest/src/main.rs`).
+///
+/// Built explicitly rather than via [MontyValue.fromDart], whose `DateTime` arm
+/// calls `.toUtc()` and leaves offset and name null — correct for neither case.
+MontyDateTime _datetimeNow(DateTime t, MontyTimeZone? tz) {
+  if (tz == null) {
+    return MontyDateTime(
+      year: t.year,
+      month: t.month,
+      day: t.day,
+      hour: t.hour,
+      minute: t.minute,
+      second: t.second,
+      microsecond: t.microsecond,
+    );
+  }
+  // Shift the instant, do not relabel the wall clock: an offset applied to UTC
+  // is what makes `datetime.now(timezone.utc)` the same moment as `now()`.
+  final shifted = t.toUtc().add(Duration(seconds: tz.offsetSeconds));
+  return MontyDateTime(
+    year: shifted.year,
+    month: shifted.month,
+    day: shifted.day,
+    hour: shifted.hour,
+    minute: shifted.minute,
+    second: shifted.second,
+    microsecond: shifted.microsecond,
+    offsetSeconds: tz.offsetSeconds,
+    timezoneName: tz.name,
+  );
 }
 
 /// Handler for `os.*` environment operations using a provided map.

--- a/test/src/os_call/time_handler_envelope_test.dart
+++ b/test/src/os_call/time_handler_envelope_test.dart
@@ -78,19 +78,20 @@ void main() {
       );
       expect(v['hour'], frozen.hour);
       expect(v['minute'], frozen.minute);
-      // The pre-0.19 handler emitted offset_seconds/timezone_name. Converting
-      // via a bare Dart DateTime would drop both (MontyValue.fromDart calls
-      // .toUtc(), leaving offsetSeconds/timezoneName null), so pin that the
-      // datetime is tz-aware and carries this machine's zone name.
+      // NAIVE, deliberately. An earlier version of this test asserted the
+      // opposite — that the datetime came back tz-aware — which pinned a
+      // divergence from monty's `DateTimeNow(None)` contract and from CPython
+      // as though it were the goal. Awareness is now requested explicitly with
+      // `datetime.now(tz)`; see time_handler_tz_test.dart.
       expect(
         v['naive'],
-        isFalse,
-        reason: 'offsetSeconds must not be silently dropped',
+        isTrue,
+        reason: 'datetime.now() with no argument is naive',
       );
       expect(
-        v['tz']! as String,
-        contains(frozen.timeZoneName),
-        reason: 'timezoneName must survive the boundary',
+        v['tz'],
+        'None',
+        reason: 'a naive datetime carries no zone',
       );
     });
   });

--- a/test/src/os_call/time_handler_tz_test.dart
+++ b/test/src/os_call/time_handler_tz_test.dart
@@ -1,0 +1,97 @@
+@TestOn('vm')
+library;
+
+// `datetime.now(tz)` semantics, per monty v0.0.19's own contract.
+//
+// `OsFunctionCall::DateTimeNow(Option<MontyTimeZone>)` carries the requested
+// timezone and documents "`None` for a naive result"
+// (monty crates/monty-types/src/os.rs). Upstream's reference embedder,
+// `dispatch_datetime_now` in crates/monty-datatest/src/main.rs, implements it as:
+//
+//   tz absent  -> local wall-clock, offset_seconds: None, timezone_name: None
+//   tz present -> the same instant converted into that zone, carrying its
+//                 offset and name
+//
+// CPython agrees: `datetime.now()` is naive, `datetime.now(tz)` is aware in tz.
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Frozen local clock. Expectations derive from it, never hard-coded, so this
+  // passes in any host timezone.
+  final frozen = DateTime(2024, 3, 15, 10, 30, 45);
+  final time = timeHandler(clock: () => frozen);
+
+  MontyRuntime newSession() =>
+      MontyRuntime(osHandlers: {'date.': time, 'datetime.': time});
+
+  group('datetime.now honours the requested timezone', () {
+    test('no argument yields a NAIVE datetime', () async {
+      final session = newSession();
+      addTearDown(session.dispose);
+
+      final r = await session
+          .execute(
+            'from datetime import datetime\n'
+            'n = datetime.now()\n'
+            '{"naive": n.tzinfo is None, "hour": n.hour, "minute": n.minute}',
+          )
+          .result;
+
+      expect(r.error, isNull);
+      final v = r.value.dartValue! as Map<String, Object?>;
+      expect(v['naive'], isTrue, reason: 'datetime.now() must be naive');
+      // Naive means LOCAL wall clock, so the frozen local fields come through.
+      expect(v['hour'], frozen.hour);
+      expect(v['minute'], frozen.minute);
+    });
+
+    test('timezone.utc yields an AWARE datetime at offset 0', () async {
+      final session = newSession();
+      addTearDown(session.dispose);
+
+      final r = await session
+          .execute(
+            // NB: monty's timezone implements no utcoffset(); repr is the
+            // observable surface, so assert on that.
+            'from datetime import datetime, timezone\n'
+            'u = datetime.now(timezone.utc)\n'
+            '{"naive": u.tzinfo is None, "hour": u.hour, '
+            '"minute": u.minute, "tz": repr(u.tzinfo)}',
+          )
+          .result;
+
+      expect(r.error, isNull);
+      final v = r.value.dartValue! as Map<String, Object?>;
+      expect(v['naive'], isFalse, reason: 'datetime.now(tz) must be aware');
+      // Requested UTC, so the zone must be UTC — not the host's local zone.
+      expect(
+        v['tz']! as String,
+        anyOf(contains('timezone.utc'), contains('timedelta(0)')),
+        reason: 'requested UTC, got ${v['tz']}',
+      );
+      // The same instant, expressed in UTC — not the local wall clock.
+      expect(v['hour'], frozen.toUtc().hour);
+      expect(v['minute'], frozen.toUtc().minute);
+    });
+
+    test('date.today is unaffected', () async {
+      final session = newSession();
+      addTearDown(session.dispose);
+
+      final r = await session
+          .execute(
+            'from datetime import date\n'
+            'd = date.today()\n'
+            '{"y": d.year, "m": d.month, "d": d.day}',
+          )
+          .result;
+
+      expect(r.error, isNull);
+      final v = r.value.dartValue! as Map<String, Object?>;
+      expect(v['y'], frozen.year);
+      expect(v['m'], frozen.month);
+      expect(v['d'], frozen.day);
+    });
+  });
+}

--- a/test/src/os_call/time_handler_tz_test.dart
+++ b/test/src/os_call/time_handler_tz_test.dart
@@ -46,7 +46,7 @@ void main() {
       expect(v['minute'], frozen.minute);
     });
 
-    test('timezone.utc yields an AWARE datetime at offset 0', () async {
+    test('a requested zone shifts the instant', () async {
       final session = newSession();
       addTearDown(session.dispose);
 
@@ -54,8 +54,13 @@ void main() {
           .execute(
             // NB: monty's timezone implements no utcoffset(); repr is the
             // observable surface, so assert on that.
-            'from datetime import datetime, timezone\n'
-            'u = datetime.now(timezone.utc)\n'
+            // A NON-ZERO offset on purpose. Requesting UTC makes this
+            // tautological on a UTC host, where the unshifted local wall clock
+            // already equals the UTC one — measured: with the shift removed,
+            // the UTC form passed under TZ=UTC and failed only under
+            // TZ=America/Chicago. GitHub runners are UTC.
+            'from datetime import datetime, timezone, timedelta\n'
+            'u = datetime.now(timezone(timedelta(hours=4)))\n'
             '{"naive": u.tzinfo is None, "hour": u.hour, '
             '"minute": u.minute, "tz": repr(u.tzinfo)}',
           )
@@ -64,15 +69,10 @@ void main() {
       expect(r.error, isNull);
       final v = r.value.dartValue! as Map<String, Object?>;
       expect(v['naive'], isFalse, reason: 'datetime.now(tz) must be aware');
-      // Requested UTC, so the zone must be UTC — not the host's local zone.
-      expect(
-        v['tz']! as String,
-        anyOf(contains('timezone.utc'), contains('timedelta(0)')),
-        reason: 'requested UTC, got ${v['tz']}',
-      );
-      // The same instant, expressed in UTC — not the local wall clock.
-      expect(v['hour'], frozen.toUtc().hour);
-      expect(v['minute'], frozen.toUtc().minute);
+      // The instant shifted into +04:00, independent of the host's zone.
+      final expected = frozen.toUtc().add(const Duration(hours: 4));
+      expect(v['hour'], expected.hour);
+      expect(v['minute'], expected.minute);
     });
 
     test('date.today is unaffected', () async {

--- a/test/src/os_call/time_os_provider_test.dart
+++ b/test/src/os_call/time_os_provider_test.dart
@@ -93,17 +93,24 @@ void main() {
       final frozen = DateTime(2026, 6, 15, 12);
       final handler = timeHandler(clock: () => frozen);
 
-      // Ask for UTC: the SAME instant must come back at offset 0, i.e. the
-      // frozen local time converted to UTC — not the local wall clock
-      // relabelled 'UTC'.
-      const utc = MontyTimeZone(offsetSeconds: 0, name: 'UTC');
+      // A NON-ZERO offset, deliberately. Requesting UTC (offset 0) makes this
+      // test tautological on a UTC host — `frozen.hour == frozen.toUtc().hour`
+      // there, so a handler that ignored the zone and returned the unshifted
+      // wall clock would still pass. Verified: with the shift removed, the UTC
+      // version passed under TZ=UTC and only failed under TZ=America/Chicago.
+      // GitHub runners are UTC, so that test could not have caught the bug it
+      // was written for.
+      const plusFour = MontyTimeZone(offsetSeconds: 4 * 3600, name: 'UTC+04');
       final result =
-          (await handler('datetime.now', [utc.toJson()], null))!
+          (await handler('datetime.now', [plusFour.toJson()], null))!
               as MontyDateTime;
-      expect(result.offsetSeconds, 0);
-      expect(result.timezoneName, 'UTC');
-      expect(result.hour, frozen.toUtc().hour);
-      expect(result.minute, frozen.toUtc().minute);
+      expect(result.offsetSeconds, 4 * 3600);
+      expect(result.timezoneName, 'UTC+04');
+      // The instant, shifted into +04:00 — independent of the host's zone.
+      final expected = frozen.toUtc().add(const Duration(hours: 4));
+      expect(result.hour, expected.hour);
+      expect(result.minute, expected.minute);
+      expect(result.day, expected.day);
     });
   });
 }

--- a/test/src/os_call/time_os_provider_test.dart
+++ b/test/src/os_call/time_os_provider_test.dart
@@ -26,8 +26,22 @@ void main() {
       expect(result.minute, isA<int>());
       expect(result.second, isA<int>());
       expect(result.microsecond, isA<int>());
-      expect(result.offsetSeconds, isA<int>());
-      expect(result.timezoneName, isA<String>());
+      // No timezone argument means NAIVE: monty's `DateTimeNow(None)` contract
+      // and CPython's `datetime.now()` both say no offset and no zone name.
+      expect(result.offsetSeconds, isNull);
+      expect(result.timezoneName, isNull);
+    });
+
+    test('datetime.now(tz) returns an aware MontyDateTime in that zone',
+        () async {
+      final handler = timeHandler();
+      const tz = MontyTimeZone(offsetSeconds: 0, name: 'UTC');
+      final result =
+          (await handler('datetime.now', [tz.toJson()], null))!
+              as MontyDateTime;
+
+      expect(result.offsetSeconds, 0);
+      expect(result.timezoneName, 'UTC');
     });
 
     test('injected clock is used (frozen time)', () async {
@@ -73,14 +87,22 @@ void main() {
       expect(result.day, lessThanOrEqualTo(after.day));
     });
 
-    test('timezone offset populated correctly', () async {
+    test('requested zone is applied to the instant, not relabelled',
+        () async {
       final frozen = DateTime(2026, 6, 15, 12);
       final handler = timeHandler(clock: () => frozen);
 
+      // Ask for UTC: the SAME instant must come back at offset 0, i.e. the
+      // frozen local time converted to UTC — not the local wall clock
+      // relabelled 'UTC'.
+      const utc = MontyTimeZone(offsetSeconds: 0, name: 'UTC');
       final result =
-          (await handler('datetime.now', const [], null))! as MontyDateTime;
-      expect(result.offsetSeconds, frozen.timeZoneOffset.inSeconds);
-      expect(result.timezoneName, frozen.timeZoneName);
+          (await handler('datetime.now', [utc.toJson()], null))!
+              as MontyDateTime;
+      expect(result.offsetSeconds, 0);
+      expect(result.timezoneName, 'UTC');
+      expect(result.hour, frozen.toUtc().hour);
+      expect(result.minute, frozen.toUtc().minute);
     });
   });
 }

--- a/test/src/os_call/time_os_provider_test.dart
+++ b/test/src/os_call/time_os_provider_test.dart
@@ -32,17 +32,19 @@ void main() {
       expect(result.timezoneName, isNull);
     });
 
-    test('datetime.now(tz) returns an aware MontyDateTime in that zone',
-        () async {
-      final handler = timeHandler();
-      const tz = MontyTimeZone(offsetSeconds: 0, name: 'UTC');
-      final result =
-          (await handler('datetime.now', [tz.toJson()], null))!
-              as MontyDateTime;
+    test(
+      'datetime.now(tz) returns an aware MontyDateTime in that zone',
+      () async {
+        final handler = timeHandler();
+        const tz = MontyTimeZone(offsetSeconds: 0, name: 'UTC');
+        final result =
+            (await handler('datetime.now', [tz.toJson()], null))!
+                as MontyDateTime;
 
-      expect(result.offsetSeconds, 0);
-      expect(result.timezoneName, 'UTC');
-    });
+        expect(result.offsetSeconds, 0);
+        expect(result.timezoneName, 'UTC');
+      },
+    );
 
     test('injected clock is used (frozen time)', () async {
       final frozen = DateTime(2026, 3, 15, 10, 30, 45, 123, 456);
@@ -87,8 +89,7 @@ void main() {
       expect(result.day, lessThanOrEqualTo(after.day));
     });
 
-    test('requested zone is applied to the instant, not relabelled',
-        () async {
+    test('requested zone is applied to the instant, not relabelled', () async {
       final frozen = DateTime(2026, 6, 15, 12);
       final handler = timeHandler(clock: () => frozen);
 


### PR DESCRIPTION
Two silent defects in `timeHandler`, found by auditing against the pinned
upstream source (`pydantic/monty` @ `e347739`, the revision
`dart_monty_core` pins as `tag = "v0.0.19"`).

## The contract

`OsFunctionCall::DateTimeNow(Option<MontyTimeZone>)` carries the timezone the
script asked for, and its doc comment says **"`None` for a naive result"**.
`to_args` (monty `crates/monty-types/src/os.rs:153`) projects it into `args[0]`:

```rust
Self::DateTimeNow(tz) => (vec![tz.map_or(MontyObject::None, MontyObject::TimeZone)], vec![]),
```

Upstream's reference embedder, `dispatch_datetime_now` in
`crates/monty-datatest/src/main.rs:1238`, implements it as:

| `tz` | result |
|---|---|
| `None` | local wall-clock, `offset_seconds: None`, `timezone_name: None` — **naive** |
| `Some(tz)` | the same **instant** converted into that zone, carrying its offset and name — **aware** |

CPython agrees: `datetime.now()` is naive, `datetime.now(tz)` is aware in `tz`.

## The defects

`timeHandler` never read `args`, and always stamped the host's local offset and
zone name. Measured, clock frozen at 2024-03-15 10:30 local (CDT):

```
datetime.now()             -> tzinfo=timezone(-5:00, 'CDT')    should be None
datetime.now(timezone.utc) -> tzinfo=timezone(-5:00, 'CDT')    should be UTC
```

1. **`datetime.now()` was aware.** Diverges from CPython and from monty's own
   contract.
2. **The `tz` argument was ignored** — so asking for UTC returned the local
   wall clock with a local label, *identical* to the naive call. Wrong instant,
   wrong label, no error. This is the "fails quietly" class the 0.19 migration
   exists to remove.

## The fix

Implemented to match the reference embedder. The zone is read through
`MontyValue.fromJson`, so the handler works with a typed `MontyTimeZone`
instead of string-keying the wire map that `dartValue` lowering hands it
(`lib/src/bridge/platform.dart:317`). Anything that is neither a timezone nor
`None` throws rather than being silently ignored.

## Test churn worth reading

Three existing tests asserted the aware behaviour and are corrected. **One was
added earlier today and pinned the divergence on purpose** — its comment argued
that dropping `offsetSeconds`/`timezoneName` would be a "silent regression".
That reasoning was backwards for the no-argument case: naive *is* the contract.
The comment now records that, so the next reader does not re-derive it.

## Verification

Red first: `test/src/os_call/time_handler_tz_test.dart` was watched failing
2/3 — `naive` false, and the zone coming back `'CDT'` when UTC was requested.

| | |
|---|---|
| `dart test test/src -p vm` | **466** passed |
| `dart test test/src -p chrome` | **431** passed |
| `example_smoke_test` | **4** passed |
| `dart analyze --fatal-infos` | clean |

## Breaking

`datetime.now` is now naive unless the script passes a timezone. Hosts relying
on `offsetSeconds`/`timezoneName` always being populated will see nulls;
scripts wanting an aware value call `datetime.now(tz)`, as in CPython.