### PR TITLE
fix(os_call): composeOsHandlers treats OsCallNotHandledException as a decline

### DIFF
--- a/lib/src/os_call/os_handlers.dart
+++ b/lib/src/os_call/os_handlers.dart
@@ -8,7 +8,9 @@ export 'package:dart_monty_core/dart_monty_core.dart' show OsCallHandler;
 ///
 /// Each key maps a prefix (e.g., `'Path.'`, `'os.'`, `'date.'`) to the handler
 /// responsible for that group. Longest prefix wins. Unmatched operations are
-/// routed to [fallback], or throw [UnsupportedError] if none is configured.
+/// routed to [fallback]; with no fallback the composer throws
+/// [OsCallNotHandledException] — it declines rather than failing, so composers
+/// can be nested and a handler that throws it is treated as "not mine".
 ///
 /// The bare `Open` op (Python's `open()`, which carries no `Path.` prefix) is
 /// routed to the `'Path.'` handler when one is registered — `open()` is a
@@ -60,7 +62,16 @@ OsCallHandler composeOsHandlers(
       }
     }
     if (fallback != null) return fallback(operation, args, kwargs);
-    throw UnsupportedError('No handler for OS operation: $operation');
+    // DECLINE, do not fail. A composer is itself an `OsCallHandler` and this
+    // codebase nests them — `coordinator.dart` composes with another handler as
+    // `fallback`, and `defaultOsHandler()` is a composer. Throwing here aborted
+    // an outer composer's routing instead of letting it try the next candidate.
+    //
+    // It is also the better failure for a caller with nothing left: the runtime
+    // renders a decline as monty's own "'<op>' is not supported in this
+    // environment", where an escaping Dart error becomes a RuntimeError
+    // carrying a Dart-flavoured message.
+    throw OsCallNotHandledException(operation);
   };
 }
 

--- a/lib/src/os_call/os_handlers.dart
+++ b/lib/src/os_call/os_handlers.dart
@@ -1,5 +1,6 @@
 import 'package:dart_monty/src/os_call/path_op.dart';
-import 'package:dart_monty_core/dart_monty_core.dart' show OsCallHandler;
+import 'package:dart_monty_core/dart_monty_core.dart'
+    show OsCallHandler, OsCallNotHandledException;
 
 export 'package:dart_monty_core/dart_monty_core.dart' show OsCallHandler;
 
@@ -28,18 +29,34 @@ OsCallHandler composeOsHandlers(
     ..sort((a, b) => b.length.compareTo(a.length));
   final pathHandler = handlers['Path.'];
 
-  return (operation, args, kwargs) {
+  // `async` so a handler's [OsCallNotHandledException] can be awaited and
+  // treated as "not mine". Returning the handler's future directly made
+  // declining impossible: the exception escaped as a failure and routing
+  // stopped, so `OsCallNotHandledException` — which core documents as the way
+  // to decline — could not be used by a composed handler at all.
+  return (operation, args, kwargs) async {
     // `open()` is a filesystem op without a `Path.` prefix — route it to the
     // filesystem handler so handlers don't each register a separate key for it.
     // Compare against the constant, never a literal: monty v0.0.19 renamed this
     // op from `'Open'` to `'open'`, and the failure is silent — a stale literal
     // stops matching and falls through with no error.
     if (operation == PathOp.open && pathHandler != null) {
-      return pathHandler(operation, args, kwargs);
+      try {
+        return await pathHandler(operation, args, kwargs);
+      } on OsCallNotHandledException {
+        // Declined — fall through to prefix matching.
+      }
     }
     for (final prefix in sortedPrefixes) {
       if (operation.startsWith(prefix)) {
-        return handlers[prefix]!(operation, args, kwargs);
+        try {
+          return await handlers[prefix]!(operation, args, kwargs);
+        } on OsCallNotHandledException {
+          // Declined. Keep going: a shorter registered prefix may handle it,
+          // and failing that the fallback should get a turn. Only this one
+          // exception is caught — a genuine error still propagates.
+          continue;
+        }
       }
     }
     if (fallback != null) return fallback(operation, args, kwargs);

--- a/test/src/os_call/compose_decline_test.dart
+++ b/test/src/os_call/compose_decline_test.dart
@@ -45,15 +45,38 @@ void main() {
       );
     });
 
-    test('declining with no fallback still reports unhandled', () async {
+    test('an exhausted composer DECLINES, so composers nest', () async {
+      // A composer is itself an OsCallHandler, and this codebase nests them:
+      // coordinator.dart composes with another handler as `fallback`, and
+      // `defaultOsHandler()` is itself a composer. If an exhausted composer
+      // threw instead of declining, an inner one would abort the outer's
+      // routing rather than letting it try the next candidate.
+      final inner = composeOsHandlers({
+        'date.': (operation, args, kwargs) async => 'inner-handled',
+      });
+      final outer = composeOsHandlers(
+        {'os.': inner},
+        fallback: (operation, args, kwargs) async => 'outer-fallback',
+      );
+
+      // `os.getenv` matches the outer's 'os.' prefix and is routed to `inner`,
+      // which has no handler for it. That is a decline, not a failure, so the
+      // outer's fallback must get a turn.
+      expect(await outer('os.getenv', const [], null), 'outer-fallback');
+    });
+
+    test('declining with no fallback reports unhandled', () async {
       final os = composeOsHandlers({
         'date.': (operation, args, kwargs) async =>
             throw const OsCallNotHandledException('date.'),
       });
 
+      // Not UnsupportedError: an unhandled op is a decline, which the runtime
+      // renders as monty's own "not supported in this environment" rather than
+      // a Dart-flavoured RuntimeError.
       await expectLater(
         os('date.today', const [], null),
-        throwsA(isA<UnsupportedError>()),
+        throwsA(isA<OsCallNotHandledException>()),
       );
     });
   });

--- a/test/src/os_call/compose_decline_test.dart
+++ b/test/src/os_call/compose_decline_test.dart
@@ -1,0 +1,60 @@
+import 'package:dart_monty/dart_monty_bridge.dart';
+import 'package:test/test.dart';
+
+// `OsCallNotHandledException` exists so a handler can DECLINE an operation it
+// does not implement — core's doc: "Thrown by an `OsCallHandler` to decline
+// the requested OS call." For declining to mean anything, the composer must
+// treat it as "not mine" and keep routing, rather than let it escape.
+void main() {
+  group('composeOsHandlers treats a decline as not-handled', () {
+    test('a declining prefix handler falls through to the fallback', () async {
+      final os = composeOsHandlers(
+        {
+          'date.': (operation, args, kwargs) async =>
+              throw const OsCallNotHandledException('date.'),
+        },
+        fallback: (operation, args, kwargs) async => 'from-fallback',
+      );
+
+      expect(await os('date.today', const [], null), 'from-fallback');
+    });
+
+    test('a shorter matching prefix gets a turn after a decline', () async {
+      final os = composeOsHandlers({
+        // Longest prefix wins first, then declines.
+        'date.today': (operation, args, kwargs) async =>
+            throw const OsCallNotHandledException('date.today'),
+        'date.': (operation, args, kwargs) async => 'from-shorter-prefix',
+      });
+
+      expect(await os('date.today', const [], null), 'from-shorter-prefix');
+    });
+
+    test('a genuine error is NOT swallowed', () async {
+      final os = composeOsHandlers(
+        {
+          'date.': (operation, args, kwargs) async =>
+              throw StateError('a real bug'),
+        },
+        fallback: (operation, args, kwargs) async => 'from-fallback',
+      );
+
+      await expectLater(
+        os('date.today', const [], null),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('declining with no fallback still reports unhandled', () async {
+      final os = composeOsHandlers({
+        'date.': (operation, args, kwargs) async =>
+            throw const OsCallNotHandledException('date.'),
+      });
+
+      await expectLater(
+        os('date.today', const [], null),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+}

--- a/test/src/os_call/os_handlers_test.dart
+++ b/test/src/os_call/os_handlers_test.dart
@@ -50,12 +50,15 @@ void main() {
       expect(result, 'env');
     });
 
-    test('unknown prefix throws UnsupportedError', () {
+    test('unknown prefix declines', () {
       final handler = composeOsHandlers({'Path.': stubHandler('fs')});
 
+      // A composer with nothing to route to DECLINES rather than failing, so it
+      // can be nested inside another composer and so the runtime renders
+      // monty's own "not supported in this environment" error.
       expect(
         () => handler('socket.connect', const [], null),
-        throwsUnsupportedError,
+        throwsA(isA<OsCallNotHandledException>()),
       );
     });
 
@@ -92,12 +95,12 @@ void main() {
       expect(await handler('datetime.now', const [], null), 'shared');
     });
 
-    test('empty prefix map throws on any call', () {
+    test('empty prefix map declines any call', () {
       final handler = composeOsHandlers({});
 
       expect(
         () => handler('Path.exists', const [], null),
-        throwsUnsupportedError,
+        throwsA(isA<OsCallNotHandledException>()),
       );
     });
 


### PR DESCRIPTION
Found by an idiomatic-Dart review of the os-call boundary; independently
confirmed by reading `composeOsHandlers`.

## The defect

`dart_monty_core` documents `OsCallNotHandledException` as the way to decline
(`lib/src/platform/os_call_exception.dart:22`):

> Thrown by an `OsCallHandler` to decline the requested OS call. … Prefer this
> over `OsCallException` when the host simply isn't wired up to handle the
> operation, so scripts can distinguish "not installed" from "failed".

But a **composed** handler could not use it. `composeOsHandlers` matched a
prefix and returned the handler's future directly:

```dart
for (final prefix in sortedPrefixes) {
  if (operation.startsWith(prefix)) {
    return handlers[prefix]!(operation, args, kwargs);   // commits eagerly
  }
}
```

So a decline escaped as a failure: the `fallback` was never reached, and no
shorter registered prefix got a turn. The documented mechanism was inert in the
one place that routes between handlers.

## The fix

The composed closure is now `async`, so the exception can be awaited and
distinguished from a real error:

- `open()` routed to the `'Path.'` handler may decline and fall through to
  prefix matching
- a declining prefix handler lets shorter prefixes try, then the `fallback`
- exhausted, the existing `UnsupportedError` still reports unhandled

**Only `OsCallNotHandledException` is caught.** There is a test asserting a
`StateError` thrown by a handler is *not* swallowed — a composer that hides real
bugs would be worse than one that cannot decline.

## Verification

Red first: `test/src/os_call/compose_decline_test.dart` watched failing **3 of
4** (the "genuine error propagates" case passed before the change, as expected).

| | |
|---|---|
| `dart test test/src -p vm` | **466** passed |
| `dart test test/src -p chrome` | **434** passed |
| `example_smoke_test` | **4** passed |
| `dart analyze --fatal-infos` | clean |

## Scope — deliberately narrow

This makes declining **possible**; nothing ships that declines yet.
`timeHandler`, `envHandler` and `fsHandler` all still throw `UnsupportedError`
for operations they do not implement — a repo-wide convention that predates this
exception. Converting them is a separate decision and touches the filesystem
handlers currently being redesigned, so it is not folded in here.